### PR TITLE
Remove image script from deploy scripts and update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ZIP_EXCLUDE= -x rooibos/**\* -x xml/* -x artwork/* -x \*.pkg -x storeassets\* -x
 
 include app.mk
 
-test: get_images prep_staging prep_tests remove install
+test: prep_staging prep_tests remove install
 	echo "Running tests"
 
-deploy: get_images prep_staging remove install
+deploy: prep_staging remove install

--- a/README.md
+++ b/README.md
@@ -10,77 +10,130 @@ your data could be lost and you'd have to re-enter it.
 
 ## Getting Started
 
-Follow the steps below or checkout the [Development Guide For New Devs](DEVGUIDE.md)
+Follow the steps below to install the app on your personal Roku device
 
 ### Developer Mode
 
-Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide)
+Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created, you will need these later.
 
 ### Clone the GitHub Repo
 
-Copy all of the application files to a new folder and then change directories:
+Navigate to where you'd like to install the app then copy the application files:
 
 ```bash
-https://github.com/jellyfin/jellyfin-roku.git
+git clone https://github.com/jellyfin/jellyfin-roku.git
+```
+
+Open up the new folder:
+
+```bash
 cd jellyfin-roku
+```
+
+### Install Necessary Packages
+
+```bash
+sudo apt-get install wget make
 ```
 
 ### Login Details
 
-Run the commands below - Replacing the IP and password (using the info from the first step)
+Run this command - replacing the IP and password with your Roku device IP and dev password from the first step:
 
 ```bash
 export ROKU_DEV_TARGET=192.168.1.234
-export ROKU_DEV_PASSWORD=aaaa
+export ROKU_DEV_PASSWORD=password
 ```
 
-This will allow you to test your code without having to manually upload a .zip file every time
-
-### Download Images
-
-Install these packages:
-
-```bash
-sudo apt-get install imagemagick wget make nodejs npm
-```
-
-Then run this script to download the images from the jellyfin-ux repo:
-
-```bash
-sh make_images.sh
-```
+Normally you would have to open up your browser and upload a .zip file containing the app code. These commands enable the app to be zipped up and installed on the Roku automatically which is essential for developers and makes it easy to upgrade in the future for users.
 
 ### Deploy
 
-This packages up the application, sends it to your Roku, and launches the channel:
+Package up the application, send it to your Roku, and launch the channel:
 
 ```bash
 make install
 ```
 
-### Testing
+Note: You only have to run this command once if you are not a developer. The Jellyfin channel will still be installed after rebooting your Roku device.
 
-Testing is done with the [Rooibos](https://github.com/georgejecook/rooibos/) library.
+### Bug/Crash Reports
 
-This works by including the tests in the deployment and then looking at telnet
-for the test results. To use the testing library you need to install [rooibos-cli](https://github.com/georgejecook/rooibos-cli):
-
-Run this in the root app directory:
-
-```bash
-npm install -g rooibos-cli
-```
-
-To deploy the application with tests:
-
-```bash
-make test
-```
-
-To see test results and crash reports:
+Did the app crash? Find a nasty bug? Use the this command to view the error log and [report it to the developers](https://github.com/jellyfin/jellyfin-roku/issues):
 
 ```bash
 telnet ${ROKU_DEV_TARGET} 8085
 ```
 
 To exit telnet: `CTRL + ]` and then type `quit + ENTER`
+
+### Upgrade
+
+Navigate to the folder where you installed the app then upgrade the code to the latest version:
+
+```bash
+git pull
+```
+
+Deploy the app:
+
+```bash
+make install
+```
+
+## Developer Setup
+
+Read below and also checkout the [Development Guide For New Devs](DEVGUIDE.md)
+
+### Workflow
+
+Modify code -> `make install` -> Use Roku remote to test changes -> `telnet ${ROKU_DEV_TARGET} 8085` -> `CTRL + ]` -> `quit + ENTER`
+
+Unfortunately there is no debuger. You will need to use telnet to see log statements, warnings, and error reports. You won't always need to telnet into your device but the workflow above is typical when you are new to Brightscript or are working on tricky code.
+
+### Testing
+
+Testing is done with the [Rooibos](https://github.com/georgejecook/rooibos/) library. This works by including tests in the deployment and then looking at telnet
+for the test results.
+
+Install necessary packages:
+
+```bash
+sudo apt-get install nodejs npm
+```
+
+Install [rooibos-cli](https://github.com/georgejecook/rooibos-cli):
+
+```bash
+npm install -g rooibos-cli
+```
+
+Deploy the application with tests:
+
+```bash
+make test
+```
+
+View test results:
+
+```bash
+telnet ${ROKU_DEV_TARGET} 8085
+```
+
+To exit telnet: `CTRL + ]` and then type `quit + ENTER`
+
+### (Optional) Update Images
+
+This repo already contains all necessary images for the app. This script only needs to be run when the [official Jellyfin images](https://github.com/jellyfin/jellyfin-ux) are changed to allow us to update the repo images.
+
+Install necessary packages:
+
+```bash
+sudo apt-get install imagemagick
+```
+
+Download and convert images:
+
+```bash
+make get_images
+```

--- a/app.mk
+++ b/app.mk
@@ -154,7 +154,7 @@ prep_tests:
 	cp -r $(SOURCEREL)/tests/source/* $(STAGINGREL)/source/tests/;\
 	./node_modules/.bin/rooibos-cli i tests/.rooibosrc.json
 
-install: get_images prep_staging package home
+install: prep_staging package home
 	@echo "Installing $(APPNAME) to host $(ROKU_DEV_TARGET)"
 	@$(CURLCMD) --user $(USERPASS) --digest -F "mysubmit=Install" -F "archive=@$(ZIPREL)/$(APPNAME).zip" -F "passwd=" http://$(ROKU_DEV_TARGET)/plugin_install | grep "<font color" | sed "s/<font color=\"red\">//" | sed "s[</font>[["
 
@@ -174,15 +174,12 @@ get_images:
 		echo "Creating images folder"; \
 	fi
 
-	@if [ -e $(ICON_SOURCE) ]; \
-	then \
-		echo "Images are already downloaded"; \
-	else \
-		echo "Downloading images from $(BRANDING_ROOT)"; \
-		wget $(BRANDING_ROOT)/$(ICON_SOURCE) > /dev/null ; \
-		wget $(BRANDING_ROOT)/$(BANNER_SOURCE) > /dev/null ; \
-		echo "Finished downloading images"; \
-	fi
+	echo "Downloading SVG source files from $(BRANDING_ROOT)"
+	@wget $(BRANDING_ROOT)/$(ICON_SOURCE) > /dev/null
+	@wget $(BRANDING_ROOT)/$(BANNER_SOURCE) > /dev/null
+	echo "Finished downloading SVG files"
+
+	echo "Creating image files"
 	@convert -background "#000b25" -gravity center -scale 535x400 -extent 540x405 $(BANNER_SOURCE) $(OUTPUT_DIR)/channel-poster_fhd.png
 	@convert -background "#000b25" -gravity center -scale 275x205 -extent 280x210 $(BANNER_SOURCE) $(OUTPUT_DIR)/channel-poster_hd.png
 	@convert -background "#000b25" -gravity center -scale 182x135 -extent 187x140 $(BANNER_SOURCE) $(OUTPUT_DIR)/channel-poster_sd.png
@@ -192,7 +189,8 @@ get_images:
 	@convert -background "#000b25" -gravity center -scale 540x540 -extent 1920x1080 $(BANNER_SOURCE) $(OUTPUT_DIR)/splash-screen_fhd.jpg
 	@convert -background "#000b25" -gravity center -scale 360x360 -extent 1280x720 $(BANNER_SOURCE) $(OUTPUT_DIR)/splash-screen_hd.jpg
 	@convert -background "#000b25" -gravity center -scale 240x240 -extent 720x480 $(BANNER_SOURCE) $(OUTPUT_DIR)/splash-screen_sd.jpg
-	
+	echo "Finished creating image files"
+
 screenshot:
 	SCREENSHOT_TIME=`date "+%s"`; \
 	curl -m 1 -o screenshot.jpg --user $(USERPASS) --digest "http://$(ROKU_DEV_TARGET)/pkgs/dev.jpg?time=$$SCREENSHOT_TIME" -H 'Accept: image/png,image/*;q=0.8,*/*;q=0.5' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate'


### PR DESCRIPTION
The image script only needs to be run when upstream changes.

**Changes**

Modified makefile. Updated readme with new image script command. Updated readme for readability and easier install instructions.

