### PR TITLE
Updated config screen dimensions for auto-scaling (#74)

### DIFF
--- a/components/config/item.brs
+++ b/components/config/item.brs
@@ -2,21 +2,14 @@ sub init()
   m.name = m.top.findNode("label")
   m.value = m.top.findNode("value")
 
-  m.top.layoutDirection = "horiz"
-  m.top.vertAlignment = "top"
-
-  m.name.width = 250
-  m.name.height = 80
+  m.name.width = 240
+  m.name.height = 75
 
   m.name.vertAlign = "center"
   m.name.horizAlign = "center"
 
-  ' TODO - calculate "width" better... this is total item - (label + spacings)
-  m.value.width = 1000 - 230
-  m.value.height = 80
-
   m.value.hintText = "Enter a value..."
-  m.value.maxTextLength = 100
+  m.value.maxTextLength = 120
 end sub
 
 sub itemContentChanged()

--- a/components/config/list.brs
+++ b/components/config/list.brs
@@ -6,9 +6,8 @@ sub init()
 
   m.top.observeField("itemSelected", "onItemSelected")
 
-  m.top.itemSize = [1000, 80]
-  m.top.itemSpacing = [0, 20]
-  m.top.vertAlign = "middle"
+  m.top.itemSize = [750, 75]
+  m.top.itemSpacing = [0, 25]
 
   m.top.setfocus(true)
 

--- a/components/config/scene.xml
+++ b/components/config/scene.xml
@@ -7,7 +7,7 @@
       translation="[150, 150]" />
     <ConfigList
       id="configOptions"
-      translation="[150, 250]" />
+      translation="[150, 240]" />
     <Button
       id="submit"
       text="Submit"
@@ -16,7 +16,7 @@
     <label text=""
       id="alert"
       font="font:MediumSystemFont"
-      translation="[150, 550]" />
+      translation="[150, 555]" />
   </children>
   <script type="text/brightscript" uri="scene.brs"/>
 </component>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Modified the dimensions of the scene, list, and items to allow for proper auto-scaling at lower resolutions.  I also removed a couple unnecessary fields that were throwing errors in the application.

**Issues**
Config Screen from #74 
