### PR TITLE
Add subtitles with preferred language prioritized

### DIFF
--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -3,6 +3,7 @@
   <interface>
     <field id="backPressed" type="boolean" alwaysNotify="true" />
     <field id="PlaySessionId" type="string" />
+    <field id="Subtitles" type="array" />
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
   <children>

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -35,7 +35,8 @@ function VideoContent(video) as object
   if video.Subtitles.count() > 0 then
     if video.Subtitles[0].IsTextSubtitleStream then
       video.content.SubtitleTracks = video.Subtitles[0].track
-    else
+    else if getCaptionMode() = "On"
+      'Only transcode if subtitles are turned on
       params.append({"SubtitleStreamIndex" : video.Subtitles[0].index })
     end if
   end if
@@ -99,6 +100,11 @@ function getSubtitles(id as string, MediaStreams)
     end if
   end for
   return tracks
+end function
+
+function getCaptionMode() as string
+  devinfo = CreateObject("roDeviceInfo")
+  return devinfo.GetCaptionsMode()
 end function
 
 'Opens dialog asking user if they want to resume video or start playback over


### PR DESCRIPTION
Checks for all subtitle streams in the MediaStream and puts the device's preferred language as the top choice(s). If subtitles are not text, it will have the server transcode only if the device is set to closed captioning always. Text subtitles are sideloaded and work with CC on instant replay and CC with mute. Currently it only will play the first stream.

In testing only srt text subtitles seemed to work with sideloading (though Roku's documentation states other formats are supported). Requests the server to send all text subtitles in srt format.

**Changes**
Array created for sending URL parameters.
Subtitle data added to JFVideo.