### PR TITLE
Enable title scrolling on ItemGrid

### DIFF
--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -32,9 +32,7 @@ sub updateSize()
     maxSize = m.top.getParent().itemSize
 
     ' Always reserve the bottom for the Poster Title
-    m.title.wrap = true
-    m.title.maxLines = 2
-    m.title.width = maxSize[0]
+    m.title.maxWidth = maxSize[0]
     m.title.height = 80
     m.title.translation = [0, int(maxSize[1]) - m.title.height]
 
@@ -72,3 +70,15 @@ function itemContentChanged() as void
 
     updateSize()
 end function
+
+'
+' Enable title scrolling based on item Focus
+sub focusChanged()
+
+  if m.top.itemHasFocus = true then
+    m.title.repeatCount = -1
+  else
+    m.title.repeatCount = 0
+  end if
+
+end sub

--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -1,21 +1,13 @@
 sub init()
     m.title = m.top.findNode("title")
-    m.title.translation = [2, 0]
-
+    m.staticTitle = m.top.findNode("staticTitle")
     m.poster = m.top.findNode("poster")
-    m.poster.translation = [2, 0]
-
     m.backdrop = m.top.findNode("backdrop")
-
     m.backdrop.color = "#404040FF"
-
     updateSize()
 end sub
 
 sub updateSize()
-    m.title = m.top.findNode("title")
-    m.poster = m.top.findNode("poster")
-    m.backdrop = m.top.findNode("backdrop")
 
     image = invalid
     if m.top.itemContent <> invalid and m.top.itemContent.image <> invalid
@@ -35,6 +27,10 @@ sub updateSize()
     m.title.maxWidth = maxSize[0]
     m.title.height = 80
     m.title.translation = [0, int(maxSize[1]) - m.title.height]
+
+    m.staticTitle.width = maxSize[0]
+    m.staticTitle.height = 80
+    m.staticTitle.translation = [0, int(maxSize[1]) - m.title.height]
 
     ratio = 1.5
     if image <> invalid and image.width <> 0 and image.height <> 0
@@ -58,14 +54,14 @@ sub updateSize()
 end sub
 
 function itemContentChanged() as void
-
-    m.title = m.top.findNode("title")
     m.poster = m.top.findNode("poster")
     itemData = m.top.itemContent
     m.title.text = itemData.title
     if itemData.json.lookup("Type") = "Episode" and itemData.json.IndexNumber <> invalid
         m.title.text = StrI(itemData.json.IndexNumber) + ". " + m.title.text
     end if
+    m.staticTitle.text = m.title.text
+
     m.poster.uri = itemData.posterUrl
 
     updateSize()
@@ -77,8 +73,13 @@ sub focusChanged()
 
   if m.top.itemHasFocus = true then
     m.title.repeatCount = -1
+    m.staticTitle.visible = false
+    m.title.visible = true
+
   else
     m.title.repeatCount = 0
+    m.staticTitle.visible = true
+    m.title.visible = false
   end if
 
 end sub

--- a/components/ListPoster.xml
+++ b/components/ListPoster.xml
@@ -3,14 +3,16 @@
   <children>
     <Rectangle id="backdrop" />
     <Poster id="poster" />
-    <Label id="title"
+    <ScrollingLabel id="title"
       horizAlign="center"
       font="font:SmallSystemFont"
+      repeatCount="0"
       />
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged"/>
     <field id="itemWidth" type="integer" />
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
     <!-- mediatype -->
   </interface>
 

--- a/components/ListPoster.xml
+++ b/components/ListPoster.xml
@@ -2,11 +2,17 @@
 <component name="ListPoster" extends="Group">
   <children>
     <Rectangle id="backdrop" />
-    <Poster id="poster" />
+    <Poster id="poster" translation="[2, 0]" />
     <ScrollingLabel id="title"
       horizAlign="center"
       font="font:SmallSystemFont"
       repeatCount="0"
+      visible="false"
+      />
+    <Label id="staticTitle"
+      horizAlign="center"
+      font="font:SmallSystemFont"
+      wrap="false"
       />
   </children>
   <interface>


### PR DESCRIPTION
**Changes**
Replace Label with Scrolling Label on ItemGrid, and enable scrolling when item has focus.  Affects TV Shows and Movies libraries

**Issues**
Fixes #196