### PR TITLE
Make ListPoster Images Flexible

### DIFF
--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -34,7 +34,7 @@ sub updateSize()
     ' Always reserve the bottom for the Poster Title
     m.title.wrap = true
     m.title.maxLines = 2
-    m.title.width = m.poster.width
+    m.title.width = maxSize[0]
     m.title.height = 80
     m.title.translation = [0, int(maxSize[1]) - m.title.height]
 

--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -1,6 +1,10 @@
 sub init()
     m.title = m.top.findNode("title")
+    m.title.translation = [2, 0]
+
     m.poster = m.top.findNode("poster")
+    m.poster.translation = [2, 0]
+
     m.backdrop = m.top.findNode("backdrop")
 
     m.backdrop.color = "#404040FF"
@@ -13,25 +17,49 @@ sub updateSize()
     m.poster = m.top.findNode("poster")
     m.backdrop = m.top.findNode("backdrop")
 
+    image = invalid
+    if m.top.itemContent <> invalid and m.top.itemContent.image <> invalid
+      image = m.top.itemContent.image
+    end if
+
+    if image = invalid
+      m.backdrop.visible = true
+    else
+      m.backdrop.visible = false
+    end if
+
     ' TODO - abstract this in case the parent doesnt have itemSize
     maxSize = m.top.getParent().itemSize
 
+    ' Always reserve the bottom for the Poster Title
+    m.title.wrap = true
+    m.title.maxLines = 2
+    m.title.width = m.poster.width
+    m.title.height = 80
+    m.title.translation = [0, int(maxSize[1]) - m.title.height]
+
+    ratio = 1.5
+    if image <> invalid
+      ratio = image.height / image.width
+    end if
+
     m.poster.width = int(maxSize[0]) - 4
-    m.poster.height = m.poster.width * 1.5
+    m.poster.height = m.poster.width * ratio
+
+    posterVertSpace = int(maxSize[1]) - m.title.height
+
+    if m.poster.height > posterVertSpace
+      ' Do a thing to shrink the image if it is too tall
+    end if
+
+    m.poster.translation = [2, (posterVertSpace - m.poster.height) / 2]
 
     m.backdrop.width = m.poster.width
     m.backdrop.height = m.poster.height
 
-    m.title.wrap = true
-    m.title.maxLines = 2
-    m.title.width = m.poster.width
-    m.title.height = int(maxSize[1]) - m.poster.height
-    m.title.translation = [0, m.poster.height]
-
 end sub
 
 function itemContentChanged() as void
-    updateSize()
 
     m.title = m.top.findNode("title")
     m.poster = m.top.findNode("poster")
@@ -40,8 +68,5 @@ function itemContentChanged() as void
     m.title.text = itemData.title
     m.poster.uri = itemData.posterUrl
 
-    if itemData.mediaType = "Episode"
-        m.poster.height = m.poster.width * 9/16
-        m.poster.translation = [2, m.poster.width / 2]
-    end if
+    updateSize()
 end function

--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -39,7 +39,7 @@ sub updateSize()
     m.title.translation = [0, int(maxSize[1]) - m.title.height]
 
     ratio = 1.5
-    if image <> invalid
+    if image <> invalid and image.width <> 0 and image.height <> 0
       ratio = image.height / image.width
     end if
 

--- a/components/ListPoster.xml
+++ b/components/ListPoster.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="ListPoster" extends="Group">
   <children>
-    <Rectangle id="backdrop"
-      translation="[2, 0]"
-      />
-    <Poster id="poster"
-      translation="[2, 0]"
-      />
+    <Rectangle id="backdrop" />
+    <Poster id="poster" />
     <Label id="title"
       horizAlign="center"
       font="font:SmallSystemFont"

--- a/components/collections/rowlist.brs
+++ b/components/collections/rowlist.brs
@@ -21,7 +21,7 @@ sub updateSize()
   border = 75
   m.top.translation = [border, border + 115]
 
-  textHeight = 50
+  textHeight = 80
   ' Do we decide width by rowSize, or rowSize by width...
   itemWidth = (dimensions["width"] - border*2) / m.top.rowSize
   itemHeight = itemWidth * 1.5 + textHeight

--- a/components/data/collection.brs
+++ b/components/data/collection.brs
@@ -7,9 +7,11 @@ sub setFields()
 
   m.top.favorite = datum.UserData.isFavorite
   m.top.watched = datum.UserData.played
+end sub
 
-  if datum.posterURL <> invalid
-    m.top.posterURL = datum.posterURL
+sub setPoster()
+  if m.top.image <> invalid
+    m.top.posterURL = m.top.image.url
   else
     m.top.posterURL = ""
   end if

--- a/components/data/collection.xml
+++ b/components/data/collection.xml
@@ -3,6 +3,7 @@
   <interface>
     <field id="id" type="string" />
     <field id="title" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
     <field id="posterUrl" type="string" />
     <field id="collectionID" type="string" />
     <field id="description" type="string" />

--- a/components/data/movie.brs
+++ b/components/data/movie.brs
@@ -12,10 +12,8 @@ sub setFields()
 end sub
 
 sub setPoster()
-  json = m.top.json
-
-  if json.posterURL <> invalid
-    m.top.posterURL = json.posterURL
+  if m.top.image <> invalid
+    m.top.posterURL = m.top.image.url
   else
     m.top.posterURL = ""
   end if

--- a/components/data/movie.xml
+++ b/components/data/movie.xml
@@ -2,6 +2,7 @@
 <component name="MovieData" extends="ContentNode">
   <interface>
     <field id="title" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
     <field id="posterUrl" type="string" />
     <field id="movieID" type="string" />
     <field id="description" type="string" />

--- a/components/data/search-result.brs
+++ b/components/data/search-result.brs
@@ -4,9 +4,11 @@ sub setFields()
     m.top.id = datum.id
     m.top.title = datum.name
     m.top.type = datum.Type
+end sub
 
-    if datum.posterURL <> invalid
-        m.top.posterURL = datum.posterURL
+sub setPoster()
+    if m.top.image <> invalid
+        m.top.posterURL = m.top.image.url
     else
         m.top.posterURL = ""
     end if

--- a/components/data/search-result.xml
+++ b/components/data/search-result.xml
@@ -4,7 +4,8 @@
     <field id="id" type="string" />
     <field id="type" type="string" />
     <field id="title" type="string" />
-    <field id="posterUrl" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
+    <field id="posterURL" type="string" />
     <field id="json" type="associativearray" onChange="setFields" />
   </interface>
   <script type="text/brightscript" uri="search-result.brs" />

--- a/components/data/series.brs
+++ b/components/data/series.brs
@@ -4,12 +4,16 @@ sub setFields()
     m.top.title = datum.name
     m.top.overview = datum.overview
 
-    if datum.posterURL <> invalid
-        m.top.posterURL = datum.posterURL
-    else
-        m.top.posterURL = ""
-    end if
+    setPoster()
 
     'm.top.seasons = TVSeasons(datum.id)
     'm.top.nextup = TVNext(datum.id)
+end sub
+
+sub setPoster()
+    if m.top.image <> invalid
+      m.top.posterURL = m.top.image.url
+    else
+        m.top.posterURL = ""
+    end if
 end sub

--- a/components/data/series.xml
+++ b/components/data/series.xml
@@ -6,6 +6,7 @@
     <field id="description" type="string" />
     <field id="seasons" type="associativearray" />
     <field id="nextup" type="associativearray" />
+    <field id="image" type="node" onChange="setPoster" />
     <field id="posterURL" type="string" />
     <field id="json" type="associativearray" onChange="setFields" />
     <function name="loadSeasons" />

--- a/components/data/tvepisode.brs
+++ b/components/data/tvepisode.brs
@@ -6,9 +6,11 @@ sub setFields()
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID
     m.top.overview = datum.overview
+end sub
 
-    if datum.posterURL <> invalid
-        m.top.posterURL = datum.posterURL
+sub setPoster()
+    if m.top.image <> invalid
+        m.top.posterURL = m.top.image.url
     else
         m.top.posterURL = ""
     end if

--- a/components/data/tvepisode.xml
+++ b/components/data/tvepisode.xml
@@ -3,6 +3,7 @@
   <interface>
     <field id="id" type="string" />
     <field id="title" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
     <field id="posterURL" type="string" />
     <field id="showID" type="string" />
     <field id="seasonID" type="string" />

--- a/components/data/tvseason.brs
+++ b/components/data/tvseason.brs
@@ -5,9 +5,14 @@ sub setFields()
     m.top.title = datum.name
     m.top.overview = datum.overview
 
-    if datum.posterURL <> invalid
-        m.top.posterURL = datum.posterURL
+    setPoster()
+end sub
+
+sub setPoster()
+    if m.top.image <> invalid
+        m.top.posterURL = m.top.image.url
     else
         m.top.posterURL = ""
     end if
+
 end sub

--- a/components/data/tvseason.xml
+++ b/components/data/tvseason.xml
@@ -3,7 +3,8 @@
   <interface>
     <field id="id" type="string" />
     <field id="title" type="string" />
-    <field id="posterUrl" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
+    <field id="posterURL" type="string" />
     <field id="description" type="string" />
     <field id="json" type="associativearray" onChange="setFields" />
     <function name="getPoster" />

--- a/components/movies/rowlist.brs
+++ b/components/movies/rowlist.brs
@@ -21,7 +21,7 @@ sub updateSize()
     border = 75
     m.top.translation = [border, border + 115]
 
-    textHeight = 75
+    textHeight = 80
     ' Do we decide width by rowSize, or rowSize by width...
     itemWidth = (dimensions["width"] - border*2) / m.top.rowSize
     itemHeight = itemWidth * 1.5 + textHeight

--- a/components/search/rowlist.brs
+++ b/components/search/rowlist.brs
@@ -23,7 +23,7 @@ sub updateSize()
     border = 75
     m.top.translation = [border, border + 115]
 
-    textHeight = 50
+    textHeight = 80
     itemWidth = (dimensions["width"] - border * 2) / m.top.rowSize
     itemHeight = itemWidth * 1.5 + textHeight
 

--- a/components/tvshows/rowlist-episode.brs
+++ b/components/tvshows/rowlist-episode.brs
@@ -17,7 +17,7 @@ sub updateSize()
     border = 75
     m.top.translation = [border, border + 115]
 
-    textHeight = 75
+    textHeight = 80
     itemWidth = (dimensions["width"] - border*2) / m.top.rowSize
     itemHeight = itemWidth * 1.5 + textHeight
 

--- a/components/tvshows/rowlist-season.brs
+++ b/components/tvshows/rowlist-season.brs
@@ -22,7 +22,7 @@ sub updateSize()
     border = 50
     m.top.translation = [border, border]
 
-    textHeight = 75
+    textHeight = 80
     ' Do we decide width by rowSize, or rowSize by width...
     itemWidth = (dimensions["width"] - border*2) / m.top.rowSize
     itemHeight = itemWidth * 1.5 + textHeight

--- a/components/tvshows/rowlist-show.brs
+++ b/components/tvshows/rowlist-show.brs
@@ -22,7 +22,7 @@ sub updateSize()
     border = 75
     m.top.translation = [border, border + 115]
 
-    textHeight = 75
+    textHeight = 80
     ' Do we decide width by rowSize, or rowSize by width...
     itemWidth = (dimensions["width"] - border*2) / m.top.rowSize
     itemHeight = itemWidth * 1.5 + textHeight

--- a/source/api/Image.brs
+++ b/source/api/Image.brs
@@ -13,6 +13,25 @@ function ItemImages(id="" as String)
 end function
 
 
+function PosterImage(id)
+    images = ItemImages(id)
+    primary_image = invalid
+
+    for each image in images
+      if image.imagetype = "Primary"
+        primary_image = image
+      else if image.imagetype = "Logo" and primary_image = invalid
+        primary_image = image
+      else if image.imagetype = "Thumb" and primary_image = invalid
+        primary_image = image
+        ' maybe find more fallback images
+      end if
+    end for
+
+    return primary_image
+end function
+
+
 function ImageURL(id, version="Primary", params={})
   if params.count() = 0
     params =  {"maxHeight": "384", "maxWidth": "196", "quality": "90"}

--- a/source/api/Image.brs
+++ b/source/api/Image.brs
@@ -1,7 +1,10 @@
 function ItemImages(id="" as String)
   ' This seems to cause crazy core dumps
+  ' if there is a conflict between on disk images, and library.db
   resp = APIRequest(Substitute("Items/{0}/Images", id))
   data = getJson(resp)
+  if data = invalid then return invalid
+
   results = []
   for each item in data
     tmp = CreateObject("roSGNode", "ImageData")
@@ -15,6 +18,7 @@ end function
 
 function PosterImage(id)
     images = ItemImages(id)
+    if images = invalid then return invalid
     primary_image = invalid
 
     for each image in images

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -46,15 +46,8 @@ function SearchMedia(query as String)
   data = getJson(resp)
   results = []
   for each item in data.SearchHints
-    if item.type = "Movie"
-      item.posterURL = ImageURL(item.id)
-    else if item.type = "Person"
-      item.posterURL = ImageURL(item.id)
-    else if item.type = "Episode"
-      item.posterURL = ImageURL(item.id)
-    end if
-
     tmp = CreateObject("roSGNode", "SearchData")
+    tmp.image = PosterImage(item.itemid)
     tmp.json = item
     results.push(tmp)
   end for
@@ -76,29 +69,19 @@ function ItemList(library_id=invalid as String, params={})
   data = getJson(resp)
   results = []
   for each item in data.Items
-    ' TODO - actually check item for available images
-
-    if item.imagetags.primary <> invalid
-      item.posterURL = ImageURL(item.id, "Primary")
-      ' item.posterAspect = item.PrimaryImageAspectRatio
-    else if item.imagetags.logo <> invalid
-      item.posterURL = ImageURL(item.id, "Logo")
-    else if item.imagetags.thumb <> invalid
-      item.posterURL = ImageURL(item.id, "Thumb")
-    else
-      ' Maybe find more fallback images!
-    end if
-
     if item.type = "Movie"
       tmp = CreateObject("roSGNode", "MovieData")
+      tmp.image = PosterImage(item.id)
       tmp.json = item
       results.push(tmp)
     else if item.type = "Series"
       tmp = CreateObject("roSGNode", "SeriesData")
+      tmp.image = PosterImage(item.id)
       tmp.json = item
       results.push(tmp)
     else if item.type = "BoxSet"
       tmp = CreateObject("roSGNode", "CollectionData")
+      tmp.image = PosterImage(item.id)
       tmp.json = item
       results.push(tmp)
     else
@@ -116,21 +99,24 @@ function ItemMetaData(id as String)
   url = Substitute("Users/{0}/Items/{1}", get_setting("active_user"), id)
   resp = APIRequest(url)
   data = getJson(resp)
-  data.posterURL = ImageURL(data.id)
   if data.type = "Movie"
     tmp = CreateObject("roSGNode", "MovieData")
+    tmp.image = PosterImage(data.id)
     tmp.json = data
     return tmp
   else if data.type = "Series"
     tmp = CreateObject("roSGNode", "SeriesData")
+    tmp.image = PosterImage(data.id)
     tmp.json = data
     return tmp
   else if data.type = "Episode"
     tmp = CreateObject("roSGNode", "TVEpisodeData")
+    tmp.image = PosterImage(data.id)
     tmp.json = data
     return tmp
   else if data.type = "BoxSet"
     tmp = CreateObject("roSGNode", "CollectionData")
+    tmp.image = PosterImage(data.id)
     tmp.json = item
     return tmp
   else
@@ -149,8 +135,8 @@ function TVSeasons(id as String)
   data = getJson(resp)
   results = []
   for each item in data.Items
-    item.posterURL = ImageURL(item.id)
     tmp = CreateObject("roSGNode", "TVEpisodeData")
+    tmp.image = PosterImage(item.id)
     tmp.json = item
     results.push(tmp)
   end for
@@ -165,8 +151,8 @@ function TVEpisodes(show_id as String, season_id as String)
   data = getJson(resp)
   results = []
   for each item in data.Items
-    item.posterURL = ImageURL(item.id)
     tmp = CreateObject("roSGNode", "TVEpisodeData")
+    tmp.image = PosterImage(item.id)
     tmp.json = item
     results.push(tmp)
   end for
@@ -181,7 +167,7 @@ function TVNext(id as String)
 
   data = getJson(resp)
   for each item in data.Items
-    item.posterURL = ImageURL(item.id)
+    item.image = PosterImage(item.id)
   end for
   return data
 end function

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -42,12 +42,26 @@ end function
 
 ' Search across all libraries
 function SearchMedia(query as String)
-  resp = APIRequest("Search/Hints", {"searchTerm": query})
+  ' This appears to be done differently on the web now
+  ' For each potential type, a separate query is done:
+  ' varying item types, and artists, and people
+  resp = APIRequest(Substitute("Users/{0}/Items", get_setting("active_user")), {
+    "searchTerm": query,
+    "IncludePeople": true,
+    "IncludeMedia": true,
+    "IncludeGenres": false,
+    "IncludeStudios": false,
+    "IncludeArtists": false,
+    ' "IncludeItemTypes: "Movie",
+    "EnableTotalRecordCount":  false,
+    "ImageTypeLimit": 1,
+    "Recursive": true
+  })
   data = getJson(resp)
   results = []
-  for each item in data.SearchHints
+  for each item in data.Items
     tmp = CreateObject("roSGNode", "SearchData")
-    tmp.image = PosterImage(item.itemid)
+    tmp.image = PosterImage(item.id)
     tmp.json = item
     results.push(tmp)
   end for


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Attach `Image` objects to movies, tv shows, etc. when rendering the `ListPoster` for showing an object in a list... we have more info available for determining aspect ratio, etc. This prevents stretching of the image if it isn't 3:2.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

This doesn't handle #13 but was inspired by the strange thumbnails in that ticket. We should determine if v1.0 is going to strive to match the web app, or if "a list of episodes that you can play"  can be good enough for now.
