### PR TITLE
Fix maxPages off-by-one bug

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -243,7 +243,7 @@ sub ShowMovieOptions(library)
   pager = scene.findNode("pager")
   pager.currentPage = page_num
   pager.maxPages = item_list.TotalRecordCount / page_size
-  if pager.maxPages = 0 then pager.maxPages = 1
+  if item_list.TotalRecordCount mod page_size > 0 then pager.maxPages += 1
 
   pager.observeField("escape", port)
   pager.observeField("pageSelected", port)
@@ -403,7 +403,7 @@ sub ShowTVShowOptions(library)
   pager = scene.findNode("pager")
   pager.currentPage = page_num
   pager.maxPages = item_list.TotalRecordCount / page_size
-  if pager.maxPages = 0 then pager.maxPages = 1
+  if item_list.TotalRecordCount mod page_size > 0 then pager.maxPages += 1
 
   pager.observeField("escape", port)
   pager.observeField("pageSelected", port)
@@ -577,7 +577,7 @@ sub ShowCollections(library)
   pager = scene.findNode("pager")
   pager.currentPage = page_num
   pager.maxPages = item_list.TotalRecordCount / page_size
-  if pager.maxPages = 0 then pager.maxPages = 1
+  if item_list.TotalRecordCount mod page_size > 0 then pager.maxPages += 1
 
   pager.observeField("escape", port)
   pager.observeField("pageSelected", port)


### PR DESCRIPTION
The `pager.maxPages` calculation currently handles the case where there
are fewer than `page_size` items to display but will cut off the final
page for any page count larger than one. This change makes the page size
the ceiling of the calculation in all cases.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Correct the calculation of `pager.maxPages` in library view.

**Issues**
Bug in `master`, no open issue.