### PR TITLE
Use best image, but fallback to secondary if it's empty

### DIFF
--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -85,7 +85,8 @@ sub itemContentChanged()
   if itemData.type = "Movie" then
     m.itemText.text = itemData.name
 
-    if imageWidth = 180
+    ' Use best image, but fallback to secondary if it's empty
+    if (imageWidth = 180 and itemData.posterURL <> "") or itemData.thumbnailURL = ""
       itemPoster.uri = itemData.posterURL
     else
       itemPoster.uri = itemData.thumbnailURL


### PR DESCRIPTION
Use the "Wide Poster" (Thumbnail/Backdrop) for movie tiles on the home screen if the primary poster image is not set.

The home screen will be re-worked later on, and will be changed to use the new JFContentItem base item, but this will resolve help in the meantime.

**Issues**
fixes #294
