### PR TITLE
Enable scrolling on Item Text on home screen

### DIFF
--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -2,7 +2,7 @@ sub itemContentChanged()
   itemData = m.top.itemContent
   if itemData = invalid then return
 
-  itemText = m.top.findNode("itemText")
+  m.itemText = m.top.findNode("itemText")
   itemPoster = m.top.findNode("itemPoster")
   itemTextExtra = m.top.findNode("itemTextExtra")
 
@@ -13,7 +13,7 @@ sub itemContentChanged()
   end if
 
   itemPoster.width = imageWidth
-  itemText.width = imageWidth
+  m.itemText.maxWidth = imageWidth
   itemTextExtra.width = imageWidth
 
   ' Whether to use WidePoster or Thumbnail in this row
@@ -23,7 +23,7 @@ sub itemContentChanged()
   ' Format the Data based on the type of Home Data
 
   if itemData.type = "CollectionFolder" OR itemData.type = "UserView" then
-    itemText.text = itemData.name
+    m.itemText.text = itemData.name
     itemPoster.uri = itemData.widePosterURL
     return
   end if
@@ -32,22 +32,22 @@ sub itemContentChanged()
     itemPoster.width = "96"
     itemPoster.height = "96"
     itemPoster.translation = "[192, 88]"
-    itemText.text = itemData.name
+    m.itemText.text = itemData.name
     itemPoster.uri = itemData.widePosterURL
     return
   end if
 
 
-  itemText.height = 34
-  itemText.font.size = 25
-  itemText.horizAlign = "left"
-  itemText.vertAlign = "bottom"
+  m.itemText.height = 34
+  m.itemText.font.size = 25
+  m.itemText.horizAlign = "left"
+  m.itemText.vertAlign = "bottom"
   itemTextExtra.visible = true
   itemTextExtra.font.size = 22
 
 
   if itemData.type = "Episode" then
-    itemText.text = itemData.json.SeriesName
+    m.itemText.text = itemData.json.SeriesName
 
     if usePoster = true then
       itemPoster.uri = itemData.widePosterURL
@@ -72,7 +72,7 @@ sub itemContentChanged()
   end if
 
   if itemData.type = "Movie" then
-    itemText.text = itemData.name
+    m.itemText.text = itemData.name
 
     if imageWidth = 180
       itemPoster.uri = itemData.posterURL
@@ -99,7 +99,7 @@ sub itemContentChanged()
 
   if itemData.type = "Series" then
 
-    itemText.text = itemData.name
+    m.itemText.text = itemData.name
 
     if usePoster = true then
       itemPoster.uri = itemData.widePosterURL
@@ -124,12 +124,24 @@ sub itemContentChanged()
   end if
 
   if itemData.type = "MusicAlbum" then
-    itemText.text = itemData.name
+    m.itemText.text = itemData.name
     itemTextExtra.text = itemData.json.AlbumArtist
     itemPoster.uri = itemData.posterURL
     return
   end if
 
   print "Unhandled Item Type: " + itemData.type
+
+end sub
+
+'
+' Enable title scrolling based on item Focus
+sub focusChanged()
+
+  if m.top.itemHasFocus = true then
+    m.itemText.repeatCount = -1
+  else
+    m.itemText.repeatCount = 0
+  end if
 
 end sub

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -4,7 +4,7 @@ sub itemContentChanged()
 
   m.itemText = m.top.findNode("itemText")
   itemPoster = m.top.findNode("itemPoster")
-  itemTextExtra = m.top.findNode("itemTextExtra")
+  m.itemTextExtra = m.top.findNode("itemTextExtra")
 
   ' Desired Image Width
   imageWidth = 464
@@ -14,7 +14,7 @@ sub itemContentChanged()
 
   itemPoster.width = imageWidth
   m.itemText.maxWidth = imageWidth
-  itemTextExtra.width = imageWidth
+  m.itemTextExtra.maxWidth = imageWidth
 
   ' Whether to use WidePoster or Thumbnail in this row
   usePoster = m.top.GetParent().content.usePoster
@@ -42,8 +42,8 @@ sub itemContentChanged()
   m.itemText.font.size = 25
   m.itemText.horizAlign = "left"
   m.itemText.vertAlign = "bottom"
-  itemTextExtra.visible = true
-  itemTextExtra.font.size = 22
+  m.itemTextExtra.visible = true
+  m.itemTextExtra.font.size = 22
 
 
   if itemData.type = "Episode" then
@@ -67,7 +67,7 @@ sub itemContentChanged()
       extraPrefix = extraPrefix + " - "
     end if
 
-    itemTextExtra.text = extraPrefix + itemData.name
+    m.itemTextExtra.text = extraPrefix + itemData.name
     return
   end if
 
@@ -92,7 +92,7 @@ sub itemContentChanged()
         textExtra = itemData.json.OfficialRating
       end if
     end if
-    itemTextExtra.text = textExtra
+    m.itemTextExtra.text = textExtra
 
     return
   end if
@@ -118,14 +118,14 @@ sub itemContentChanged()
     else if itemData.json.Status = "Ended" and itemData.json.EndDate <> invalid
       textExtra = textExtra + " - " + LEFT(itemData.json.EndDate, 4)
     end if
-    itemTextExtra.text = textExtra
+    m.itemTextExtra.text = textExtra
 
     return
   end if
 
   if itemData.type = "MusicAlbum" then
     m.itemText.text = itemData.name
-    itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = itemData.json.AlbumArtist
     itemPoster.uri = itemData.posterURL
     return
   end if
@@ -140,8 +140,10 @@ sub focusChanged()
 
   if m.top.itemHasFocus = true then
     m.itemText.repeatCount = -1
+    m.itemTextExtra.repeatCount = -1
   else
     m.itemText.repeatCount = 0
+    m.itemTextExtra.repeatCount = 0
   end if
 
 end sub

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -4,7 +4,7 @@ sub itemContentChanged()
 
   m.itemText = m.top.findNode("itemText")
   itemPoster = m.top.findNode("itemPoster")
-  m.itemTextExtra = m.top.findNode("itemTextExtra")
+  itemTextExtra = m.top.findNode("itemTextExtra")
 
   ' Desired Image Width
   imageWidth = 464
@@ -14,7 +14,7 @@ sub itemContentChanged()
 
   itemPoster.width = imageWidth
   m.itemText.maxWidth = imageWidth
-  m.itemTextExtra.maxWidth = imageWidth
+  itemTextExtra.width = imageWidth
 
   ' Whether to use WidePoster or Thumbnail in this row
   usePoster = m.top.GetParent().content.usePoster
@@ -42,8 +42,8 @@ sub itemContentChanged()
   m.itemText.font.size = 25
   m.itemText.horizAlign = "left"
   m.itemText.vertAlign = "bottom"
-  m.itemTextExtra.visible = true
-  m.itemTextExtra.font.size = 22
+  itemTextExtra.visible = true
+  itemTextExtra.font.size = 22
 
 
   if itemData.type = "Episode" then
@@ -67,7 +67,7 @@ sub itemContentChanged()
       extraPrefix = extraPrefix + " - "
     end if
 
-    m.itemTextExtra.text = extraPrefix + itemData.name
+    itemTextExtra.text = extraPrefix + itemData.name
     return
   end if
 
@@ -92,7 +92,7 @@ sub itemContentChanged()
         textExtra = itemData.json.OfficialRating
       end if
     end if
-    m.itemTextExtra.text = textExtra
+    itemTextExtra.text = textExtra
 
     return
   end if
@@ -118,14 +118,14 @@ sub itemContentChanged()
     else if itemData.json.Status = "Ended" and itemData.json.EndDate <> invalid
       textExtra = textExtra + " - " + LEFT(itemData.json.EndDate, 4)
     end if
-    m.itemTextExtra.text = textExtra
+    itemTextExtra.text = textExtra
 
     return
   end if
 
   if itemData.type = "MusicAlbum" then
     m.itemText.text = itemData.name
-    m.itemTextExtra.text = itemData.json.AlbumArtist
+    itemTextExtra.text = itemData.json.AlbumArtist
     itemPoster.uri = itemData.posterURL
     return
   end if
@@ -140,10 +140,8 @@ sub focusChanged()
 
   if m.top.itemHasFocus = true then
     m.itemText.repeatCount = -1
-    m.itemTextExtra.repeatCount = -1
   else
     m.itemText.repeatCount = 0
-    m.itemTextExtra.repeatCount = 0
   end if
 
 end sub

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="HomeItem" extends="Group">
   <children>
-    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" loadDisplayMode="scaleToZoom" />
+    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" />
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
     <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
   </children>

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -3,7 +3,7 @@
   <children>
     <Poster id="itemPoster" width="464" height="261" translation="[8,5]" />
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
-    <ScrollingLabel id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" maxWidth="456" translation="[8,300]" visible="false" repeatCount="0" color="#777777FF" />
+    <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged" />

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="HomeItem" extends="Group">
   <children>
-    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" />
-    <Label id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" width="456" translation="[8,267]" />
+    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" loadDisplayMode="scaleToZoom" />
+    <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
     <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged" />
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>
   <script type="text/brightscript" uri="HomeItem.brs" />
 </component>

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -3,7 +3,7 @@
   <children>
     <Poster id="itemPoster" width="464" height="261" translation="[8,5]" />
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
-    <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
+    <ScrollingLabel id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" maxWidth="456" translation="[8,300]" visible="false" repeatCount="0" color="#777777FF" />
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged" />


### PR DESCRIPTION
Make Item Titles scroll when too long to be displayed under the Poster

**Changes**
Changed from using Label to ScrollingLabel for item title.  When the focussed item on the Home Screen is too long to be displayed fully (and ellipses are used to truncate the text)  the scrolling is started.  When the item loses focus, the scrolling is stopped.

The delay after gaining focus appears to be set by Roku and is not configurable.