### PR TITLE
Auto play the next TV episode

### DIFF
--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -13,6 +13,7 @@
     <field id="decodeAudioSupported" type="boolean" />
     <field id="isTranscoded" type="boolean" />
     <field id="systemOverlay" type="boolean" value="false" />
+    <field id="showID" type="string" />
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
   <children>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -62,6 +62,7 @@ sub Main()
       n = m.scene.getChildCount() - 1
       if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
         stopPlayback()
+        RemoveCurrentGroup()
       else
         if n = 1 then return
         RemoveCurrentGroup()
@@ -397,6 +398,12 @@ sub Main()
       video = msg.getRoSGNode()
       if video.position >= video.duration and not video.content.live then
         stopPlayback()
+        if video.showID = invalid then
+          RemoveCurrentGroup()
+        else
+          MarkItemWatched(video.id)
+          playNextEpisode(video.id, video.showID)
+        end if
       end if
     else if isNodeEvent(msg, "fire")
       ReportPlayback(group, "update")
@@ -404,6 +411,11 @@ sub Main()
       node = msg.getRoSGNode()
       if node.state = "finished" then
         stopPlayback()
+        if node.showID = invalid then
+          RemoveCurrentGroup()
+        else
+          playNextEpisode(node.id, node.showID)
+        end if
       else if node.state = "playing" or node.state = "paused" then
         ReportPlayback(group, "update")
       end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -21,6 +21,7 @@ function VideoContent(video, audio_stream_idx = 1) as object
 
   meta = ItemMetaData(video.id)
   video.content.title = meta.Name
+  video.showID = meta.showID
   
   ' If there is a last playback positon, ask user if they want to resume
   position = meta.json.UserData.PlaybackPositionTicks
@@ -310,13 +311,11 @@ end function
 
 function StopPlayback()
   video = m.scene.focusedchild
+  if video.state = "finished" then MarkItemWatched(video.id)
   video.control = "stop"
   m.device.EnableAppFocusEvent(False)
   video.findNode("playbackTimer").control = "stop"
-  video.visible = "false"
-  if video.status = "finished" then MarkItemWatched(video.id)
   ReportPlayback(video, "stop")
-  RemoveCurrentGroup()
 end function
 
 function displaySubtitlesByUserConfig(subtitleTrack, audioTrack)
@@ -335,5 +334,30 @@ function displaySubtitlesByUserConfig(subtitleTrack, audioTrack)
     return false
   else
     return false
+  end if
+end function
+
+function playNextEpisode(videoID as string, showID as string)
+  ' query API for next episode ID
+  url = Substitute("Shows/{0}/Episodes", showID)
+  urlParams = { "UserId": get_setting("active_user")}
+  urlParams.Append({ "StartItemId": videoID })
+  urlParams.Append({ "Limit": 2 })
+  resp = APIRequest(url, urlParams)
+  data = getJson(resp)
+  
+  if data <> invalid and data.Items.Count() = 2 then
+    ' remove finished video node
+    n = m.scene.getChildCount() - 1
+    m.scene.removeChildIndex(n)
+    ' setup new video node
+    nextVideo = CreateVideoPlayerGroup(data.Items[1].Id)
+    m.scene.appendChild(nextVideo)
+    nextVideo.setFocus(true)
+    nextVideo.control = "play"
+    ReportPlayback(nextVideo, "start")
+  else
+    ' can't play next episode
+    RemoveCurrentGroup()
   end if
 end function

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -20,7 +20,7 @@ function VideoContent(video, audio_stream_idx = 1) as object
   params = {}
 
   meta = ItemMetaData(video.id)
-  video.content.title = meta.Name
+  video.content.title = meta.title
   video.showID = meta.showID
   
   ' If there is a last playback positon, ask user if they want to resume


### PR DESCRIPTION
This auto plays the next available episode for all videos of type "Episode". Ideally this would be a client user setting but user settings still need a lot of work.

**Changes**
Add `showID` field to JFVideo
Small refactor to `StopPlayback()`
Create `playNextEpisode()` function to lookup and play the next available episode
Fix a typo that was preventing the video title from being passed to the video player

**Issues**
Fixes #160
