### PR TITLE
Update Movies screen to match TV Shows

### DIFF
--- a/components/movies/Movies.xml
+++ b/components/movies/Movies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="Movies" extends="JFGroup">
   <children>
-    <ItemGrid id="picker" visible="true" itemsPerRow="10" />
+    <ItemGrid id="picker" visible="true" itemsPerRow="6" />
     <OptionsSlider id="options" />
     <Rectangle translation="[0,981]" width="1920" height="100" color="#101010" />
   </children>


### PR DESCRIPTION
Apply work done by @shauncampbell in PR #206 to the Movie Screen.

**Changes**
Set movie screen to show 6 items per row, keeping it in line with TV shows
