### PR TITLE
Check indexNumber exist for episode

### DIFF
--- a/components/tvshows/details-list.brs
+++ b/components/tvshows/details-list.brs
@@ -6,7 +6,12 @@ end sub
 function itemContentChanged() as void
   item = m.top.itemContent
   itemData = item.json
-  m.top.findNode("title").text = itemData.indexNumber.toStr() + ". " + item.title
+  if itemData.indexNumber <> invalid then
+    indexNumber = itemData.indexNumber.toStr() + ". "
+  else 
+    indexNumber = ""
+  end if
+    m.top.findNode("title").text = indexNumber + item.title
   m.top.findNode("poster").uri = item.posterURL
   m.top.findNode("overview").text = item.overview
 

--- a/components/tvshows/details-list.brs
+++ b/components/tvshows/details-list.brs
@@ -11,7 +11,7 @@ function itemContentChanged() as void
   else 
     indexNumber = ""
   end if
-    m.top.findNode("title").text = indexNumber + item.title
+  m.top.findNode("title").text = indexNumber + item.title
   m.top.findNode("poster").uri = item.posterURL
   m.top.findNode("overview").text = item.overview
 


### PR DESCRIPTION
Checks to make sure indexNumber exits before displaying it with the episode's title. Items that the server did not find metadata for will not have an indexNumber.