### PR TITLE
Send Playback Position as Number

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -296,7 +296,7 @@ end function
 function ReportPlayback(video, state = "update" as string)
   params = {
     "PlaySessionId": video.PlaySessionId,
-    "PositionTicks": str(int(video.position)) + "0000000",
+    "PositionTicks": int(video.position) * 10000000&,   'Ensure a LongInteger is used
     "IsPaused": (video.state = "paused"),
   }
   if video.content.live then


### PR DESCRIPTION
Currently sending Playback Position to the API as a string.  With the updated API in 10.7, the server is more picky about the data being sent, and the string we were sending contained a leading space.

**Changes**
* Updated Playback Position to be sent as a number rather than string.

