### PR TITLE
Correct a swap of sort by and sort order

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -296,8 +296,10 @@ sub ShowMovieOptions(library)
       pager.currentPage = page_num
       options_list = ItemList(library.id, {"limit": page_size,
         "StartIndex": page_size * (page_num - 1),
-        "SortBy": sort_order,
-        "SortOrder": sort_field })
+        "SortBy": sort_field,
+        "SortOrder": sort_order,
+        "IncludeItemTypes": "Movie"
+      })
       options.movieData = options_list
       options.setFocus(true)
     else if nodeEventQ(msg, "itemSelected")
@@ -624,8 +626,8 @@ sub ShowCollections(library)
       pager.currentPage = page_num
       options_list = ItemList(library.id, {"limit": page_size,
         "StartIndex": page_size * (page_num - 1),
-        "SortBy": sort_order,
-        "SortOrder": sort_field })
+        "SortBy": sort_field,
+        "SortOrder": sort_order })
       options.itemData = options_list
       options.setFocus(true)
     else if nodeEventQ(msg, "itemSelected")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
My wife was complaining about how the ordering wasn't working, so I looked into it. Turns out `SortBy` and `SortOrder` were flipped in paged queries (probably another thing we should look into abstracting better).

This un-flips them, so the user defined sort orders are applied.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
No issue was created for this because I was able to solve it in the same amount of time as it took to confirm the bug existed.