### PR TITLE
Add support for AAC 5.1 audio

### DIFF
--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -8,7 +8,7 @@ function buildParams(params={} as Object) as string
     if type(field.value) = "String" or type(field.value) = "roString"
       item = field.key + "=" + req.escape(field.value.trim())
       'item = field.key + "=" + field.value.trim()
-    else if type(field.value) = "roInteger"
+    else if type(field.value) = "roInteger" or type(field.value) = "roInt"
       item = field.key + "=" + stri(field.value).trim()
       'item = field.key + "=" + str(field.value).trim()
     else if type(field.value) = "roFloat"


### PR DESCRIPTION
Media with aac 5.1 audio would play but with no audio. This PR fixes that by forcing aac 5.1 to stereo aac.

"Multichannel AAC is not supported on all Roku models. Roku TVs, Roku 4, and Roku Ultra set-top-boxes support multichannel decode to PCM stereo." - https://developer.roku.com/docs/specs/streaming.md#supported-audio-codecs

**Changes**
Check if device can decode audio codec/num channels before attempting to direct play
Force all 5.1 aac to stereo aac
