### PR TITLE
Improve readability of items on the TV Shows Grid

### DIFF
--- a/components/ItemGrid.brs
+++ b/components/ItemGrid.brs
@@ -12,12 +12,7 @@ end sub
 sub updateSize()
   m.top.numRows = 1
   if m.top.itemsPerRow = invalid or m.top.itemsPerRow = 0 then
-    m.top.itemsPerRow = 5
-  end if
-
-  ' Default this to two rows per page unless otherwise configured
-  if m.top.rowsPerPage = invalid or m.top.rowsPerPage < 1 then
-    m.top.rowsPerPage = 2
+    m.top.itemsPerRow = 6
   end if
 
   dimensions = m.top.getScene().currentDesignResolution
@@ -26,7 +21,7 @@ sub updateSize()
   topSpace = border + 105
   m.top.translation = [border, topSpace]
 
-  textHeight = 80
+  textHeight = 100
   itemWidth = (dimensions["width"] - border*2) / m.top.itemsPerRow -20
   itemHeight = itemWidth * 1.5 + textHeight
 

--- a/components/ItemGrid.brs
+++ b/components/ItemGrid.brs
@@ -15,15 +15,26 @@ sub updateSize()
     m.top.itemsPerRow = 5
   end if
 
+  ' Default this to two rows per page unless otherwise configured
+  if m.top.rowsPerPage = invalid or m.top.rowsPerPage < 1 then
+    m.top.rowsPerPage = 2
+  end if
+
   dimensions = m.top.getScene().currentDesignResolution
 
   border = 75
-  m.top.translation = [border, border + 115]
+  topSpace = border + 105
+  m.top.translation = [border, topSpace]
 
   textHeight = 80
-  itemWidth = (dimensions["width"] - border*2) / m.top.itemsPerRow
+  itemWidth = (dimensions["width"] - border*2) / m.top.itemsPerRow -20
   itemHeight = itemWidth * 1.5 + textHeight
 
+  if itemHeight*m.top.rowsPerPage > (dimensions["height"] - border - 115) then
+    ratio = (itemHeight*m.top.rowsPerPage) / (981 - topSpace - 15)
+    itemHeight = itemHeight / ratio
+    itemWidth = itemWidth / ratio
+  end if
   m.top.visible = true
 
   ' Size of the individual rows
@@ -34,7 +45,8 @@ sub updateSize()
   ' Size of items in the row
   m.top.rowItemSize = [ itemWidth, itemHeight ]
   ' Spacing between items in the row
-  m.top.rowItemSpacing = [ 0, 0 ]
+  itemSpace = (dimensions["width"] - border*2 - itemWidth*m.top.itemsPerRow) / (m.top.itemsPerRow-1)
+  m.top.rowItemSpacing = [ itemSpace-1, 0 ]
 end sub
 
 function setupRows()

--- a/components/ItemGrid.xml
+++ b/components/ItemGrid.xml
@@ -2,7 +2,7 @@
 <component name="ItemGrid" extends="RowList">
   <interface>
     <field id="itemsPerRow" type="int" />
-    <field id="rowsPerPage" type="int" />
+    <field id="rowsPerPage" type="int" value="2" />
     <field id="objects" type="associativearray" onChange="setupRows" />
     <field id="escapeButton" type="string" alwaysNotify="true" />
   </interface>

--- a/components/ItemGrid.xml
+++ b/components/ItemGrid.xml
@@ -2,6 +2,7 @@
 <component name="ItemGrid" extends="RowList">
   <interface>
     <field id="itemsPerRow" type="int" />
+    <field id="rowsPerPage" type="int" />
     <field id="objects" type="associativearray" onChange="setupRows" />
     <field id="escapeButton" type="string" alwaysNotify="true" />
   </interface>

--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -54,6 +54,7 @@ sub updateSize()
 
     m.poster.translation = [2, (posterVertSpace - m.poster.height) / 2]
 
+    m.backdrop.translation = [2, (posterVertSpace - m.poster.height) / 2]
     m.backdrop.width = m.poster.width
     m.backdrop.height = m.poster.height
 

--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -46,7 +46,7 @@ sub updateSize()
     m.poster.width = int(maxSize[0]) - 4
     m.poster.height = m.poster.width * ratio
 
-    posterVertSpace = int(maxSize[1]) - m.title.height
+    posterVertSpace = int(maxSize[1]) - m.title.height - 20
 
     if m.poster.height > posterVertSpace
       ' Do a thing to shrink the image if it is too tall

--- a/components/collections/Collections.xml
+++ b/components/collections/Collections.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="Collections" extends="JFGroup">
   <children>
-    <ItemGrid id="picker" visible="true" itemsPerRow="5" />
+    <ItemGrid id="picker" visible="true" itemsPerRow="6" />
     <OptionsSlider id="options" />
     <Rectangle translation="[0,981]" width="1920" height="100" color="#101010" />
   </children>

--- a/components/tvshows/TVShows.xml
+++ b/components/tvshows/TVShows.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="TVShows" extends="JFGroup">
   <children>
-    <ItemGrid id="picker" visible="true" itemsPerRow="10" />
+    <ItemGrid id="picker" visible="true" itemsPerRow="6" />
     <OptionsSlider id="options" />
     <Rectangle translation="[0,981]" width="1920" height="100" color="#101010" />
   </children>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -17,7 +17,7 @@ sub Main()
   m.overhang = CreateObject("roSGNode", "JFOverhang")
   m.scene.insertChild(m.overhang, 0)
   
-  m.page_size = 50
+  m.page_size = 48
 
   app_start:
   m.overhang.title = ""


### PR DESCRIPTION
This PR is to decrease the number of items on the TV series grid to increase the amount of available space for text. 

**Changes**
- Decreasing number of items from 10 to 6.
- Adding code to auto scale the spacing between items.
- Adding code to configure number of rows on screen.
- Adding translation to backdrop so that it aligns with everything else when artwork is missing.

**Issues**
Addresses issue #202 

**Additional Information**

Decided to stick with a standard label for now. Scrolling Label in theory should be better as it would allow us to see everything without ellipses. However the behaviour is such that the label only restarts its cycle every 3 seconds. Therefore there is a 3 second delay between when a user focuses on an item and when the scrolling starts. Further thought required on how to better present long series names.