### PR TITLE
Fix background color on screensaver

### DIFF
--- a/components/screensaver/Screensaver.brs
+++ b/components/screensaver/Screensaver.brs
@@ -1,7 +1,7 @@
 function init()
     ' backgroundUri must be set to an empty string before backgroundColor can be set
     m.top.backgroundUri = ""
-    m.top.backgroundColor = &h000000
+    m.top.backgroundColor = "#000000"
 
     m.PosterOne = m.top.findNode("PosterOne")
     m.PosterOne.uri = "pkg:/images/logo.png"


### PR DESCRIPTION
If you pause a video and wait for the screensaver to kick in, the logo shows up an bounces around but the background isn't being set to black. This fixes that bug.
