### PR TITLE
No need for focus icons for splash and channel.

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,17 +1,14 @@
 ##   Channel Details
 title=Jellyfin
-version=10.3.0
 major_version=0
 minor_version=1
 build_version=1
 
 ###  Main Menu Icons / Channel Poster Artwork
-mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png
 mm_icon_focus_hd=pkg:/images/channel-poster_hd.png
 mm_icon_focus_sd=pkg:/images/channel-poster_sd.png
 
 ###  Splash Screen + Loading Screen Artwork
-splash_screen_fhd=pkg:/images/splash-screen_fhd.jpg
 splash_screen_hd=pkg:/images/splash-screen_hd.jpg
 splash_screen_sd=pkg:/images/splash-screen_sd.jpg
 

--- a/manifest
+++ b/manifest
@@ -9,6 +9,7 @@ mm_icon_focus_hd=pkg:/images/channel-poster_hd.png
 mm_icon_focus_sd=pkg:/images/channel-poster_sd.png
 
 ###  Splash Screen + Loading Screen Artwork
+splash_screen_fhd=pkg:/images/splash-screen_fhd.jpg
 splash_screen_hd=pkg:/images/splash-screen_hd.jpg
 splash_screen_sd=pkg:/images/splash-screen_sd.jpg
 


### PR DESCRIPTION
Having a focus icon for the splash screen is not required and we were not using the focus icon on channel selection. 

Removing old Emby version number