### PR TITLE
Fix to exiting playback and changing subtitle settings

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -45,7 +45,6 @@ sub Main()
     else if isNodeEvent(msg, "backPressed")
       n = m.scene.getChildCount() - 1
       if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
-        print "backPressed on video"
         stopPlayback()
       else
         if n = 1 then return

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -43,34 +43,15 @@ sub Main()
       print "CLOSING SCREEN"
       return
     else if isNodeEvent(msg, "backPressed")
-      if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
-        stopPlayback()
-      end if
-      ' Pop a group off the stack and expose what's below
       n = m.scene.getChildCount() - 1
-      if n = 1
-        ' Overhang + last scene... this is the end
-        return
-      end if
-      m.scene.removeChildIndex(n)
-      prevOptionsAvailable = group.optionsAvailable
-      group = m.scene.getChild(n - 1)
-      m.overhang.title = group.overhangTitle
-      m.overhang.showOptions = group.optionsAvailable
-      if group.optionsAvailable <> prevOptionsAvailable then
-        if group.optionsAvailable = false then
-          m.scene.unobserveField("optionsPressed")
-        else
-          m.scene.observeField("optionsPressed", m.port)
-        end if
-      end if
-      m.overhang.visible = true
-      if group.lastFocus <> invalid
-        group.lastFocus.setFocus(true)
+      if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
+        print "backPressed on video"
+        stopPlayback()
       else
-        group.setFocus(true)
+        if n = 1 then return
+        RemoveCurrentGroup()
       end if
-      group.visible = true
+      group = m.scene.getChild(n-1)
     else if isNodeEvent(msg, "optionsPressed")
       group.lastFocus = group.focusedChild
       panel = group.findNode("options")
@@ -340,15 +321,14 @@ sub Main()
     else if isNodeEvent(msg, "position")
       video = msg.getRoSGNode()
       if video.position >= video.duration then
-        video.control = "stop"
-        video.state = "finished"
+        stopPlayback()
       end if
     else if isNodeEvent(msg, "fire")
       ReportPlayback(group, "update")
     else if isNodeEvent(msg, "state")
       node = msg.getRoSGNode()
       if node.state = "finished" then
-        node.backPressed = "true"
+        stopPlayback()
       else if node.state = "playing" or node.state = "paused" then
         ReportPlayback(group, "update")
       end if
@@ -365,7 +345,7 @@ sub Main()
       else if event.Mute <> invalid then
         m.mute = event.Mute
         child = m.scene.focusedChild
-        if child <> invalid and child.isSubType("JFVideo") and child.systemOverlay = false then
+        if child <> invalid and child.isSubType("JFVideo") and areSubtitlesDisplayed() and child.systemOverlay = false then
         'Event will be called on caption change which includes the current mute status, but we do not want to call until the overlay is closed
           reviewSubtitleDisplay()
         end if
@@ -430,4 +410,30 @@ sub wipe_groups()
   while(m.scene.getChildCount() > 1)
     m.scene.removeChildIndex(1)
   end while
+end sub
+
+sub RemoveCurrentGroup()
+  ' Pop a group off the stack and expose what's below
+  n = m.scene.getChildCount() - 1
+  group = m.scene.focusedChild
+  m.scene.removeChildIndex(n)
+  prevOptionsAvailable = group.optionsAvailable
+  group = m.scene.getChild(n - 1)
+  m.overhang.title = group.overhangTitle
+  m.overhang.showOptions = group.optionsAvailable
+  if group.optionsAvailable <> prevOptionsAvailable then
+    if group.optionsAvailable = false then
+      m.scene.unobserveField("optionsPressed")
+    else
+      m.scene.observeField("optionsPressed", m.port)
+    end if
+  end if
+  m.overhang.visible = true
+  if group.lastFocus <> invalid
+    print "lastfocus" group.lastfocus
+    group.lastFocus.setFocus(true)
+  else
+    group.setFocus(true)
+  end if
+  group.visible = true
 end sub

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -190,10 +190,11 @@ end function
 
 function StopPlayback()
   video = m.scene.focusedchild
+  video.control = "stop"
   m.device.EnableAppFocusEvent(False)
   video.findNode("playbackTimer").control = "stop"
-  video.control = "stop"
   video.visible = "false"
   if video.status = "finished" then MarkItemWatched(video.id)
   ReportPlayback(video, "stop")
+  RemoveCurrentGroup()
 end function


### PR DESCRIPTION
Changed call to "backPressed" when transcoded video was beyond the duration of the video or the playstate became "finished" to a call to StopPlayback(). StopPlayback now calls a new subroutine to remove the current focused group and return the focus to the previous group.

Fix to text subtitles was made. systemOverlay would not be set and would remain false. Changes to caption options during playback would cause transcoding changes. Added check to see if subtitles need to be transcoded before changing stream on system changes.

**Changes**

Creates sub to remove focus from the current group.
Stop trancoding changes when caption mode is changed with text subtitles.