### PR TITLE
Hide blue background placeholder when Home Item Poster Loaded

### DIFF
--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -3,6 +3,7 @@ sub init()
   m.itemText = m.top.findNode("itemText")
   m.itemPoster = m.top.findNode("itemPoster")
   m.itemIcon = m.top.findNode("itemIcon")
+  m.itemTextExtra = m.top.findNode("itemTextExtra")
   m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
 
   ' Randomize the background colors
@@ -18,11 +19,12 @@ sub itemContentChanged()
   if itemData = invalid then return
   itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
   
-  itemTextExtra = m.top.findNode("itemTextExtra")
 
   m.itemPoster.width = itemData.imageWidth
   m.itemText.maxWidth = itemData.imageWidth
-  itemTextExtra.width = itemData.imageWidth
+  m.itemTextExtra.width = itemData.imageWidth
+  m.itemTextExtra.visible = true
+
 
   m.backdrop.width = itemData.imageWidth
 
@@ -51,8 +53,8 @@ sub itemContentChanged()
   m.itemText.font.size = 25
   m.itemText.horizAlign = "left"
   m.itemText.vertAlign = "bottom"
-  itemTextExtra.visible = true
-  itemTextExtra.font.size = 22
+  m.itemTextExtra.visible = true
+  m.itemTextExtra.font.size = 22
 
 
   if itemData.type = "Episode" then
@@ -76,7 +78,7 @@ sub itemContentChanged()
       extraPrefix = extraPrefix + " - "
     end if
 
-    itemTextExtra.text = extraPrefix + itemData.name
+    m.itemTextExtra.text = extraPrefix + itemData.name
     return
   end if
 
@@ -102,7 +104,7 @@ sub itemContentChanged()
         textExtra = itemData.json.OfficialRating
       end if
     end if
-    itemTextExtra.text = textExtra
+    m.itemTextExtra.text = textExtra
 
     return
   end if
@@ -142,14 +144,14 @@ sub itemContentChanged()
     else if itemData.json.Status = "Ended" and itemData.json.EndDate <> invalid
       textExtra = textExtra + " - " + LEFT(itemData.json.EndDate, 4)
     end if
-    itemTextExtra.text = textExtra
+    m.itemTextExtra.text = textExtra
 
     return
   end if
 
   if itemData.type = "MusicAlbum" then
     m.itemText.text = itemData.name
-    itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = itemData.json.AlbumArtist
     m.itemPoster.uri = itemData.posterURL
     return
   end if

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -30,12 +30,6 @@ sub itemContentChanged()
     m.itemIcon.uri = itemData.iconUrl
   end if
 
-  'If Poster not loaded, ensure "blue box" is shown until loaded
-  if m.itemPoster.loadStatus <> "ready" then
-    m.backdrop.visible = true
-    m.itemIcon.visible = true
-  end if
-
   ' Format the Data based on the type of Home Data
   if itemData.type = "CollectionFolder" OR itemData.type = "UserView"  OR itemData.type = "Channel" then
     m.itemText.text = itemData.name
@@ -178,8 +172,12 @@ end sub
 
 'Hide backdrop and icon when poster loaded
 sub onPosterLoadStatusChanged()
-  if m.itemPoster.loadStatus = "ready" then
+  if m.itemPoster.loadStatus = "ready" and m.itemPoster.uri <> ""  then
+    print m.itemText.text + " image ready - hiding blue"
     m.backdrop.visible = false
     m.itemIcon.visible = false
+  else
+    m.backdrop.visible = true
+    m.itemIcon.visible = true
   end if
 end sub

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -4,11 +4,13 @@ sub itemContentChanged()
   itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
   
   m.itemText = m.top.findNode("itemText")
-  itemPoster = m.top.findNode("itemPoster")
-  itemIcon = m.top.findNode("itemIcon")
+  m.itemPoster = m.top.findNode("itemPoster")
+  m.itemIcon = m.top.findNode("itemIcon")
   itemTextExtra = m.top.findNode("itemTextExtra")
 
-  itemPoster.width = itemData.imageWidth
+  m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
+
+  m.itemPoster.width = itemData.imageWidth
   m.itemText.maxWidth = itemData.imageWidth
   itemTextExtra.width = itemData.imageWidth
 
@@ -19,23 +21,28 @@ sub itemContentChanged()
   m.backdrop.width = itemData.imageWidth
 
   if itemData.iconUrl <> invalid
-    itemIcon.uri = itemData.iconUrl
+    m.itemIcon.uri = itemData.iconUrl
+  end if
+
+  'If Poster not loaded, ensure "blue box" is shown until loaded
+  if m.itemPoster.loadStatus <> "ready" then
+    m.backdrop.visible = true
+    m.itemIcon.visible = true
   end if
 
   ' Format the Data based on the type of Home Data
-
   if itemData.type = "CollectionFolder" OR itemData.type = "UserView"  OR itemData.type = "Channel" then
     m.itemText.text = itemData.name
-    itemPoster.uri = itemData.widePosterURL
+    m.itemPoster.uri = itemData.widePosterURL
     return
   end if
 
   if itemData.type = "UserView" then
-    itemPoster.width = "96"
-    itemPoster.height = "96"
-    itemPoster.translation = "[192, 88]"
+    m.itemPoster.width = "96"
+    m.itemPoster.height = "96"
+    m.itemPoster.translation = "[192, 88]"
     m.itemText.text = itemData.name
-    itemPoster.uri = itemData.widePosterURL
+    m.itemPoster.uri = itemData.widePosterURL
     return
   end if
 
@@ -52,9 +59,9 @@ sub itemContentChanged()
     m.itemText.text = itemData.json.SeriesName
 
     if itemData.usePoster = true then
-      itemPoster.uri = itemData.widePosterURL
+      m.itemPoster.uri = itemData.widePosterURL
     else
-      itemPoster.uri = itemData.thumbnailURL
+      m.itemPoster.uri = itemData.thumbnailURL
     end if
 
     ' Set Series and Episode Number for Extra Text
@@ -78,9 +85,9 @@ sub itemContentChanged()
 
     ' Use best image, but fallback to secondary if it's empty
     if (itemData.imageWidth = 180 and itemData.posterURL <> "") or itemData.thumbnailURL = ""
-      itemPoster.uri = itemData.posterURL
+      m.itemPoster.uri = itemData.posterURL
     else
-      itemPoster.uri = itemData.thumbnailURL
+      m.itemPoster.uri = itemData.thumbnailURL
     end if
 
     ' Set Release Year and Age Rating for Extra Text
@@ -104,9 +111,9 @@ sub itemContentChanged()
     m.itemText.text = itemData.name
 
     if itemData.imageWidth = 180
-      itemPoster.uri = itemData.posterURL
+      m.itemPoster.uri = itemData.posterURL
     else
-      itemPoster.uri = itemData.thumbnailURL
+      m.itemPoster.uri = itemData.thumbnailURL
     end if
     return
   end if
@@ -116,12 +123,12 @@ sub itemContentChanged()
 
     if itemData.usePoster = true then
       if itemData.imageWidth = 180 then
-        itemPoster.uri = itemData.posterURL
+        m.itemPoster.uri = itemData.posterURL
       else
-        itemPoster.uri = itemData.widePosterURL
+        m.itemPoster.uri = itemData.widePosterURL
       end if
     else
-      itemPoster.uri = itemData.thumbnailURL
+      m.itemPoster.uri = itemData.thumbnailURL
     end if
 
     textExtra = ""
@@ -143,7 +150,7 @@ sub itemContentChanged()
   if itemData.type = "MusicAlbum" then
     m.itemText.text = itemData.name
     itemTextExtra.text = itemData.json.AlbumArtist
-    itemPoster.uri = itemData.posterURL
+    m.itemPoster.uri = itemData.posterURL
     return
   end if
 
@@ -161,4 +168,12 @@ sub focusChanged()
     m.itemText.repeatCount = 0
   end if
 
+end sub
+
+'Hide backdrop and icon when poster loaded
+sub onPosterLoadStatusChanged()
+  if m.itemPoster.loadStatus = "ready" then
+    m.backdrop.visible = false
+    m.itemIcon.visible = false
+  end if
 end sub

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -173,7 +173,6 @@ end sub
 'Hide backdrop and icon when poster loaded
 sub onPosterLoadStatusChanged()
   if m.itemPoster.loadStatus = "ready" and m.itemPoster.uri <> ""  then
-    print m.itemText.text + " image ready - hiding blue"
     m.backdrop.visible = false
     m.itemIcon.visible = false
   else

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -1,23 +1,29 @@
-sub itemContentChanged()
-  itemData = m.top.itemContent
-  if itemData = invalid then return
-  itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
-  
+sub init()
+
   m.itemText = m.top.findNode("itemText")
   m.itemPoster = m.top.findNode("itemPoster")
   m.itemIcon = m.top.findNode("itemIcon")
-  itemTextExtra = m.top.findNode("itemTextExtra")
-
   m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
-
-  m.itemPoster.width = itemData.imageWidth
-  m.itemText.maxWidth = itemData.imageWidth
-  itemTextExtra.width = itemData.imageWidth
 
   ' Randomize the background colors
   m.backdrop = m.top.findNode("backdrop")
   posterBackgrounds = m.global.constants.poster_bg_pallet
   m.backdrop.color = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+
+end sub
+
+
+sub itemContentChanged()
+  itemData = m.top.itemContent
+  if itemData = invalid then return
+  itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
+  
+  itemTextExtra = m.top.findNode("itemTextExtra")
+
+  m.itemPoster.width = itemData.imageWidth
+  m.itemText.maxWidth = itemData.imageWidth
+  itemTextExtra.width = itemData.imageWidth
+
   m.backdrop.width = itemData.imageWidth
 
   if itemData.iconUrl <> invalid


### PR DESCRIPTION
Update HomeItem to automatically hide the placeholder blue box and icon when the Poster Image is loaded and displayed.

**Changes**
 * Add function to fire on Image Loading Status Event to hide blue box
 * Ensure Blue Box is made visible again when Item Content changed (to handle recycling of nodes)

**Issues**
fixed #321
