### PR TITLE
Sort subtitles and set initial display based on user preferences

### DIFF
--- a/components/JFMessageDialog.brs
+++ b/components/JFMessageDialog.brs
@@ -20,7 +20,6 @@ sub updateOptions()
     row.title = item
     m.top.findNode("content").appendChild(row)
   end for
-  m.top.findNode("optionList").numRows = m.top.options.count()
   redraw()
 end sub
 
@@ -35,6 +34,7 @@ sub redraw()
   border = 40
   itemSpacing = 40
   optionHeight = 60
+  maxRows = 9
 
   bg = m.top.findNode("dialogBackground")
   text = m.top.findNode("messageText")
@@ -56,6 +56,13 @@ sub redraw()
   options.translation = [ border * 2, textHeight + itemSpacing]
   options.itemSize = [ boxWidth - ( border * 4 ), optionHeight ]
   options.itemSpacing = "[0,20]"
+
+  options.numRows = m.top.options.count()
+  if options.numRows > maxRows then
+    options.numRows = maxRows
+    options.wrapDividerHeight = 0
+    options.vertFocusAnimationStyle= "fixedFocusWrap"
+  end if
 
   boxHeight = options.translation[1] + (options.itemSize[1]  * options.numRows ) + (options.itemSpacing[1] * (options.NumRows - 1)) + border
 

--- a/source/utils/TranscodeSubtitles.brs
+++ b/source/utils/TranscodeSubtitles.brs
@@ -12,13 +12,17 @@ function selectSubtitleTrackDialog(tracks, currentTrack = -1)
   iso6392 = getSubtitleLanguages()
   options = ["None"]
   for each item in tracks
+    forced = ""
+    default = ""
+    if item.IsForced then forced = " [Forced]"
+    if item.IsDefault then default = " - Default"
     if item.Track.Language <> invalid then
       language = iso6392.lookup(item.Track.Language)
       if language = invalid then language = item.Track.Language
     else 
       language = "Undefined"
     end if
-    options.push(language)
+    options.push(language + forced + default)
   end for
   return option_dialog(options, "Select a subtitle track", currentTrack + 1)
 end function

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -94,12 +94,8 @@ function show_dialog(message as string, options = [], defaultSelection = 0) as i
   end if
 
   dialog.visible = true
-  dialog.setFocus(true)
   m.scene.appendChild(dialog)
-
-  if defaultSelection > 0 then
-    dialog.findNode("optionList").jumpToItem = defaultSelection
-  end if
+  dialog.setFocus(true)
 
   port = CreateObject("roMessagePort")
   dialog.observeField("backPressed", port)


### PR DESCRIPTION
Use user's configuration from the server to sort the subtitles. If the user's configuration would not display subtitles, the track is set to "None". User can still change subtitles during playback.

Forced and default subtitles are now sorted to the top. Forced is given priority over default. If subtitle language preference is set, it is prioritized in each category.

The "Smart" setting for subtitles has been set very strict. Default settings for a user would have audio language as any and subtitle language as any. When audio language is set and subtitle language is set, it will display subtitles if the audio track's language is different and the subtitle track language matches. With default language settings but subtitle setting changed to "Smart", we would never display subtitles. Should we make this less strict?

**Changes**
Gets user's language preference from the server instead of Roku.
Limit options displayed on JFMesssageDialog to prevent displaying beyond screen.
Removed setting focus twice on message dialog's default option.
Added forced and default to subtitle track display names.

**Issues**
Fixes #171 #172