### PR TITLE
Transcode finished fix

### DIFF
--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -2,6 +2,10 @@
 <component name="JFVideo" extends="Video">
   <interface>
     <field id="backPressed" type="boolean" alwaysNotify="true" />
+    <field id="PlaySessionId" type="string" />
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
+  <children>
+    <timer id="playbackTimer" repeat="true" duration="30" />
+  </children>
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -39,7 +39,7 @@ sub Main()
       print "CLOSING SCREEN"
       return
     else if isNodeEvent(msg, "backPressed")
-      if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo") 
+      if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
         stopPlayback()
       end if
       ' Pop a group off the stack and expose what's below

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -212,6 +212,7 @@ sub Main()
         m.scene.appendChild(group)
         group.setFocus(true)
         group.control = "play"
+        ReportPlayback(group, "start")
         m.overhang.visible = false
       else if btn.id = "watched-button"
         movie = group.itemContent

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -39,6 +39,9 @@ sub Main()
       print "CLOSING SCREEN"
       return
     else if isNodeEvent(msg, "backPressed")
+      if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo") 
+        stopPlayback()
+      end if
       ' Pop a group off the stack and expose what's below
       n = m.scene.getChildCount() - 1
       if n = 1
@@ -156,6 +159,7 @@ sub Main()
       m.scene.appendChild(group)
       group.setFocus(true)
       group.control = "play"
+      ReportPlayback(group, "start")
       m.overhang.visible = false
     else if isNodeEvent(msg, "search_value")
       query = msg.getRoSGNode().search_value
@@ -261,6 +265,15 @@ sub Main()
         unset_setting("port")
         wipe_groups()
         goto app_start
+      end if
+    else if isNodeEvent(msg, "fire")
+      ReportPlayback(group, "update")
+    else if isNodeEvent(msg, "state")
+      node = msg.getRoSGNode()
+      if node.state = "finished" then
+        node.backPressed = "true"
+      else if node.state = "playing" or node.state = "paused" then
+        ReportPlayback(group, "update")
       end if
     else
       print type(msg)

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -267,14 +267,20 @@ sub Main()
         wipe_groups()
         goto app_start
       end if
+    else if isNodeEvent(msg, "position")
+      video = msg.getRoSGNode()
+      if video.position >= video.duration then
+        video.control = "stop"
+        video.state = "finished"
+      end if
     else if isNodeEvent(msg, "fire")
-      ReportPlayback(group, "update")
+      ReportPlayback(group)
     else if isNodeEvent(msg, "state")
       node = msg.getRoSGNode()
       if node.state = "finished" then
         node.backPressed = "true"
       else if node.state = "playing" or node.state = "paused" then
-        ReportPlayback(group, "update")
+        ReportPlayback(group)
       end if
     else
       print type(msg)

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -266,14 +266,20 @@ sub Main()
         wipe_groups()
         goto app_start
       end if
+    else if isNodeEvent(msg, "position")
+      video = msg.getRoSGNode()
+      if video.position >= video.duration then
+        video.control = "stop"
+        video.state = "finished"
+      end if
     else if isNodeEvent(msg, "fire")
-      ReportPlayback(group, "update")
+      ReportPlayback(group)
     else if isNodeEvent(msg, "state")
       node = msg.getRoSGNode()
       if node.state = "finished" then
         node.backPressed = "true"
       else if node.state = "playing" or node.state = "paused" then
-        ReportPlayback(group, "update")
+        ReportPlayback(group)
       end if
     else
       print type(msg)

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -274,13 +274,13 @@ sub Main()
         video.state = "finished"
       end if
     else if isNodeEvent(msg, "fire")
-      ReportPlayback(group)
+      ReportPlayback(group, "update")
     else if isNodeEvent(msg, "state")
       node = msg.getRoSGNode()
       if node.state = "finished" then
         node.backPressed = "true"
       else if node.state = "playing" or node.state = "paused" then
-        ReportPlayback(group)
+        ReportPlayback(group, "update")
       end if
     else
       print type(msg)

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -348,6 +348,7 @@ function CreateVideoPlayerGroup(video_id)
 
   video.observeField("backPressed", m.port)
   video.observeField("state", m.port)
+  video.observeField("position", m.port)
   timer.control = "start"
   timer.observeField("fire", m.port)
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -344,9 +344,12 @@ end function
 function CreateVideoPlayerGroup(video_id)
   ' Video is Playing
   video = VideoPlayer(video_id)
+  timer = video.findNode("playbackTimer")
 
   video.observeField("backPressed", m.port)
   video.observeField("state", m.port)
+  timer.control = "start"
+  timer.observeField("fire", m.port)
 
   return video
 end function

--- a/source/api/Playstate.brs
+++ b/source/api/Playstate.brs
@@ -1,18 +1,13 @@
-function PlaystateStart(id, params)
+function PlaystateUpdate(id, state as string, params = {})
+  if state = "start" then
+    url = "Sessions/Playing"
+  else if state = "stop" then
+    url = "Sessions/Playing/Stopped"
+  else if state = "update"
+    url = "Sessions/Playing/Progress"
+  end if
   params = PlaystateDefaults(id, params)
-  resp = APIRequest("Sessions/Playing")
-  return postJson(resp, params)
-end function
-
-function PlaystateUpdate(id, params)
-  params = PlaystateDefaults(id, params)
-  resp = APIRequest("Sessions/Playing/Progress")
-  return postJson(resp, params)
-end function
-
-function PlaystateStop(id, params={})
-  params = PlaystateDefaults(id, params)
-  resp = APIRequest("Sessions/Playing/Stopped")
+  resp = APIRequest(url)
   return postJson(resp, params)
 end function
 
@@ -29,7 +24,7 @@ function PlaystateDefaults(id="" as string, params={} as object)
     '"SubtitleStreamIndex": 0,
     "IsPaused": false,
     '"IsMuted": false,
-    '"PositionTicks": 0,
+    "PositionTicks": 0,
     '"PlaybackStartTimeTicks": 0,
     '"VolumeLevel": 100,
     '"Brightness": 100,


### PR DESCRIPTION
**Changes**
Player was not terminating at end of duration with transcoded files and would loop end of video. 

This uses the timer from videos's position (default is 0.5 seconds) to check the current playback position and forces playback to end when the duration is met. There probably is a more elegant solution to this.