### PR TITLE
Fix back button on options menu in Library (#39)

### DIFF
--- a/components/options/panel.brs
+++ b/components/options/panel.brs
@@ -33,7 +33,7 @@ end sub
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
-    if key = "options"
+    if key = "options" or key = "back"
         m.top.visible = false
         m.top.escape = true
         return true


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Added back button handling to panel.brs so that back button will function the same as the options button.

With this fix a user can press the option button from the Library page to bring up the Options menu, then press the back or options button to exit the Options menu to go back to the Library page.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #39 
