### PR TITLE
Stop observing options buton as needed

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -49,9 +49,17 @@ sub Main()
         return
       end if
       m.scene.removeChildIndex(n)
+      prevOptionsAvailable = group.optionsAvailable
       group = m.scene.getChild(n - 1)
       m.overhang.title = group.overhangTitle
       m.overhang.showOptions = group.optionsAvailable
+      if group.optionsAvailable <> prevOptionsAvailable then
+        if group.optionsAvailable = false then
+          m.scene.unobserveField("optionsPressed")
+        else
+          m.scene.observeField("optionsPressed", m.port)
+        end if
+      end if
       m.overhang.visible = true
       if group.lastFocus <> invalid
         group.lastFocus.setFocus(true)
@@ -123,6 +131,7 @@ sub Main()
 
         m.overhang.title = node.name
         m.overhang.showOptions = false
+        m.scene.unobserveField("optionsPressed")
         group = CreateMovieDetailsGroup(node)
         group.overhangTitle = node.name
         m.scene.appendChild(group)
@@ -151,6 +160,7 @@ sub Main()
 
       m.overhang.title = node.title
       m.overhang.showOptions = false
+      m.scene.unobserveField("optionsPressed")
       group = CreateMovieDetailsGroup(node)
       group.overhangTitle = node.title
       m.scene.appendChild(group)
@@ -164,6 +174,7 @@ sub Main()
 
       m.overhang.title = node.title
       m.overhang.showOptions = false
+      m.scene.unobserveField("optionsPressed")
       group = CreateSeriesDetailsGroup(node)
       group.overhangTitle = node.title
       m.scene.appendChild(group)
@@ -180,6 +191,7 @@ sub Main()
 
       m.overhang.title = series.overhangTitle + " - " + node.title
       m.overhang.showOptions = false
+      m.scene.unobserveField("optionsPressed")
       group = CreateSeasonDetailsGroup(series.itemContent, node)
       m.scene.appendChild(group)
     else if isNodeEvent(msg, "episodeSelected")


### PR DESCRIPTION
Pressing the options button on pages(groups) where `optionsAvailable = false` would cause the app to crash. This fixes that, causing the options button to do nothing as expected.

**Changes**
Stop observing `optionsPressed` as needed before entering a new screen(group) without options
On `backPressed`, save previous `group.optionsAvailable` and compare to current `group.optionsAvailable`. Start or stop observing `optionsPressed` as needed