### PR TITLE
Fix user selection with no public users

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -393,11 +393,11 @@ function LoginFlow(startOver = false as boolean)
       end for
       userSelected = CreateUserSelectGroup(publicUsersNodes)
       m.scene.focusedChild.visible = false
-      if user = "backPressed" then
+      if userSelected = "backPressed" then
         return LoginFlow(true)
       else
         'Try to login without password. If the token is valid, we're done
-        get_token(user, "")
+        get_token(userSelected, "")
         if get_setting("active_user") <> invalid then
           m.user = AboutMe()
           return true

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -391,7 +391,7 @@ function LoginFlow(startOver = false as boolean)
         end if
         publicUsersNodes.push(user)
       end for
-      user = CreateUserSelectGroup(publicUsersNodes)
+      userSelected = CreateUserSelectGroup(publicUsersNodes)
       m.scene.focusedChild.visible = false
       if user = "backPressed" then
         return LoginFlow(true)
@@ -403,8 +403,10 @@ function LoginFlow(startOver = false as boolean)
           return true
         end if
       end if
+    else 
+      userSelected = ""
     end if
-    passwordEntry = CreateSigninGroup(user)
+    passwordEntry = CreateSigninGroup(userSelected)
     if passwordEntry = "backPressed" then
       m.scene.focusedChild.visible = false
       return LoginFlow(true)


### PR DESCRIPTION
If there were no publicly viewable users, the login script would crash 
**Changes**
Created userSelected variable to distinguish from user
Define userSelected when publicUsers.count() = 0

**Issues**
Fixes #167
