### PR TITLE
Made work around for jellyfin#93

### DIFF
--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -2,7 +2,7 @@ function get_token(user as String, password as String)
   url = "Users/AuthenticateByName?format=json"
   req = APIRequest(url)
 
-  json = postJson(req, "Username=" + user + "&Pw=" + password)
+  json = postJson(req, "Username=" + user + "&Pw=" + password.replace("&", "%26"))
 
   if json = invalid then return invalid
 

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -2,7 +2,7 @@ function get_token(user as String, password as String)
   url = "Users/AuthenticateByName?format=json"
   req = APIRequest(url)
 
-  json = postJson(req, "Username=" + user + "&Pw=" + password.replace("&", "%26"))
+  json = postJson(req, "Username=" + user + "&Pw=" + Escape(password))
 
   if json = invalid then return invalid
 

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -2,7 +2,8 @@ function get_token(user as String, password as String)
   url = "Users/AuthenticateByName?format=json"
   req = APIRequest(url)
 
-  json = postJson(req, "Username=" + user + "&Pw=" + Escape(password))
+  encPass = CreateObject("roUrlTransfer")
+  json = postJson(req, "Username=" + user + "&Pw=" + encPass.Escape(password) )
 
   if json = invalid then return invalid
 


### PR DESCRIPTION
When passwords would include ampersand '&', they wouldn't process correctly with URL encoding.

**Changes**
Replaces '&' with '%26'

**Issues**
Fixes issue #93
