### PR TITLE
Bump version for release

### DIFF
--- a/manifest
+++ b/manifest
@@ -18,7 +18,7 @@ splash_min_time=1500
 
 ui_resolutions=fhd
 
-screensaver_private=0
+screensaver_private=1
 screensaver_title=Jellyfin
 
 supports_input_launch=1

--- a/manifest
+++ b/manifest
@@ -1,7 +1,7 @@
 ##   Channel Details
 title=Jellyfin
 major_version=1
-minor_version=1
+minor_version=2
 build_version=0
 
 ###  Main Menu Icons / Channel Poster Artwork


### PR DESCRIPTION
Also sets the screensaver to private in manifest. This was an oversight when I originally set up the screensaver

**Changes**
Set `screensaver_private=1` in manifest
Bump version to 1.2.0 for release

