### PR TITLE
Fix favorite boolean invalid error and incorrect name for description

### DIFF
--- a/components/data/movie.xml
+++ b/components/data/movie.xml
@@ -5,7 +5,7 @@
     <field id="image" type="node" onChange="setPoster" />
     <field id="posterUrl" type="string" />
     <field id="movieID" type="string" />
-    <field id="description" type="string" />
+    <field id="overview" type="string" />
     <field id="favorite" type="boolean" />
     <field id="watched" type="boolean" />
     <field id="seasons" type="associativearray" />

--- a/components/movies/details.brs
+++ b/components/movies/details.brs
@@ -102,7 +102,7 @@ end function
 sub setFavoriteColor()
   fave = m.top.itemContent.favorite
   fave_button = m.top.findNode("favorite-button")
-  if fave
+  if fave <> invalid And fave
     fave_button.textColor = "#00ff00ff"
     fave_button.focusedTextColor = "#269926ff"
   else


### PR DESCRIPTION
**Changes**
The variable in movie.xml was inconsistent with movie.brs and was renamed to be overview to alleviate a warning. Also fave/m.top.itemContent.favorite is invalid causing a segfault when clicking a TV show from search. This is resolved by adding an invalid check.

**Issues**
N/A