### PR TITLE
Reworks URL to match other clients

### DIFF
--- a/components/config/scene.xml
+++ b/components/config/scene.xml
@@ -8,6 +8,10 @@
     <ConfigList
       id="configOptions"
       translation="[150, 240]" />
+      <label text=""
+      id="example"
+      font="font:smallSystemFont"
+      translation="[150, 350]" />
     <Button
       id="submit"
       text="Submit"

--- a/components/config/scene.xml
+++ b/components/config/scene.xml
@@ -8,7 +8,7 @@
     <ConfigList
       id="configOptions"
       translation="[150, 240]" />
-      <label text=""
+    <label text=""
       id="example"
       font="font:smallSystemFont"
       translation="[150, 350]" />

--- a/components/data/user.brs
+++ b/components/data/user.brs
@@ -31,7 +31,6 @@ function saveToRegistry()
             id: m.top.id,
             username: m.top.username,
             server: get_setting("server"),
-            port: get_setting("port")
         })
         set_setting("available_users", formatJson(users))
     end if
@@ -59,7 +58,6 @@ function setActive()
     set_setting("active_user", m.top.id)
 end function
 
-function setServer(hostname as string, port as string)
+function setServer(hostname as string)
     m.top.server = hostname
-    m.top.port = port
 end function

--- a/components/data/user.xml
+++ b/components/data/user.xml
@@ -5,7 +5,6 @@
     <field id="username" type="string" />
     <field id="token" type="string" />
     <field id="server" type="string" />
-    <field id="port" type="string" />
     <field id="json" type="associativearray" onChange="setDataFromJSON" />
     <function name="setServer" />
     <function name="getPreference" />

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -14,7 +14,7 @@ sub CreateServerGroup()
   if get_setting("server") <> invalid
     server_field.value = get_setting("server")
   end if
-  group.findNode("example").text = "192.168.1.100:8096 or https://example.com"
+  group.findNode("example").text = "192.168.1.100:8096 or https://example.com/jellyfin"
 
 
   items = [ server_field ]

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -14,21 +14,14 @@ sub CreateServerGroup()
   if get_setting("server") <> invalid
     server_field.value = get_setting("server")
   end if
-  port_field = CreateObject("roSGNode", "ConfigData")
-  port_field.label = "Port"
-  port_field.field = "port"
-  port_field.type = "string"
-  if get_setting("port") <> invalid
-    port_field.value = get_setting("port")
-  end if
-  items = [ server_field, port_field ]
+
+  items = [ server_field]
   config.configItems = items
 
   button = group.findNode("submit")
   button.observeField("buttonSelected", m.port)
 
   server_hostname = config.content.getChild(0)
-  server_port = config.content.getChild(1)
 
   while(true)
     msg = wait(0, m.port)
@@ -38,7 +31,6 @@ sub CreateServerGroup()
       node = msg.getNode()
       if node = "submit"
         set_setting("server", server_hostname.value)
-        set_setting("port", server_port.value)
         if ServerInfo() = invalid then
           ' Maybe don't unset setting, but offer as a prompt
           ' Server not found, is it online? New values / Retry

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -14,6 +14,8 @@ sub CreateServerGroup()
   if get_setting("server") <> invalid
     server_field.value = get_setting("server")
   end if
+  group.findNode("example").text = "192.168.1.100:8096 or https://example.com"
+
 
   items = [ server_field]
   config.configItems = items

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -17,7 +17,7 @@ sub CreateServerGroup()
   group.findNode("example").text = "192.168.1.100:8096 or https://example.com"
 
 
-  items = [ server_field]
+  items = [ server_field ]
   config.configItems = items
 
   button = group.findNode("submit")
@@ -396,5 +396,4 @@ function CollectionLister(group, page_size)
   p = group.findNode("paginator")
   p.maxPages = div_ceiling(group.objects.TotalRecordCount, page_size)
 end function
-
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -15,8 +15,6 @@ sub CreateServerGroup()
     server_field.value = get_setting("server")
   end if
   group.findNode("example").text = "192.168.1.100:8096 or https://example.com/jellyfin"
-
-
   items = [ server_field ]
   config.configItems = items
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -46,10 +46,8 @@ function VideoContent(video) as object
 
   ' todo - audioFormat is read only
   video.content.audioFormat = getAudioFormat(meta)
+  video.content.setCertificatesFile("common:/certs/ca-bundle.crt")
 
-  if server_is_https() then
-    video.content.setCertificatesFile("common:/certs/ca-bundle.crt")
-  end if
   return video
 end function
 

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -100,7 +100,7 @@ function get_url()
   end if
 
   ' append http:// to the start if not specified
-  if base.left(5) <> "https" or base.left(5) <> "http:"
+  if base.left(7) <> "http://" and base.left(8) <> "https://"
     base = "http://" + base
   end if
 

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -102,6 +102,8 @@ function get_url()
   ' append http:// to the start if not specified
   if base.left(5) <> "https" or <> "http:"
     base = "http://" + base
+  end if
+  
   return base
 
 end function

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -101,10 +101,11 @@ end function
 function get_base_url()
   base = get_setting("server")
   port = get_setting("port")
-
-  if base.right(1) = "/"
-    base = base.left(base.len() - 1)
+  
+  if base.right(1) <> "/"
+    base = base + "/"
   end if
+
 
   if base.left(4) <> "http"
     if server_is_https()

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -100,10 +100,10 @@ function get_url()
   end if
 
   ' append http:// to the start if not specified
-  if base.left(5) <> "https" or <> "http:"
+  if base.left(5) <> "https" or base.left(5) <> "http:"
     base = "http://" + base
   end if
-  
+
   return base
 
 end function

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -36,7 +36,7 @@ end function
 
 function buildURL(path as String, params={} as Object) as string
   
-  full_url = get_url() + path
+  full_url = get_url() + "/" + path
   if params.count() > 0
     full_url = full_url + "?" + buildParams(params)
   end if
@@ -46,15 +46,10 @@ end function
 
 function APIRequest(url as String, params={} as Object)
   req = createObject("roUrlTransfer")
-
-  if server_is_https() then
-    req.setCertificatesFile("common:/certs/ca-bundle.crt")
-  end if
+  req.setCertificatesFile("common:/certs/ca-bundle.crt")
 
   full_url = buildURL(url, params)
-
   req.setUrl(full_url)
-
   req = authorize_request(req)
 
   return req
@@ -100,16 +95,15 @@ end function
 
 function get_url()
   base = get_setting("server")
-  
-  if base.right(1) <> "/"
-    base = base + "/"
+  if base.right(1) = "/"
+    base = base.left(base.len() - 1)
   end if
 
+  ' append http:// to the start if not specified
+  if base.left(5) <> "https" or <> "http:"
+    base = "http://" + base
   return base
-end function
 
-function server_is_https() as Boolean
-    return True
 end function
 
 function authorize_request(request)

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -36,7 +36,7 @@ end function
 
 function buildURL(path as String, params={} as Object) as string
   
-  full_url = get_base_url() + "/" + path
+  full_url = get_url() + path
   if params.count() > 0
     full_url = full_url + "?" + buildParams(params)
   end if
@@ -98,52 +98,18 @@ function postJson(req, data="" as string)
   return json
 end function
 
-function get_base_url()
+function get_url()
   base = get_setting("server")
-  port = get_setting("port")
   
   if base.right(1) <> "/"
     base = base + "/"
-  end if
-
-
-  if base.left(4) <> "http"
-    if server_is_https()
-      protocol = "https://"
-    else
-      protocol = "http://"
-    end if
-    base = protocol + base
-  end if
-
-  if port <> "" and port <> invalid then
-    base = base + ":" + port
   end if
 
   return base
 end function
 
 function server_is_https() as Boolean
-  server = get_setting("server")
-  port = get_setting("port")
-
-  i = server.Instr(":")
-
-  ' No protocol found
-  if i = 0 then
-    return False
-  end if
-
-  protocol = Left(server, i)
-  if protocol = "https" then
     return True
-  end if
-
-  if port = "443" or port = "8920"
-    return True
-  end if
-
-  return False
 end function
 
 function authorize_request(request)

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -42,7 +42,6 @@ function PickUser(id as string)
   if this_user = invalid then return invalid
   set_setting("active_user", this_user.id)
   set_setting("server", this_user.server)
-  set_setting("port", this_user.port)
 end function
 
 function RemoveUser(id as string)


### PR DESCRIPTION
**Changes**
Changes the server entry screen to have a single URL entry, to take both server name, base url, and port.
This matches the other clients, and effectively adds Base URL support. It also removes the https check, since we should verify that whenever possible.
If a protocol isn't specified, it assumes `http://` for the user's sake.

Adds a little explainer text, just like in the Android app.

**Issues**
Fixes #95.

**Notes**
This is my first attempt at anything Roku related, and this is one step closer to publishing to the store.

Please squash when merging.
