### PR TITLE
Offset the overhang, exactly value to be tweaked

### DIFF
--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -35,6 +35,7 @@ sub themeScene(scene)
 
   if overhang <> invalid
     overhang.logoUri = "pkg:/images/logo.png"
+    overhang.logoBaselineOffset = 7.5
     overhang.showOptions = true
     if options <> invalid
       overhang.optionsAvailable = true


### PR DESCRIPTION
Addresses issue #17 by dropping the logo down just a few pixels. Looks right on my device, but we may find that this is one of those things where the pixel value changes per device, or per resolution.