### PR TITLE
Integrate dialog changes with continue watching changes.

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -102,17 +102,19 @@ sub Main()
       else if node.type = "Episode" then
         ' play episode
         ' todo: create an episode page to link here
-        group.lastFocus = group.focusedChild
-        group.setFocus(false)
-        group.visible = false
         video_id = node.id
-
-        group = CreateVideoPlayerGroup(video_id)
-        m.scene.appendChild(group)
-        group.setFocus(true)
-        group.control = "play"
-        ReportPlayback(group, "start")
-        m.overhang.visible = false
+        video = CreateVideoPlayerGroup(video_id)
+        if video <> invalid then
+          group.lastFocus = group.focusedChild
+          group.setFocus(false)
+          group.visible = false
+          group = video
+          m.scene.appendChild(group)
+          group.setFocus(true)
+          group.control = "play"
+          ReportPlayback(group, "start")
+          m.overhang.visible = false
+        end if
       else if node.type = "Movie" then
         ' open movie detail page
         group.lastFocus = group.focusedChild

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -73,8 +73,10 @@ end function
 
 function lastFocusedChild(obj as object) as object
   child = obj
-  for i = 0  to obj.getChildCount() 
-    child = child.focusedChild
+  for i = 0 to obj.getChildCount()
+    if obj.focusedChild <> invalid then
+      child = child.focusedChild
+    end if 
   end for 
   return child
 end function


### PR DESCRIPTION
Selecting episodes from the new continue watching changes conflicted with the dialog changes. Now dialog pops up asking to resume or start over with home in the background and allows the dialog to be exited to return to the home menu.

**Changes** 
Removed focus from home after dialog is closed.
Added check to make sure focusedChild exist.
