### PR TITLE
Start/Stop transcoding for subtitles settings changes during playback.

### DIFF
--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -4,6 +4,14 @@
     <field id="backPressed" type="boolean" alwaysNotify="true" />
     <field id="PlaySessionId" type="string" />
     <field id="Subtitles" type="array" />
+    <field id="SelectedSubtitle" type="integer" />
+    <field id="captionMode" type="string" />
+    <field id="transcodeParams" type="associativearray" />
+    <field id="container" type="string" />
+    <field id="directPlaySupported" type="boolean" />
+    <field id="decodeAudioSupported" type="boolean" />
+    <field id="isTranscoded" type="boolean" />
+    <field id="systemOverlay" type="boolean" value="false" />
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
   <children>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -339,7 +339,6 @@ sub Main()
       end if
     else if type(msg) = "roDeviceInfoEvent" then
       event = msg.GetInfo()
-      print "roDeviceInfoEvent: " event
       if event.appFocused <> invalid then
         child = m.scene.focusedChild
         if child <> invalid and child.isSubType("JFVideo") then

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -28,6 +28,10 @@ sub Main()
 
   m.scene.observeField("backPressed", m.port)
   m.scene.observeField("optionsPressed", m.port)
+  m.scene.observeField("mutePressed", m.port)
+
+  m.device = CreateObject("roDeviceInfo")
+  m.device.SetMessagePort(m.port)
 
   ' This is the core logic loop. Mostly for transitioning between scenes
   ' This now only references m. fields so could be placed anywhere, in theory
@@ -332,6 +336,28 @@ sub Main()
         node.backPressed = "true"
       else if node.state = "playing" or node.state = "paused" then
         ReportPlayback(group, "update")
+      end if
+    else if type(msg) = "roDeviceInfoEvent" then
+      event = msg.GetInfo()
+      print "roDeviceInfoEvent: " event
+      if event.appFocused <> invalid then
+        child = m.scene.focusedChild
+        if child <> invalid and child.isSubType("JFVideo") then
+          child.systemOverlay = not event.appFocused
+          if event.AppFocused = true then
+            systemOverlayClosed()
+          end if
+        end if
+      else if event.Mute <> invalid then
+        m.mute = event.Mute
+        child = m.scene.focusedChild
+        if child <> invalid and child.isSubType("JFVideo") and child.systemOverlay = false then
+        'Event will be called on caption change which includes the current mute status, but we do not want to call until the overlay is closed
+          reviewSubtitleDisplay()
+        end if
+      else
+        print "Unhandled roDeviceInfoEvent:"
+        print msg.GetInfo()
       end if
     else
       print type(msg)

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -62,7 +62,7 @@ function VideoContent(video) as object
   video.decodeAudioSupported = decodeAudioSupported(meta)
   video.transcodeParams = transcodeParams
 
-  if directPlaySupported(meta) and decodeAudioSupported(meta) and transcodeParams.SubtitleStreamIndex = invalid then
+  if video.directPlaySupported and video.decodeAudioSupported and transcodeParams.SubtitleStreamIndex = invalid then
     params.append({
       "Static": "true",
       "Container": container

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -81,7 +81,6 @@ function VideoContent(video) as object
   ' todo - audioFormat is read only
   video.content.audioFormat = getAudioFormat(meta)
   video.content.setCertificatesFile("common:/certs/ca-bundle.crt")
-  print "video url: " video.content.url
   return video
 end function
 

--- a/source/api/Playstate.brs
+++ b/source/api/Playstate.brs
@@ -39,3 +39,11 @@ function PlaystateDefaults(id="" as string, params={} as object)
   end for
   return buildParams(new_params)
 end function
+
+function deleteTranscode(id)
+  devinfo = CreateObject("roDeviceInfo")
+  device_id = devinfo.getChannelClientID()
+  req = APIRequest("/Videos/ActiveEncodings", { "deviceID" : devinfo.getChannelClientID(),  "PlaySessionId": id })
+  req.setRequest("DELETE")
+  postVoid(req)
+end function

--- a/source/utils/TranscodeSubtitles.brs
+++ b/source/utils/TranscodeSubtitles.brs
@@ -1,0 +1,88 @@
+function systemOverlayClosed()
+  video = m.scene.focusedChild
+  if video.globalCaptionMode <> video.captionMode then
+    video.captionMode = video.globalCaptionMode
+    reviewSubtitleDisplay()
+  end if
+end function
+
+function reviewSubtitleDisplay()
+  'TODO handle changing subtitles tracks during playback
+  displayed = areSubtitlesDisplayed()
+  needed = areSubtitlesNeeded()
+  print "displayed: " displayed " needed: " needed
+  if areSubtitlesNeeded() and (not areSubtitlesDisplayed()) then 
+    rebuildURL(true)
+  else if areSubtitlesDisplayed() and (not areSubtitlesNeeded()) then
+    rebuildURL(false)
+  end if
+end function
+
+function areSubtitlesDisplayed()
+  index = m.scene.focusedChild.transcodeParams.lookup("SubtitleStreamIndex")
+  if index <> invalid and index <> -1 then
+    return true
+  else 
+    return false
+  end if
+ end function
+
+function areSubtitlesNeeded() 
+  captions = m.scene.focusedChild.globalCaptionMode
+  if captions = "On"
+    return true
+  else if captions = "Off"
+    return false
+  else if captions = "When mute"
+    return m.mute
+  else if captions = "Instant replay"
+    'Unsupported. Do we want to do this? Is it worth transcoding for rewinded content and then untranscoding?
+    return false
+  end if
+end function
+
+sub rebuildURL(captions as boolean)
+  playBackBuffer = -5
+
+  video = m.scene.focusedChild
+  video.control = "pause"
+
+  tmpParams = video.transcodeParams
+  if captions = false then
+    tmpParams.delete("SubtitleStreamIndex")
+     tmpParams.delete("SubtitleStreamIndex")
+  else
+    if video.Subtitles[video.SelectedSubtitle] <> invalid then
+      tmpParams.addreplace("SubtitleStreamIndex", int(video.Subtitles[video.SelectedSubtitle].Index))
+    end if
+  end if
+
+  if video.isTranscoded then
+    deleteTranscode(video.PlaySessionId)
+  end if
+  tmpParams.PlaySessionId  = video.PlaySessionId = ItemGetSession(video.id, int(video.position) + playBackBuffer)
+  video.transcodeParams = tmpParams
+
+  if video.directPlaySupported and video.decodeAudioSupported and not captions then
+    'Captions are off and we do not need to transcode video or audo
+    base = Substitute("Videos/{0}/stream", video.id)
+    params = {
+      "Static": "true",
+      "Container": video.container
+      "PlaySessionId": video.PlaySessionId
+    }
+    video.isTranscoded = false
+    video.content.streamformat = video.container
+  else
+    'Captions are on or we need to transcode for any other reason
+    video.content.streamformat = "hls"
+    base = Substitute("Videos/{0}/master.m3u8", video.id)
+    video.isTranscoded = true
+    params = video.transcodeParams
+  end if
+
+  video.content.url = buildURL(base, params)
+  print "video url: " video.content.url
+  video.content.BookmarkPosition = int(video.position + playBackBuffer)
+  video.control = "play"
+end sub

--- a/source/utils/TranscodeSubtitles.brs
+++ b/source/utils/TranscodeSubtitles.brs
@@ -82,7 +82,6 @@ sub rebuildURL(captions as boolean)
   end if
 
   video.content.url = buildURL(base, params)
-  print "video url: " video.content.url
   video.content.BookmarkPosition = int(video.position + playBackBuffer)
   video.control = "play"
 end sub


### PR DESCRIPTION
When the system's caption settings change or if the system is muted (if when muted is the setting), the transcode settings for subtitles will be changed and the stream will be reset if necessary.

The first time the program opens, an roDeviceInfoEvent should fire with the current mute setting. This was the only reliable way I found to get the mute setting if the button is not pressed while the program is open. I don't think the on mute option will work set top boxes but I do not have one for testing.

The overlay is tracked because if just the glboalCaptionMode is used to fire an event, it will fire each time the options are scrolled through. Currently, playback should only be changed if the setting requires a change to subtitle transcoding. A change from always on to when mute while the system is muted should not change the stream. 

**Changes**
Added device stored to main thread.
Added event for muting system
System overlay status is observed during video playback