### PR TITLE
Fix typo in UserSelect : iItemContentChanged() => itemContentChanged()

### DIFF
--- a/components/login/UserSelect.brs
+++ b/components/login/UserSelect.brs
@@ -1,7 +1,7 @@
 sub init()
 end sub
 
-sub iItemContentChanged()
+sub itemContentChanged()
   m.top.findNode("UserRow").ItemContent = m.top.itemContent
   redraw()
 end sub


### PR DESCRIPTION
Typo in function name, preventing login.  

**Changes**
Removed duplicate _i_ from function name

