### PR TITLE
Detect when content buffering hangs

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -9,12 +9,25 @@ end sub
 sub onState(msg) 
 
     ' When buffering, start timer to monitor buffering process
-    if m.top.state = "buffering" then
-    
+    if m.top.state = "buffering" and m.bufferCheckTimer <> invalid then
+
         ' start timer
         m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
         m.bufferCheckTimer.control = "start"
         m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
+    else if m.top.state = "error" then
+
+        ' If an error was encountered, Display dialog
+        dialog = createObject("roSGNode", "Dialog")
+        dialog.title = tr("Error During Playback")
+        dialog.buttons = [tr("OK")]
+        dialog.message = tr("An error was encountered while playing this item.")
+        dialog.observeField("buttonSelected", "dialogClosed")
+        m.top.getScene().dialog = dialog
+
+        ' Stop playback and exit player
+        m.top.control = "stop"
+        m.top.backPressed = true
     end if
 
 end sub

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -1,5 +1,66 @@
 sub init()
+    m.top.observeField("state", "onState")
+    m.bufferPercentage = 0  ' Track whether content is being loaded
 end sub
+
+
+'
+' When Video Player state changes
+sub onState(msg) 
+
+    ' When buffering, start timer to monitor buffering process
+    if m.top.state = "buffering" then
+    
+        ' start timer
+        m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
+        m.bufferCheckTimer.control = "start"
+        m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
+    end if
+
+end sub
+
+'
+' Check the the buffering has not hung
+sub bufferCheck(msg)
+
+    if m.top.state <> "buffering"
+        ' If video is not buffering, stop timer
+        m.bufferCheckTimer.control = "stop"
+        m.bufferCheckTimer.unobserveField("fire")
+        return
+    end if
+
+    if m.top.bufferingStatus <> invalid then
+
+        ' Check that the buffering percentage is increasing
+        if m.top.bufferingStatus["percentage"] > m.bufferPercentage then
+            m.bufferPercentage = m.top.bufferingStatus["percentage"]
+        else
+            ' If buffering has stopped Display dialog
+            dialog = createObject("roSGNode", "Dialog")
+            dialog.title = tr("Error Retrieving Content")
+            dialog.buttons = [tr("OK")]
+            dialog.message = tr("There was an error retrieving the data for this item from the server.")
+            dialog.observeField("buttonSelected", "dialogClosed")
+            m.top.getScene().dialog = dialog
+
+            ' Stop playback and exit player
+            m.top.control = "stop"
+            m.top.backPressed = true
+        end if
+    end if
+
+end sub
+
+'
+' Clean up on Dialog Closed
+sub dialogClosed(msg)
+    sourceNode = msg.getRoSGNode()
+    sourceNode.unobserveField("buttonSelected")
+    sourceNode.close = true
+end sub
+
+
 
 function onKeyEvent(key as string, press as boolean) as boolean
   if not press then return false

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -17,5 +17,6 @@
   <script type="text/brightscript" uri="JFVideo.brs" />
   <children>
     <timer id="playbackTimer" repeat="true" duration="30" />
+    <timer id="bufferCheckTimer" repeat="true" duration="10" />
   </children>
 </component>

--- a/locale/default/translations.ts
+++ b/locale/default/translations.ts
@@ -215,6 +215,30 @@
         </message>
 
         <message>
+            <source>Error Retrieving Content</source>
+            <translation>Error Retrieving Content</translation>
+            <extracomment>Dialog title when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
+            <source>Error During Playback</source>
+            <translation>Error During Playback</translation>
+            <extracomment>Dialog title when error occurs during playback</extracomment>
+        </message>
+    
+        <message>
+            <source>There was an error retrieving the data for this item from the server.</source>
+            <translation>There was an error retrieving the data for this item from the server.</translation>
+            <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
+            <source>An error was encountered while playing this item.</source>
+            <translation>An error was encountered while playing this item.</translation>
+            <extracomment>Dialog detail when error occurs during playback</extracomment>
+        </message>
+	
+        <message>
             <source>Loading Channel Data</source>
             <translation>Loading Channel Data</translation>
         </message>
@@ -228,6 +252,5 @@
             <source>Unable to load Channel Data from the server</source>
             <translation>Unable to load Channel Data from the server</translation>
         </message>
-
     </context>
 </TS>

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -215,6 +215,18 @@
         </message>
 
         <message>
+            <source>Error Retrieving Content</source>
+            <translation>Error Retrieving Content</translation>
+            <extracomment>Dialog title when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
+            <source>There was an error retrieving the data for this item from the server.</source>
+            <translation>There was an error retrieving the data for this item from the server.</translation>
+            <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
             <source>Loading Channel Data</source>
             <translation>Loading Channel Data</translation>
         </message>

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -221,9 +221,21 @@
         </message>
 
         <message>
+            <source>Error During Playback</source>
+            <translation>Error During Playback</translation>
+            <extracomment>Dialog title when error occurs during playback</extracomment>
+        </message>
+    
+        <message>
             <source>There was an error retrieving the data for this item from the server.</source>
             <translation>There was an error retrieving the data for this item from the server.</translation>
             <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
+            <source>An error was encountered while playing this item.</source>
+            <translation>An error was encountered while playing this item.</translation>
+            <extracomment>Dialog detail when error occurs during playback</extracomment>
         </message>
 
         <message>
@@ -240,6 +252,5 @@
             <source>Unable to load Channel Data from the server</source>
             <translation>Unable to load Channel Data from the server</translation>
         </message>
-
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -221,10 +221,23 @@
         </message>
 
         <message>
+            <source>Error During Playback</source>
+            <translation>Error During Playback</translation>
+            <extracomment>Dialog title when error occurs during playback</extracomment>
+        </message>
+    
+        <message>
             <source>There was an error retrieving the data for this item from the server.</source>
             <translation>There was an error retrieving the data for this item from the server.</translation>
             <extracomment>Dialog detail when unable to load Content from Server</extracomment>
         </message>
+
+        <message>
+            <source>An error was encountered while playing this item.</source>
+            <translation>An error was encountered while playing this item.</translation>
+            <extracomment>Dialog detail when error occurs during playback</extracomment>
+        </message>
+        
         <message>
             <source>Loading Channel Data</source>
             <translation>Loading Channel Data</translation>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -215,6 +215,17 @@
         </message>
 
         <message>
+            <source>Error Retrieving Content</source>
+            <translation>Error Retrieving Content</translation>
+            <extracomment>Dialog title when unable to load Content from Server</extracomment>
+        </message>
+
+        <message>
+            <source>There was an error retrieving the data for this item from the server.</source>
+            <translation>There was an error retrieving the data for this item from the server.</translation>
+            <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+        </message>
+        <message>
             <source>Loading Channel Data</source>
             <translation>Loading Channel Data</translation>
         </message>


### PR DESCRIPTION
Detect when Roku _hangs_ trying to download content from the server.

**Changes**
When buffering content from the server, start a timer that checks (every 10 seconds) that the Buffered Percentage has increased form the last check.  If there has been no increase, display a dialog to the user and return to the previous screen.

Once the video starts playing, disable timer.

**Issues**
Refs #189