### PR TITLE
Disable options button and overhang text as needed

### DIFF
--- a/components/config/ConfigScene.brs
+++ b/components/config/ConfigScene.brs
@@ -1,5 +1,6 @@
 sub init()
     m.top.setFocus(true)
+    m.top.optionsAvailable = false
 end sub
 
 function onKeyEvent(key as String, press as Boolean) as Boolean

--- a/components/home/Home.brs
+++ b/components/home/Home.brs
@@ -1,5 +1,6 @@
 sub init()
 	m.top.overhangTitle = "Home"
+	m.top.optionsAvailable = true
 end sub
 
 function refresh()

--- a/components/login/UserSelect.brs
+++ b/components/login/UserSelect.brs
@@ -1,4 +1,5 @@
 sub init()
+  m.top.optionsAvailable = false
 end sub
 
 sub itemContentChanged()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -29,6 +29,7 @@ sub Main()
   ' load home page
   m.overhang.title = "Home"
   m.overhang.currentUser = m.user.Name
+  m.overhang.showOptions = true
   group = CreateHomeGroup()
   m.scene.appendChild(group)
 

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -28,6 +28,8 @@ function SignOut()
   end if
   unset_setting("active_user")
   m.overhang.currentUser = ""
+  m.overhang.showOptions = false
+  m.scene.unobserveField("optionsPressed")
 end function
 
 function AvailableUsers()


### PR DESCRIPTION
Disables options for screens that don't have any and prevents crashing. I think I got them all this time...

**Changes**
Disables options on:
config scene (server select and manual login)
sign out (change server)

