### PR TITLE
Fix to Home for epsidoes without indexes

### DIFF
--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -23,7 +23,17 @@ function itemContentChanged() as void
 
     if itemData.type = "Episode" then
       itemText.text = itemData.json.SeriesName
-      itemTextExtra.text = "S" + StrI(itemData.json.ParentIndexNumber).trim() + "E" + StrI(itemData.json.IndexNumber).trim() + " - " + itemData.name
+      extraPrefix = ""
+      if (itemData.json.IndexNumber <> Invalid) then
+        extraPrefix = "S" + StrI(itemData.json.ParentIndexNumber).trim()
+      end if
+      if (itemData.json.IndexNumber) <> invalid) then
+        extraPrefix = extraPrefix + "E" + StrI(itemData.json.IndexNumber).trim()
+      end if
+      if ( extraPrefix.len() > 0 ) then 
+        extraPrefix = extraPrefix + " - "
+      end if     
+      itemTextExtra.text = extraPrefix + itemData.name
     else if itemData.type = "Movie" then
       itemText.text = itemData.name
       itemTextExtra.text = StrI(itemData.json.ProductionYear).trim() + " - " + itemData.json.OfficialRating

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -24,7 +24,7 @@ function itemContentChanged() as void
     if itemData.type = "Episode" then
       itemText.text = itemData.json.SeriesName
       extraPrefix = ""
-      if (itemData.json.IndexNumber <> Invalid) then
+      if (itemData.json.ParentIndexNumber <> Invalid) then
         extraPrefix = "S" + StrI(itemData.json.ParentIndexNumber).trim()
       end if
       if (itemData.json.IndexNumber) <> invalid) then

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -27,7 +27,7 @@ function itemContentChanged() as void
       if (itemData.json.ParentIndexNumber <> Invalid) then
         extraPrefix = "S" + StrI(itemData.json.ParentIndexNumber).trim()
       end if
-      if (itemData.json.IndexNumber) <> invalid) then
+      if (itemData.json.IndexNumber <> invalid) then
         extraPrefix = extraPrefix + "E" + StrI(itemData.json.IndexNumber).trim()
       end if
       if ( extraPrefix.len() > 0 ) then 


### PR DESCRIPTION
Episodes without itemData.json.IndexNumber cause the home page to crash. Discovered with youtube content that I haven't bothered to have the server identify correctly to populate metadata.

I added a check for the season id to error on the side of caution.

**Changes**
Check to see if season and episode ids exist before adding them to itemTextExtra.

**Fixes**
I made a issue to put the log in. I am not sure if that was necessary. But this fixes #143.


