### PR TITLE
Ensure currently selected channel in guide is used when "Watch" selected

### DIFF
--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -157,8 +157,7 @@ sub onWatchChannelSelected()
     ' Set focus back to grid before showing channel, to ensure grid has focus when we return
     focusProgramDetails(false) 
 
-    m.top.watchChannel = m.scheduleGrid.content.GetChild(m.LoadProgramDetailsTask.programDetails.channelIndex)
-
+    m.top.watchChannel = m.detailsPane.channel
 end sub
 
 ' As user scrolls grid, check if more data requries to be loaded


### PR DESCRIPTION
When _view channel_ is selected from the Guide, sometimes a different channel was streamed.  Issue was the streamed channel was incorrectly taken from the last loaded "Program Details", whereas it should have been taken from the selected Program Details view.

**Issues**
refs #311