### PR TITLE
Create custom overhang

### DIFF
--- a/components/JFOverhang.brs
+++ b/components/JFOverhang.brs
@@ -1,10 +1,117 @@
 sub init()
-  m.top.title = "Jellyfin"
   m.top.id = "overhang"
-  m.top.logoUri = "pkg:/images/logo.png"
-  m.top.height = 115
-  m.top.logoBaselineOffset = 20
-  m.top.showOptions = true
+  ' set opacity
+  bgg = m.top.findNode("overlayBackgroundGroup")
+  bgg.opacity = 0.333
+  ' hide seperators till they're needed
+  leftSeperator = m.top.findNode("overlayLeftSeperator")
+  leftSeperator.visible = "false"
+  rightSeperator = m.top.findNode("overlayRightSeperator")
+  rightSeperator.visible = "false"
+  ' set font sizes
+  optionText = m.top.findNode("overlayOptionsText")
+  optionText.font.size = 20
+  optionStar = m.top.findNode("overlayOptionsStar")
+  optionStar.font.size = 58
+  overlayMeridian = m.top.findNode("overlayMeridian")
+  overlayMeridian.font.size = 20
+  ' grab current time
+  currentTime = CreateObject("roDateTime")
+  currentTime.ToLocalTime()
+  m.currentHours = currentTime.GetHours()
+  m.currentMinutes = currentTime.GetMinutes()
+  ' start timer
+  m.currentTimeTimer = m.top.findNode("currentTimeTimer")
+  m.currentTimeTimer.control = "start"
+  m.currentTimeTimer.ObserveField("fire", "updateTime")
 
-  m.top.optionsAvailable = true
+  updateTimeDisplay()
 end sub
+
+
+function updateTitle()
+  leftSeperator = m.top.findNode("overlayLeftSeperator")
+  if m.top.title <> "" then
+    leftSeperator.visible = "true"
+  else
+    leftSeperator.visible = "false"
+  end if
+  title = m.top.findNode("overlayTitle")
+  title.text = m.top.title
+  resetTime()
+end function
+
+function updateUser()
+  rightSeperator = m.top.findNode("overlayRightSeperator")
+  if m.top.currentUser <> "" then
+    rightSeperator.visible = "true"
+  else
+    rightSeperator.visible = "false"
+  end if
+  user = m.top.findNode("overlayCurrentUser")
+  user.text = m.top.currentUser
+end function
+
+function updateTime()
+  if (m.currentMinutes + 1) > 59 then
+    m.currentHours = m.currentHours + 1
+    m.currentMinutes = 0
+  else
+    m.currentMinutes = m.currentMinutes + 1
+  end if
+
+  updateTimeDisplay()
+end function
+
+function resetTime()
+  m.currentTimeTimer.control = "stop"
+
+  currentTime = CreateObject("roDateTime")
+  m.currentTimeTimer.control = "start"
+
+  currentTime.ToLocalTime()
+
+  m.currentHours = currentTime.GetHours()
+  m.currentMinutes = currentTime.GetMinutes()
+
+  updateTimeDisplay()
+end function
+
+function updateTimeDisplay()
+  overlayHours = m.top.findNode("overlayHours")
+  overlayMinutes = m.top.findNode("overlayMinutes")
+  overlayMeridian = m.top.findNode("overlayMeridian")
+  if m.currentHours < 12 then
+    overlayMeridian.text = "AM"
+    if m.currentHours = 0 then
+      overlayHours.text = "12"
+    else
+      overlayHours.text = m.currentHours
+    end if
+  else
+    overlayMeridian.text = "PM"
+    if m.currentHours = 12 then
+      overlayHours.text = "12"
+    else
+      overlayHours.text = m.currentHours - 12
+    end if
+  end if
+
+  if m.currentMinutes < 10 then
+    overlayMinutes.text = "0" + StrI(m.currentMinutes).trim()
+  else
+    overlayMinutes.text = m.currentMinutes
+  end if
+end function
+
+function updateOptions()
+  optionText = m.top.findNode("overlayOptionsText")
+  optionStar = m.top.findNode("overlayOptionsStar")
+  if m.top.showOptions = true then
+    optionText.visible = true
+    optionStar.visible = true
+  else
+    optionText.visible = false
+    optionStar.visible = false
+  end if
+end function

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -1,4 +1,52 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<component name="JFOverhang" extends="Overhang">
+<component name="JFOverhang" extends="Group">
+  <children>
+    <LayoutGroup id="overlayBackgroundGroup" layoutDirection="horiz" translation="[0, 0]" >
+      <Rectangle
+        id="overlayBackground"
+        color="#000000"
+        width="1920"
+        height="96"
+        translation="[0,0]" />
+    </LayoutGroup>
+    <Poster id="overlayLogo"
+      uri="pkg:/images/logo.png"
+      translation="[0, 12]"
+      width="270" height="72" />
+    <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[275, 18]" itemSpacings="30" >
+      <Rectangle
+        id="overlayLeftSeperator"
+        color="#666666"
+        width="2"
+        height="64"/>
+      <Label id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" width="1150" />
+    </LayoutGroup>
+    <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" translation="[1770, 18]" horizAlignment="right" itemSpacings="30" >
+      <Label id="overlayCurrentUser" font="font:MediumSystemFont" width="300" horizAlign="right" vertAlign="center" height="64" />
+      <Rectangle
+        id="overlayRightSeperator"
+        color="#666666"
+        width="2"
+        height="64"/>
+    </LayoutGroup>
+    <LayoutGroup id="overlayTimeGroup" layoutDirection="horiz" translation="[1900, 18]" horizAlignment="right" itemSpacings="0" >
+      <Label id="overlayHours" font="font:MediumSystemFont" vertAlign="center" height="64" />
+      <Label font="font:MediumSystemFont" text=":" vertAlign="center" height="64" />
+      <Label id="overlayMinutes" font="font:MediumSystemFont" vertAlign="center" height="64" />
+      <Label id="overlayMeridian" font="font:SmallSystemFont" vertAlign="bottom" height="48" />
+    </LayoutGroup>
+    <Label id="overlayOptionsStar" font="font:LargeSystemFont" text="*" translation="[1791, 96]" />
+    <Label id="overlayOptionsText" font="font:SmallSystemFont" text="Options" translation="[1821, 103]" />
+    <Timer
+      id="currentTimeTimer"
+      repeat="true"
+      duration="60" />
+  </children>
+  <interface>
+    <field id="id" type="string" />
+    <field id="currentUser" type="string" onChange="updateUser" />
+    <field id="title" value="Jellyfin" type="string" onChange="updateTitle" />
+    <field id="showOptions" value="true" type="boolean" onChange="updateOptions" />
+  </interface>
   <script type="text/brightscript" uri="JFOverhang.brs" />
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -24,6 +24,7 @@ sub Main()
   ' Confirm the configured server and user work
   group = CreateLibraryGroup()
   m.overhang.title = group.overhangTitle
+  m.overhang.currentUser = m.user.Name
   m.scene.appendChild(group)
 
   m.scene.observeField("backPressed", m.port)


### PR DESCRIPTION
I couldn't find a way to customize the built in overhang the way I wanted so I made this. Mainly to decrease padding on either side(by logo and clock) and to display the currently logged in user.

I tried to make this "plug and play" so no other parts of the app would need to be rewritten.

**Changes**
JFOverhang is now a group node instead of an overhang node
Informing the user to press "* for options" has been added just below the overhang on the far right
The "clock" is just the current time with a 60 second timer to update minutes