### PR TITLE
Make home screen use user settings

### DIFF
--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -6,6 +6,7 @@
   </children>
   <interface>
     <field id="selectedItem" alias="homeRows.selectedItem" />
+    <field id="userConfig" alias="homeRows.userConfig" />
     <field id="timeLastRefresh" type="integer" />
     <function name="refresh" />
   </interface>

--- a/components/home/HomeRows.xml
+++ b/components/home/HomeRows.xml
@@ -2,6 +2,7 @@
 <component name="HomeRows" extends="RowList">
   <interface>
     <field id="selectedItem" type="node" alwaysNotify="true" />
+    <field id="userConfig" type="assocarray" />
     <function name="updateHomeRows" />
   </interface>
   <script type="text/brightscript" uri="HomeRows.brs"/>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -35,6 +35,7 @@ sub Main()
   m.overhang.currentUser = m.user.Name
   m.overhang.showOptions = true
   group = CreateHomeGroup()
+  group.userConfig = m.user.configuration
   m.scene.appendChild(group)
 
   m.scene.observeField("backPressed", m.port)


### PR DESCRIPTION
Some of the user settings were already being applied to the home screen such as the order of libraries in My Media and whether or not to show watched in Latest In rows. This PR adds the following:

- Hide collections in My Media if asked ("Collections - Display on home screen")
- Arrange the "Latest In" rows based on "Library Order"
- Hide libraries from "Latest In" if asked ("Display in home screen sections such as latest media and continue watching")

**Changes**
Add `userConfig` field to Home, to gain access from HomeRows
After loading library data for My Media task, create blank rows for everything else to preserve library order for latest in rows
Create `filterNodeArray()` function to filter libraries using the list of exclusions saved in the users config

**Issues**
Fixes #158 
