### PR TITLE
Fix for crash when exiting a video

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -40,9 +40,9 @@ sub Main()
   input = CreateObject("roInput")
   input.SetMessagePort(m.port)
 
-  di = CreateObject("roDeviceInfo")
-  di.setMessagePort(m.port)
-  di.EnableScreensaverExitedEvent(true)
+  m.device = CreateObject("roDeviceInfo")
+  m.device.setMessagePort(m.port)
+  m.device.EnableScreensaverExitedEvent(true)
 
   ' This is the core logic loop. Mostly for transitioning between scenes
   ' This now only references m. fields so could be placed anywhere, in theory


### PR DESCRIPTION
Bug was caused by #180 removing [m.device from main.brs](https://github.com/jellyfin/jellyfin-roku/pull/180/files#diff-ef524df9fe9fab6e361a762e2440d0aeL35)


**Issues**
Fixes #203 
