### PR TITLE
Ensure MaxAudioChannels is set to a string for updated API

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -146,7 +146,7 @@ function getTranscodeParameters(meta as object)
   return {
     "VideoCodec": "h264",
     "AudioCodec": audioCodec,
-    "MaxAudioChannels": audioChannels,
+    "MaxAudioChannels": StrI(audioChannels),    ' Currently Jellyfin server expects this as a string
     "MediaSourceId": meta.id,
     "SegmentContainer": "ts",
     "MinSegments": 1,

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -37,7 +37,7 @@ function getDeviceProfile() as object
                 "AudioCodec": "aac",
                 "Context": "Streaming",
                 "Protocol": "http",
-                "MaxAudioChannels": maxAudioChannels
+                "MaxAudioChannels": StrI(maxAudioChannels)    ' Currently Jellyfin server expects this as a string
             },
             {
                 "Container": "mp3",
@@ -45,7 +45,7 @@ function getDeviceProfile() as object
                 "AudioCodec": "mp3",
                 "Context": "Streaming",
                 "Protocol": "http",
-                "MaxAudioChannels": 2
+                "MaxAudioChannels": "2"
             },
             {
                 "Container": "mp3",
@@ -53,7 +53,7 @@ function getDeviceProfile() as object
                 "AudioCodec": "mp3",
                 "Context": "Static",
                 "Protocol": "http",
-                "MaxAudioChannels": 2
+                "MaxAudioChannels": "2"
             },
             {
                 "Container": "aac",
@@ -61,7 +61,7 @@ function getDeviceProfile() as object
                 "AudioCodec": "aac",
                 "Context": "Static",
                 "Protocol": "http",
-                "MaxAudioChannels": maxAudioChannels
+                "MaxAudioChannels": StrI(maxAudioChannels)    ' Currently Jellyfin server expects this as a string
             },
             {
                 "Container": "ts",
@@ -70,7 +70,7 @@ function getDeviceProfile() as object
                 "VideoCodec": "h264",
                 "Context": "Streaming",
                 "Protocol": "hls",
-                "MaxAudioChannels": maxAudioChannels,
+                "MaxAudioChannels": StrI(maxAudioChannels)    ' Currently Jellyfin server expects this as a string
                 "MinSegments": "1",
                 "BreakOnNonKeyFrames": true
             },


### PR DESCRIPTION
Updates to server api currently require `MaxAudioChannels` to be set to a string value rather than integer value we previously sent.  10.6 code base accepts either, so this won't break backwards compatibility.

**Changes**
- Always send `MaxAudioChannels` as a string
