### PR TITLE
Set Roku Safe zones for Overhang & Home

### DIFF
--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -6,14 +6,14 @@
         id="overlayBackground"
         color="#000000"
         width="1920"
-        height="96"
+        height="150"
         translation="[0,0]" />
     </LayoutGroup>
     <Poster id="overlayLogo"
       uri="pkg:/images/logo.png"
-      translation="[0, 12]"
+      translation="[96, 53]"
       width="270" height="72" />
-    <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[275, 18]" itemSpacings="30" >
+    <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[375, 53]" itemSpacings="30" >
       <Rectangle
         id="overlayLeftSeperator"
         color="#666666"
@@ -21,7 +21,7 @@
         height="64"/>
       <Label id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" width="1100" />
     </LayoutGroup>
-    <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="30" translation="[1900, 18]" horizAlignment="right" >
+    <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="30" translation="[1820, 53]" horizAlignment="right" >
       <Label id="overlayCurrentUser" font="font:MediumSystemFont" width="300" horizAlign="right" vertAlign="center" height="64" />
       <Rectangle
         id="overlayRightSeperator"
@@ -36,7 +36,7 @@
       </LayoutGroup>
     </LayoutGroup>
 
-    <LayoutGroup layoutDirection="horiz" horizAlignment="right" translation="[1900, 96]" vertAlignment="custom">
+    <LayoutGroup layoutDirection="horiz" horizAlignment="right" translation="[1820, 120]" vertAlignment="custom">
         <Label id="overlayOptionsStar" font="font:LargeSystemFont" text="*"   />
         <Label id="overlayOptionsText" font="font:SmallSystemFont" text="Options" translation="[0,6]" />
     </LayoutGroup>

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -6,7 +6,7 @@
         id="overlayBackground"
         color="#000000"
         width="1920"
-        height="150"
+        height="125"
         translation="[0,0]" />
     </LayoutGroup>
     <Poster id="overlayLogo"
@@ -36,7 +36,7 @@
       </LayoutGroup>
     </LayoutGroup>
 
-    <LayoutGroup layoutDirection="horiz" horizAlignment="right" translation="[1820, 120]" vertAlignment="custom">
+    <LayoutGroup layoutDirection="horiz" horizAlignment="right" translation="[1820, 125]" vertAlignment="custom">
         <Label id="overlayOptionsStar" font="font:LargeSystemFont" text="*"   />
         <Label id="overlayOptionsText" font="font:SmallSystemFont" text="Options" translation="[0,6]" />
     </LayoutGroup>

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -19,7 +19,7 @@
         color="#666666"
         width="2"
         height="64"/>
-      <Label id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" width="1100" />
+      <ScrollingLabel id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" maxWidth="1100" repeatCount="0" />
     </LayoutGroup>
     <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="30" translation="[1820, 53]" horizAlignment="right" >
       <Label id="overlayCurrentUser" font="font:MediumSystemFont" width="300" horizAlign="right" vertAlign="center" height="64" />

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -11,7 +11,7 @@
     </LayoutGroup>
     <Poster id="overlayLogo"
       uri="pkg:/images/logo.png"
-      translation="[96, 53]"
+      translation="[70, 53]"
       width="270" height="72" />
     <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[375, 53]" itemSpacings="30" >
       <Rectangle

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -36,8 +36,9 @@ sub updateSize()
   itemWidth = 480
   itemHeight = 330
 
-  m.top.rowCounterRightOffset = 80
-  m.top.itemSize = [1920 - 111 - 27, itemHeight]
+  'Set width of Rows to cut off at edge of Safe Zone
+  m.top.itemSize = [1703, itemHeight]
+
   ' spacing between rows
   m.top.itemSpacing = [0, 105]
 

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -31,11 +31,12 @@ end sub
 
 sub updateSize()
   sideborder = 100
-  m.top.translation = [111, 155]
+  m.top.translation = [111, 180]
 
   itemWidth = 480
   itemHeight = 330
 
+  m.top.rowCounterRightOffset = 80
   m.top.itemSize = [1920 - 111 - 27, itemHeight]
   ' spacing between rows
   m.top.itemSpacing = [0, 105]


### PR DESCRIPTION
Ensure that the Home screen observes Roku Safe Zones 

**Changes**
Updated Overhang to move titles and information away from the edge, observing the Safe Zones.

For the Row, moved the Item Count in from the edge of the screen.   Since the content is supposed to flow off the edge of the screen the Rows themselves are not affected

**Issues**
Refs #182 #74