### PR TITLE
Allowing transcoding to 5.1ch if appropriate output connected

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -106,6 +106,12 @@ function getTranscodeParameters(meta as object)
   else
     audioCodec = "aac"
     audioChannels = 2
+
+    ' If 5.1 Audio Output is connected then allow transcoding to 5.1
+    di = CreateObject("roDeviceInfo")
+    if di.GetAudioOutputChannel() = "5.1 surround" then
+      audioChannels = 6
+    end if
   end if
   return {
     "VideoCodec": "h264",

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -109,7 +109,7 @@ function getTranscodeParameters(meta as object)
 
     ' If 5.1 Audio Output is connected then allow transcoding to 5.1
     di = CreateObject("roDeviceInfo")
-    if di.GetAudioOutputChannel() = "5.1 surround" then
+    if di.GetAudioOutputChannel() = "5.1 surround" and di.CanDecodeAudio({ Codec: "aac", ChCnt: 6 }).result then
       audioChannels = 6
     end if
   end if


### PR DESCRIPTION
Allow media that requires transcoding to still provide 5.1 audio if the Roku unit currently has a 5.1 output source connected.

**Changes**
Changed max channels for the audio to be 6 if the DeviceInfo reports that a 5.1 audio output channel is selected.  Previously any time the audio was transcoded it was downmixed to 2 channel.

It does not sort the issue referenced, but was discovered when looking into it.

**Issues**
refs #189
