### PR TITLE
Ensure index number exists on Episode search results

### DIFF
--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -65,7 +65,7 @@ function itemContentChanged() as void
     m.poster = m.top.findNode("poster")
     itemData = m.top.itemContent
     m.title.text = itemData.title
-    if itemData.json.lookup("Type") = "Episode"
+    if itemData.json.lookup("Type") = "Episode" and itemData.json.IndexNumber <> invalid
         m.title.text = StrI(itemData.json.IndexNumber) + ". " + m.title.text
     end if
     m.poster.uri = itemData.posterUrl


### PR DESCRIPTION
When a `Episode` appears in the search results, the IndexNumber is prepended to the title.  If the IndexNumber is not set, the app crashes.

**Changes**
Check IndexNumber is valid before prepending to title

**Issues**
fixes #186
