### PR TITLE
Set overhang title early, use real library names

### DIFF
--- a/components/JFGroup.xml
+++ b/components/JFGroup.xml
@@ -3,7 +3,7 @@
   <interface>
     <field id="backPressed" type="boolean" alwaysNotify="true" />
     <field id="lastFocus" type="node" />
-    <field id="overhangTitle" value="Jellyfin" type="string" />
+    <field id="overhangTitle" type="string" />
   </interface>
   <script type="text/brightscript" uri="JFGroup.brs" />
 </component>

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -45,7 +45,7 @@
   <interface>
     <field id="id" type="string" />
     <field id="currentUser" type="string" onChange="updateUser" />
-    <field id="title" value="Jellyfin" type="string" onChange="updateTitle" />
+    <field id="title" type="string" onChange="updateTitle" />
     <field id="showOptions" value="true" type="boolean" onChange="updateOptions" />
   </interface>
   <script type="text/brightscript" uri="JFOverhang.brs" />

--- a/components/movies/details.brs
+++ b/components/movies/details.brs
@@ -1,9 +1,8 @@
 sub init()
-  m.top.overhangTitle = "Movie"
   main = m.top.findNode("main_group")
   dimensions = m.top.getScene().currentDesignResolution
 
-  main.translation=[50, 175]
+  main.translation = [50, 175]
 
   overview = m.top.findNode("overview")
   overview.width = dimensions.width - 100 - 400
@@ -104,7 +103,7 @@ end function
 sub setFavoriteColor()
   fave = m.top.itemContent.favorite
   fave_button = m.top.findNode("favorite-button")
-  if fave <> invalid And fave
+  if fave <> invalid and fave
     fave_button.textColor = "#00ff00ff"
     fave_button.focusedTextColor = "#269926ff"
   else

--- a/components/movies/scene.brs
+++ b/components/movies/scene.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.top.overhangTitle = "Movies"
+
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/tvshows/details.brs
+++ b/components/tvshows/details.brs
@@ -1,5 +1,4 @@
 sub init()
-  m.top.overhangTitle = "TV Show"
   main = m.top.findNode("toplevel")
   main.translation = [50, 175]
 end sub

--- a/components/tvshows/scene.brs
+++ b/components/tvshows/scene.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.top.overhangTitle = "TV Shows"
+
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -78,24 +78,27 @@ sub Main()
         group.setFocus(false)
         group.visible = false
 
+        m.overhang.title = node.name
         group = CreateMovieListGroup(node)
-        m.overhang.title = group.overhangTitle
+        group.overhangTitle = node.name
         m.scene.appendChild(group)
       else if node.type = "tvshows"
         group.lastFocus = group.focusedChild
         group.setFocus(false)
         group.visible = false
 
+        m.overhang.title = node.name
         group = CreateSeriesListGroup(node)
-        m.overhang.title = group.overhangTitle
+        group.overhangTitle = node.name
         m.scene.appendChild(group)
       else if node.type = "boxsets"
         group.lastFocus = group.focusedChild
         group.setFocus(false)
         group.visible = false
 
+        m.overhang.title = node.name
         group = CreateCollectionsList(node)
-        m.overhang.title = group.overhangTitle
+        group.overhangTitle = node.name
         m.scene.appendChild(group)
       else
         ' TODO - switch on more node types
@@ -108,8 +111,9 @@ sub Main()
       group.setFocus(false)
       group.visible = false
 
-      group = CreateMovieListGroup(node)
       m.overhang.title = node.title
+      group = CreateMovieListGroup(node)
+      group.overhangTitle = node.title
       m.scene.appendChild(group)
     else if isNodeEvent(msg, "movieSelected")
       ' If you select a movie from ANYWHERE, follow this flow
@@ -119,9 +123,10 @@ sub Main()
       group.setFocus(false)
       group.visible = false
 
+      m.overhang.title = node.title
       group = CreateMovieDetailsGroup(node)
+      group.overhangTitle = node.title
       m.scene.appendChild(group)
-      m.overhang.title = group.overhangTitle
     else if isNodeEvent(msg, "seriesSelected")
       ' If you select a TV Series from ANYWHERE, follow this flow
       node = getMsgPicker(msg, "picker")
@@ -130,9 +135,10 @@ sub Main()
       group.setFocus(false)
       group.visible = false
 
+      m.overhang.title = node.title
       group = CreateSeriesDetailsGroup(node)
+      group.overhangTitle = node.title
       m.scene.appendChild(group)
-      m.overhang.title = group.overhangTitle
     else if isNodeEvent(msg, "seasonSelected")
       ' If you select a TV Season from ANYWHERE, follow this flow
       ptr = msg.getData()
@@ -144,9 +150,9 @@ sub Main()
       group.setFocus(false)
       group.visible = false
 
+      m.overhang.title = series.overhangTitle + " - " + node.title
       group = CreateSeasonDetailsGroup(series.itemContent, node)
       m.scene.appendChild(group)
-      m.overhang.title = group.overhangTitle
     else if isNodeEvent(msg, "episodeSelected")
       ' If you select a TV Episode from ANYWHERE, follow this flow
       node = getMsgPicker(msg, "picker")


### PR DESCRIPTION
This updates the overhang title before loading a new screen(group node) for better UX when loading large libraries. Also uses the real library title instead of defaults.

**Changes**
Use the actual title of the library selected
Set overhang title before loading group node
Remove any default `overhangTitle`s set on init() ("Movie", "TV Show" etc.)
