### PR TITLE
Fix for issue 46 - test failure due to missing projectPath in configuration

### DIFF
--- a/tests/.rooibosrc.json
+++ b/tests/.rooibosrc.json
@@ -1,5 +1,6 @@
 {
     "testPath": "out/staging/source/tests/specs",
     "rootPath": "",
-    "outputPath": "out/staging/source/tests/rooibos"
+    "outputPath": "out/staging/source/tests/rooibos",
+    "projectPath": "."
   }


### PR DESCRIPTION
**Changes**
Add missing parameter projectPath to tests/.rooibosrc.json
to fix test failure reported in issue 46.

**Issues**
Fixes #46.

