### PR TITLE
Ask user whether to start playback over or resume

### DIFF
--- a/components/JFMessageDialog.brs
+++ b/components/JFMessageDialog.brs
@@ -4,7 +4,7 @@ end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
   if key = "OK"
-    m.top.buttonSelected = 0
+    m.top.buttonSelected = m.top.buttonFocused
     handle_button()
     return true
   end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -19,7 +19,15 @@ function VideoContent(video) as object
   meta = ItemMetaData(video.id)
   video.content.title = meta.Name
   container = getContainerType(meta)
-  video.PlaySessionId = ItemGetSession(video.id)
+  
+  ' If there is a last playback positon, ask user if they want to resume
+  position = meta.json.UserData.PlaybackPositionTicks
+  if position > 0 and startPlaybackOver(position) then
+    position = 0
+  end if
+  video.content.BookmarkPosition = int(position/10000000)
+
+  video.PlaySessionId = ItemGetSession(video.id, position)
 
   if directPlaySupported(meta) then
     video.content.url = buildURL(Substitute("Videos/{0}/stream", video.id), {
@@ -49,6 +57,11 @@ function VideoContent(video) as object
   video.content.setCertificatesFile("common:/certs/ca-bundle.crt")
 
   return video
+end function
+
+'Opens dialog asking user if they want to resume video or start playback over
+function startPlayBackOver(time as LongInteger) as boolean
+  return option_dialog([ "Resume playing at " + ticksToHuman(time) + ".", "Start over from the begining." ])
 end function
 
 function directPlaySupported(meta as object) as boolean

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -22,10 +22,10 @@ function UserItemsResume(params = {} as object)
   return data
 end function
 
-function ItemGetSession(id as string)
+function ItemGetSession(id as string, StartTimeTicks = 0 as longinteger)
   params = {
     UserId: get_setting("active_user"),
-    StartTimeTicks: "0",
+    StartTimeTicks: StartTimeTicks,
     IsPlayback: "true",
     AutoOpenLiveStream: "true",
     MaxStreamingBitrate: "140000000"
@@ -34,7 +34,6 @@ function ItemGetSession(id as string)
   data = getJson(resp)
   return data.PlaySessionId
 end function
-
 
 ' List of available libraries
 function LibraryList()

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -13,6 +13,8 @@ function buildParams(params={} as Object) as string
       'item = field.key + "=" + str(field.value).trim()
     else if type(field.value) = "roFloat"
       item = field.key + "=" + stri(int(field.value)).trim()
+    else if type(field.value) = "LongInteger"
+      item = field.key + "=" + field.value.toStr().trim()
     else if type(field.value) = "roArray"
       ' TODO handle array params
     else if type(field.value) = "roBoolean"

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -36,13 +36,25 @@ function leftPad(base as string, fill as string, length as integer) as string
   return base
 end function
 
+function ticksToHuman(ticks as longinteger) as string
+  totalSeconds = int(ticks / 10000000)
+  hours = stri(int(totalSeconds / 3600)).trim()
+  minutes = stri(int((totalSeconds - (val(hours)*3600))/60)).trim()
+  seconds = stri(totalSeconds - (val(hours)*3600) - (val(minutes)*60)).trim()
+  if val(hours) > 0 and val(minutes) < 10 then minutes = "0" + minutes
+  if val(seconds) < 10 then seconds = "0" + seconds
+  r=""
+  if val(hours) > 0 then r = stri(hours).trim() + ":"
+  r = r + minutes + ":" + seconds
+  return r
+end function
+
 function div_ceiling(a as integer, b as integer) as integer
   if a < b then return 1
   if int(a/b) = a/b then
     return a/b
   end if
   return a/b + 1
-
 end function
 
 function message_dialog(message = "" as string)
@@ -54,4 +66,17 @@ function message_dialog(message = "" as string)
 
   m.scene.dialog = dialog
   m.scene.dialog.setFocus(true)
+end function
+
+function option_dialog(options) as integer
+  dialog = CreateObject("roSGNode", "JFMessageDialog")
+  dialog.backExitsDialog = false
+  dialog.buttons = options
+  m.scene.dialog = dialog
+  m.scene.dialog.setFocus(true)
+  
+  while m.scene.dialog <> invalid
+  end while
+  
+  return dialog.buttonSelected
 end function


### PR DESCRIPTION
Checks data provided by the server if there is a saved playback tick. If it is saved, it will create a dialog asking the user if they would like to resume or start playback from the beginning. It defaults to resuming.

**Changes**
Adds support for longinteger to API requests.
Notifies server of playback start when creating session.

**Issues**