### PR TITLE
Display clock format in 12/24hr based on Roku Clock setting

### DIFF
--- a/components/JFOverhang.brs
+++ b/components/JFOverhang.brs
@@ -15,6 +15,9 @@ sub init()
   optionStar.font.size = 58
   overlayMeridian = m.top.findNode("overlayMeridian")
   overlayMeridian.font.size = 20
+  ' get system preference clock format (12/24hr)
+  di = CreateObject("roDeviceInfo")
+  m.clockFormat = di.GetClockFormat() 
   ' grab current time
   currentTime = CreateObject("roDateTime")
   currentTime.ToLocalTime()
@@ -81,19 +84,29 @@ function updateTimeDisplay()
   overlayHours = m.top.findNode("overlayHours")
   overlayMinutes = m.top.findNode("overlayMinutes")
   overlayMeridian = m.top.findNode("overlayMeridian")
-  if m.currentHours < 12 then
-    overlayMeridian.text = "AM"
-    if m.currentHours = 0 then
-      overlayHours.text = "12"
+  
+  if m.clockFormat = "24h" then
+    overlayMeridian.text = ""
+    if m.currentHours < 10 then
+      overlayHours.text = "0" + StrI(m.currentHours).trim()
     else
       overlayHours.text = m.currentHours
     end if
   else
-    overlayMeridian.text = "PM"
-    if m.currentHours = 12 then
-      overlayHours.text = "12"
+    if m.currentHours < 12 then
+      overlayMeridian.text = "AM"
+      if m.currentHours = 0 then
+        overlayHours.text = "12"
+      else
+        overlayHours.text = m.currentHours
+      end if
     else
-      overlayHours.text = m.currentHours - 12
+      overlayMeridian.text = "PM"
+      if m.currentHours = 12 then
+        overlayHours.text = "12"
+      else
+        overlayHours.text = m.currentHours - 12
+      end if
     end if
   end if
 

--- a/components/collections/CollectionDetail.brs
+++ b/components/collections/CollectionDetail.brs
@@ -76,20 +76,8 @@ function getEndTime() as string
   duration_s = int(itemData.RunTimeTicks / 10000000.0)
   date.fromSeconds(date.asSeconds() + duration_s)
   date.toLocalTime()
-  hours = date.getHours()
-  meridian = "AM"
-  if hours = 0
-    hours = 12
-    meridian = "AM"
-  else if hours = 12
-    hours = 12
-    meridian = "PM"
-  else if hours > 12
-    hours = hours - 12
-    meridian = "PM"
-  end if
 
-  return Substitute("{0}:{1} {2}", stri(hours).trim(), leftPad(stri(date.getMinutes()).trim(), "0", 2), meridian)
+  return formatTime(date)
 end function
 
 sub setFavoriteColor()

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -96,20 +96,8 @@ function getEndTime() as string
   duration_s = int(itemData.RunTimeTicks / 10000000.0)
   date.fromSeconds(date.asSeconds() + duration_s)
   date.toLocalTime()
-  hours = date.getHours()
-  meridian = "AM"
-  if hours = 0
-    hours = 12
-    meridian = "AM"
-  else if hours = 12
-    hours = 12
-    meridian = "PM"
-  else if hours > 12
-    hours = hours - 12
-    meridian = "PM"
-  end if
 
-  return Substitute("{0}:{1} {2}", stri(hours).trim(), leftPad(stri(date.getMinutes()).trim(), "0", 2), meridian)
+  return formatTime(date)
 end function
 
 sub setFavoriteColor()

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -41,22 +41,6 @@ function getEndTime() as string
   duration_s = int(itemData.RunTimeTicks / 10000000.0)
   date.fromSeconds(date.asSeconds() + duration_s)
   date.toLocalTime()
-  hours = date.getHours()
-  meridian = "AM"
-  if hours = 0
-    hours = 12
-    meridian = "AM"
-  else if hours = 12
-    hours = 12
-    meridian = "PM"
-  else if hours > 12
-    hours = hours - 12
-    meridian = "PM"
-  end if
-  minutes = stri(date.getMinutes()).trim()
-  if val(minutes) < 10
-    minutes= "0" + minutes
-  end if
 
-  return Substitute("{0}:{1} {2}", stri(hours).trim(), minutes, meridian)
+  return formatTime(date)
 end function

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -25,4 +25,5 @@
     <field id="itemContent" type="node" onChange="itemContentChanged"/>
   </interface>
   <script type="text/brightscript" uri="TVListDetails.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/tvshows/TVShowDescription.brs
+++ b/components/tvshows/TVShowDescription.brs
@@ -76,20 +76,8 @@ function getEndTime() as string
   duration_s = int(itemData.RunTimeTicks / 10000000.0)
   date.fromSeconds(date.asSeconds() + duration_s)
   date.toLocalTime()
-  hours = date.getHours()
-  meridian = "AM"
-  if hours = 0
-    hours = 12
-    meridian = "AM"
-  else if hours = 12
-    hours = 12
-    meridian = "PM"
-  else if hours > 12
-    hours = hours - 12
-    meridian = "PM"
-  end if
 
-  return Substitute("{0}:{1} {2}", stri(hours).trim(), stri(date.getMinutes()).trim(), meridian)
+  formatTime(date)
 end function
 
 function getHistory() as string

--- a/components/tvshows/TVShowDescription.xml
+++ b/components/tvshows/TVShowDescription.xml
@@ -26,4 +26,5 @@
     <field id="itemContent" type="node" onChange="itemContentChanged" />
   </interface>
   <script type="text/brightscript" uri="TVShowDescription.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/tvshows/TVShowDetails.brs
+++ b/components/tvshows/TVShowDetails.brs
@@ -79,20 +79,8 @@ function getEndTime() as string
   duration_s = int(itemData.RunTimeTicks / 10000000.0)
   date.fromSeconds(date.asSeconds() + duration_s)
   date.toLocalTime()
-  hours = date.getHours()
-  meridian = "AM"
-  if hours = 0
-    hours = 12
-    meridian = "AM"
-  else if hours = 12
-    hours = 12
-    meridian = "PM"
-  else if hours > 12
-    hours = hours - 12
-    meridian = "PM"
-  end if
 
-  return Substitute("{0}:{1} {2}", stri(hours).trim(), stri(date.getMinutes()).trim(), meridian)
+  formatTime(date)
 end function
 
 function getHistory() as string

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -41,6 +41,33 @@ function ticksToHuman(ticks as longinteger) as string
   return r
 end function
 
+' Format time as 12 or 24 hour format based on system clock setting
+function formatTime(time) as string
+  hours = time.getHours()
+  minHourDigits = 1
+  di = CreateObject("roDeviceInfo")
+  if di.GetClockFormat() = "12h" then
+    meridian = "AM"
+    if hours = 0
+      hours = 12
+      meridian = "AM"
+    else if hours = 12
+      hours = 12
+      meridian = "PM"
+    else if hours > 12
+      hours = hours - 12
+      meridian = "PM"
+    end if
+  else
+    ' For 24hr Clock, no meridian and pad hours to 2 digits
+    minHourDigits = 2
+    meridian = ""
+  end if
+
+  return Substitute("{0}:{1} {2}", leftPad(stri(hours).trim(), "0", minHourDigits), leftPad(stri(time.getMinutes()).trim(), "0", 2), meridian)
+
+end function
+
 function div_ceiling(a as integer, b as integer) as integer
   if a < b then return 1
   if int(a/b) = a/b then


### PR DESCRIPTION
Currently the time displayed in JellyFin is always 12 hour format with meridian.   Roku has a setting for whether the clock should be displayed in 12 or 24 hour format.  This should be respected in JellyFin 

**Changes**
Updated Overhang to use 12 or 24 hour format based on Roku Clock setting.   Also updated "End Time" of media to use same format.

Created a single time format function for end times, rather the replicating code in each component.