### PR TITLE
Make TV show seasons and episode lists wrap the screen

### DIFF
--- a/components/tvshows/TVEpisodeRow.brs
+++ b/components/tvshows/TVEpisodeRow.brs
@@ -2,7 +2,7 @@ sub init()
   m.top.itemComponentName = "TVListDetails"
   m.top.content = setData()
 
-  m.top.rowFocusAnimationStyle = "floatingFocus"
+  m.top.vertFocusAnimationStyle = "fixedFocusWrap"
 
   m.top.showRowLabel = [false]
   

--- a/components/tvshows/TVSeasonRow.brs
+++ b/components/tvshows/TVSeasonRow.brs
@@ -2,8 +2,7 @@ sub init()
     m.top.itemComponentName = "ListPoster"
     m.top.content = getData()
 
-    m.top.rowFocusAnimationStyle = "floatingFocus"
-    'm.top.vertFocusAnimationStyle = "floatingFocus"
+    m.top.rowFocusAnimationStyle = "fixedFocusWrap"
 
     m.top.showRowLabel = [false]
     m.top.showRowCounter = [true]


### PR DESCRIPTION
This was annoying me too and it was only one line to fix

**Changes**
Made both of the RowList's `fixedFocusWrap` instead of `floatingFocus`

**Issues**
Fixes #304 
