### PR TITLE
Fix Collections for Movies, Episodes & Series

### DIFF
--- a/components/collections/CollectionDetail.xml
+++ b/components/collections/CollectionDetail.xml
@@ -1,36 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="CollectionDetail" extends="JFGroup">
   <children>
-    <LayoutGroup id="main_group" layoutDirection="horiz" >
-      <Poster id="poster"
-        translation="[250,150]"
-        width="400" height="600" />
-      <LayoutGroup layoutDirection="vert" translation="[355, 150]" itemSpacings="[25]">
-        <LayoutGroup layoutDirection="horiz" itemSpacings="[150]">
-          <Label id="releaseYear" />
-          <Label id="runtime" />
-          <Label id="officialRating" />
-          <Label id="communityRating" />
-          <Label id="ends-at" />
-        </LayoutGroup>
-        <Label id="genres" />
-        <Label id="director" />
-        <Label id="video_codec" />
-        <Label id="audio_codec" />
-        <ButtonGroupHoriz id="buttons" itemSpacings="[10]">
-          <Button text="Play" id="play-button" />
-          <Button text="Watched" id="watched-button" />
-          <Button text="Favorite" id="favorite-button" />
-        </ButtonGroupHoriz>
-        <Label id="tagline" />
-        <Label id="overview" />
-
-      </LayoutGroup>
-    </LayoutGroup>
+    <RowList id="rowList" />
   </children>
   <interface>
-    <field id="itemContent" type="node" onChange="itemContentChanged" />
+    <field id="collectionId" type="string" onChange="collectionIdChanged" />
+    <field id="selectedItem" type="node" alwaysNotify="true" />
+    <field id="objects" type="associativearray" onChange="setupRows" />
   </interface>
-  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="CollectionDetail.brs" />
 </component>

--- a/components/data/AlbumData.brs
+++ b/components/data/AlbumData.brs
@@ -1,0 +1,7 @@
+sub setFields()
+    datum = m.top.json
+
+    m.top.id = datum.id
+    m.top.title = datum.name
+end sub
+

--- a/components/data/AlbumData.xml
+++ b/components/data/AlbumData.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="AlbumData" extends="ContentNode">
+  <interface>
+    <field id="id" type="string" />
+    <field id="title" type="string" />
+    <field id="json" type="associativearray" onChange="setFields" />
+  </interface>
+  <script type="text/brightscript" uri="AlbumData.brs" />
+</component>

--- a/components/data/CollectionData.xml
+++ b/components/data/CollectionData.xml
@@ -9,6 +9,7 @@
     <field id="favorite" type="boolean" />
     <field id="watched" type="boolean" />
     <field id="type" type="string" value="boxsets" />
+    <field id="overview" type="string" value="boxsets" />
     <field id="json" type="associativearray" onChange="setFields" />
   </interface>
   <script type="text/brightscript" uri="CollectionData.brs" />

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -100,6 +100,33 @@ sub setData()
             m.top.thumbnailUrl = ImageURL(datum.id, "Backdrop", imgParams)
         end if
 
+    else if datum.type = "Video" then
+        imgParams = { AddPlayedIndicator: datum.UserData.Played }
+
+        if datum.UserData.PlayedPercentage <> invalid then
+            imgParams.Append({ "PercentPlayed": datum.UserData.PlayedPercentage })
+        end if
+
+        imgParams.Append({ "maxHeight": 261 })
+        imgParams.Append({ "maxWidth": 175 })
+
+        if datum.ImageTags.Primary <> invalid then
+            param = { "Tag" : datum.ImageTags.Primary }
+            imgParams.Append(param)
+        end if
+
+        m.top.posterURL = ImageURL(datum.id, "Primary", imgParams)
+
+        ' For wide image, use backdrop
+        imgParams["maxWidth"] = 464
+
+        if datum.ImageTags <> invalid and datum.imageTags.Thumb <> invalid then
+            imgParams["Tag"] = datum.imageTags.Thumb
+            m.top.thumbnailUrl = ImageURL(datum.Id, "Thumb", imgParams)
+        else if datum.BackdropImageTags[0] <> invalid then
+            imgParams["Tag"] = datum.BackdropImageTags[0]
+            m.top.thumbnailUrl = ImageURL(datum.id, "Backdrop", imgParams)
+        end if
     else if datum.type = "MusicAlbum" then
         params = { "Tag" : datum.ImageTags.Primary, "maxHeight" : 261, "maxWidth" : 261 }
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)

--- a/components/data/VideoData.brs
+++ b/components/data/VideoData.brs
@@ -1,0 +1,16 @@
+sub setFields()
+    datum = m.top.json
+
+    m.top.id = datum.id
+    m.top.title = datum.name
+
+end sub
+
+sub setPoster()
+  if m.top.image <> invalid
+    m.top.posterURL = m.top.image.url
+  else
+    m.top.posterURL = ""
+  end if
+
+end sub

--- a/components/data/VideoData.xml
+++ b/components/data/VideoData.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="VideoData" extends="ContentNode">
+  <interface>
+    <field id="id" type="string" />
+    <field id="title" type="string" />
+    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="image" type="node" onChange="setPoster" />
+    <field id="posterUrl" type="string" />
+  </interface>
+  <script type="text/brightscript" uri="VideoData.brs" />
+</component>

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -103,12 +103,26 @@ sub itemContentChanged()
     return
   end if
 
+  if itemData.type = "Video" then
+    m.itemText.text = itemData.name
+
+    if imageWidth = 180
+      itemPoster.uri = itemData.posterURL
+    else
+      itemPoster.uri = itemData.thumbnailURL
+    end if
+    return
+  end if
   if itemData.type = "Series" then
 
     m.itemText.text = itemData.name
 
     if usePoster = true then
-      itemPoster.uri = itemData.widePosterURL
+      if imageWidth = 180 then
+        itemPoster.uri = itemData.posterURL
+      else
+        itemPoster.uri = itemData.widePosterURL
+      end if
     else
       itemPoster.uri = itemData.thumbnailURL
     end if

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -2,7 +2,7 @@
 <component name="HomeItem" extends="Group">
   <children>
     <Rectangle id="backdrop" width="464" height="261" translation="[8,5]" />
-    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" />
+    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" loadDisplayMode="scaleToZoom" />
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
     <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
   </children>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -151,6 +151,21 @@ sub Main()
         group = CreateMovieDetailsGroup(selectedItem)
         group.overhangTitle = selectedItem.name
         m.scene.appendChild(group)
+      else if selectedItem.type = "Video" then
+        ' play episode
+        video_id = selectedItem.id
+        video = CreateVideoPlayerGroup(video_id)
+        if video <> invalid then
+          group.lastFocus = group.focusedChild
+          group.setFocus(false)
+          group.visible = false
+          group = video
+          m.scene.appendChild(group)
+          group.setFocus(true)
+          group.control = "play"
+          ReportPlayback(group, "start")
+          m.overhang.visible = false
+        end if
       else
         ' TODO - switch on more node types
         if selectedItem.type = "CollectionFolder" OR selectedItem.type = "UserView" then
@@ -168,7 +183,7 @@ sub Main()
       group.visible = false
 
       m.overhang.title = node.title
-      group = CreateMovieListGroup(node)
+      group = CreateCollectionDetailList(node.Id)
       group.overhangTitle = node.title
       m.scene.appendChild(group)
     else if isNodeEvent(msg, "movieSelected")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -293,7 +293,7 @@ function CreateSeasonDetailsGroup(series, season)
 end function
 
 function CreateCollectionsList(libraryId)
-  ' Load Movie Collection Items
+  ' Load Collection Items
   group = CreateObject("roSGNode", "Collections")
   group.id = libraryId
 
@@ -343,6 +343,27 @@ function CreateCollectionsList(libraryId)
 
   return group
 end function
+
+function CreateCollectionDetailList(collectionId)
+
+  sort_order = get_user_setting("movie_sort_order", "Ascending")
+  sort_field = get_user_setting("movie_sort_field", "SortName")
+
+  item_list = ItemList(collectionId, {
+    "SortBy": sort_field,
+    "SortOrder": sort_order
+  })
+
+  group = CreateObject("roSGNode", "CollectionDetail")
+  group.collectionId = collectionId
+  group.objects = item_list
+
+  group.observeField("selectedItem", m.port)
+
+  return group
+end function
+
+
 
 
 function CreateChannelList(libraryId)

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -130,6 +130,22 @@ function ItemList(library_id = invalid as string, params = {})
       tmp.image = PosterImage(item.id, imgParams)
       tmp.json = item
       results.push(tmp)
+    else if item.type = "Episode"
+      imgParams.Append({ "AddPlayedIndicator": item.UserData.Played })
+      tmp = CreateObject("roSGNode", "TVEpisodeData")
+      tmp.image = PosterImage(item.id, imgParams)
+      tmp.json = item
+      results.push(tmp)
+    else if item.type = "MusicAlbum"
+      tmp = CreateObject("roSGNode", "AlbumData")
+     tmp.image = PosterImage(item.id, imgParams)
+      tmp.json = item
+      results.push(tmp)
+    else if item.type = "Video"
+      tmp = CreateObject("roSGNode", "VideoData")
+      tmp.image = PosterImage(item.id, imgParams)
+      tmp.json = item
+      results.push(tmp)
     else
       print "Items.brs::ItemList received unhandled type: " item.type
       ' Otherwise we just stick with the JSON
@@ -174,6 +190,11 @@ function ItemMetaData(id as string)
     return tmp
   else if data.type = "Season"
     tmp = CreateObject("roSGNode", "TVSeasonData")
+    tmp.image = PosterImage(data.id)
+    tmp.json = data
+    return tmp
+  else if data.type = "Video"
+    tmp = CreateObject("roSGNode", "VideoData")
     tmp.image = PosterImage(data.id)
     tmp.json = data
     return tmp


### PR DESCRIPTION
Partial fix for collections.  Allows viewing of collections and playing of Movies, Videos, TV Episodes and Series.  Shows Albums but does not play them.

**Changes**
- Added Album and Video Data items to allow retrieval from server
- Reworked Collection Screen to show mixed media types in Row Lists
- Update Main loop to handle playing of Videos
- Updated Home Items Poster Display format to ScaleToZoom since Movies in collection are currently stored as Videos and only Thumbnails are available for them

**Issues**
Fixes #197, #154
