### PR TITLE
Update make script for curl 7.69

### DIFF
--- a/app.mk
+++ b/app.mk
@@ -59,9 +59,9 @@ endif
 HTTPSTATUS = $(shell curl --silent --write-out "\n%{http_code}\n" $(ROKU_DEV_TARGET))
 
 ifeq "$(HTTPSTATUS)" " 401"
-	CURLCMD = curl -S --connect-timeout 2 --max-time 30 --retry 5
+	CURLCMD = curl -S --tcp-fastopen --connect-timeout 2 --max-time 30 --retry 5
 else
-	CURLCMD = curl -S --connect-timeout 2 --max-time 30 --retry 5 --user $(USERPASS) --digest
+	CURLCMD = curl -S --tcp-fastopen --connect-timeout 2 --max-time 30 --retry 5 --user $(USERPASS) --digest
 endif
 
 home:


### PR DESCRIPTION
I was getting an issue when building and installing. The build would complete and when sending the zip file to the device, the curl command would reach the 30 second timeout.  After the timeout, it would immediately succeed in sending to the device.

It appears curl has changed some functionality with version 7.69 and the authorization isn't being handled correctly on the first request. Adding the tcp-fastopen flag allows the build to be sent the first time without waiting for the timeout to send a second time.

