### PR TITLE
Overhang fixes

### DIFF
--- a/components/JFGroup.xml
+++ b/components/JFGroup.xml
@@ -4,6 +4,7 @@
     <field id="backPressed" type="boolean" alwaysNotify="true" />
     <field id="lastFocus" type="node" />
     <field id="overhangTitle" type="string" />
+    <field id="optionsAvailable" value="true" type="boolean" />
   </interface>
   <script type="text/brightscript" uri="JFGroup.brs" />
 </component>

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -19,22 +19,23 @@
         color="#666666"
         width="2"
         height="64"/>
-      <Label id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" width="1150" />
+      <Label id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" width="1100" />
     </LayoutGroup>
-    <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" translation="[1770, 18]" horizAlignment="right" itemSpacings="30" >
+    <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="30" translation="[1900, 18]" horizAlignment="right" >
       <Label id="overlayCurrentUser" font="font:MediumSystemFont" width="300" horizAlign="right" vertAlign="center" height="64" />
       <Rectangle
         id="overlayRightSeperator"
         color="#666666"
         width="2"
         height="64"/>
+      <LayoutGroup id="overlayTimeGroup" layoutDirection="horiz" horizAlignment="right" itemSpacings="0" >
+        <Label id="overlayHours" font="font:MediumSystemFont" vertAlign="center" height="64" />
+        <Label font="font:MediumSystemFont" text=":" vertAlign="center" height="64" />
+        <Label id="overlayMinutes" font="font:MediumSystemFont" vertAlign="center" height="64" />
+        <Label id="overlayMeridian" font="font:SmallSystemFont" vertAlign="bottom" height="48" />
+      </LayoutGroup>
     </LayoutGroup>
-    <LayoutGroup id="overlayTimeGroup" layoutDirection="horiz" translation="[1900, 18]" horizAlignment="right" itemSpacings="0" >
-      <Label id="overlayHours" font="font:MediumSystemFont" vertAlign="center" height="64" />
-      <Label font="font:MediumSystemFont" text=":" vertAlign="center" height="64" />
-      <Label id="overlayMinutes" font="font:MediumSystemFont" vertAlign="center" height="64" />
-      <Label id="overlayMeridian" font="font:SmallSystemFont" vertAlign="bottom" height="48" />
-    </LayoutGroup>
+    
     <Label id="overlayOptionsStar" font="font:LargeSystemFont" text="*" translation="[1791, 96]" />
     <Label id="overlayOptionsText" font="font:SmallSystemFont" text="Options" translation="[1821, 103]" />
     <Timer

--- a/components/movies/details.brs
+++ b/components/movies/details.brs
@@ -1,4 +1,6 @@
 sub init()
+  m.top.optionsAvailable = false
+
   main = m.top.findNode("main_group")
   main.translation = [50, 175]
 

--- a/components/movies/details.brs
+++ b/components/movies/details.brs
@@ -1,11 +1,9 @@
 sub init()
   main = m.top.findNode("main_group")
-  dimensions = m.top.getScene().currentDesignResolution
-
   main.translation = [50, 175]
 
   overview = m.top.findNode("overview")
-  overview.width = dimensions.width - 100 - 400
+  overview.width = 1920 - 100 - 400
 
   m.top.findNode("buttons").setFocus(true)
 end sub

--- a/components/tvshows/details.brs
+++ b/components/tvshows/details.brs
@@ -1,4 +1,5 @@
 sub init()
+  m.top.optionsAvailable = false
   main = m.top.findNode("toplevel")
   main.translation = [50, 175]
 end sub

--- a/components/tvshows/episodes.brs
+++ b/components/tvshows/episodes.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.top.overhangTitle = "Season"
+  m.top.optionsAvailable = false
 end sub
 
 sub setSeason()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -52,6 +52,7 @@ sub Main()
       m.scene.removeChildIndex(n)
       group = m.scene.getChild(n - 1)
       m.overhang.title = group.overhangTitle
+      m.overhang.showOptions = group.optionsAvailable
       m.overhang.visible = true
       if group.lastFocus <> invalid
         group.lastFocus.setFocus(true)
@@ -124,6 +125,7 @@ sub Main()
       group.visible = false
 
       m.overhang.title = node.title
+      m.overhang.showOptions = false
       group = CreateMovieDetailsGroup(node)
       group.overhangTitle = node.title
       m.scene.appendChild(group)
@@ -136,6 +138,7 @@ sub Main()
       group.visible = false
 
       m.overhang.title = node.title
+      m.overhang.showOptions = false
       group = CreateSeriesDetailsGroup(node)
       group.overhangTitle = node.title
       m.scene.appendChild(group)
@@ -151,6 +154,7 @@ sub Main()
       group.visible = false
 
       m.overhang.title = series.overhangTitle + " - " + node.title
+      m.overhang.showOptions = false
       group = CreateSeasonDetailsGroup(series.itemContent, node)
       m.scene.appendChild(group)
     else if isNodeEvent(msg, "episodeSelected")


### PR DESCRIPTION
Fix padding between overlay time and separator. Hide overlay options text when there are no options available.

**Changes**
Rearrange overlay layout groups to make padding between separator and time dynamic
Add a field called `optionsAvailable` to `JFGroup` - defaults to true
Set overlay option text before loading new `JFGroup` for better UX
Set `optionsAvailable` to false on init() for `JFGroup` that don't have options available

