### PR TITLE
Move home library loading from init into own function

### DIFF
--- a/components/home/Home.brs
+++ b/components/home/Home.brs
@@ -6,3 +6,7 @@ end sub
 function refresh()
 	m.top.findNode("homeRows").callFunc("updateHomeRows")
 end function
+
+function loadLibraries()
+	m.top.findNode("homeRows").callFunc("loadLibraries")
+end function

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -9,6 +9,7 @@
     <field id="userConfig" alias="homeRows.userConfig" />
     <field id="timeLastRefresh" type="integer" />
     <function name="refresh" />
+    <function name="loadLibraries" />
   </interface>
   <script type="text/brightscript" uri="Home.brs" />
 </component>

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -21,13 +21,16 @@ sub init()
   ' Load the Libraries from API via task
   m.LoadLibrariesTask = createObject("roSGNode", "LoadItemsTask")
   m.LoadLibrariesTask.observeField("content", "onLibrariesLoaded")
-  m.LoadLibrariesTask.control = "RUN"
   ' set up tesk nodes for other rows
   m.LoadContinueTask = createObject("roSGNode", "LoadItemsTask")
   m.LoadContinueTask.itemsToLoad = "continue"
   m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
   m.LoadNextUpTask.itemsToLoad = "nextUp"
 end sub
+
+function loadLibraries()
+  m.LoadLibrariesTask.control = "RUN"
+end function
 
 sub updateSize()
   sideborder = 100

--- a/components/home/HomeRows.xml
+++ b/components/home/HomeRows.xml
@@ -4,6 +4,7 @@
     <field id="selectedItem" type="node" alwaysNotify="true" />
     <field id="userConfig" type="assocarray" />
     <function name="updateHomeRows" />
+    <function name="loadLibraries" />
   </interface>
   <script type="text/brightscript" uri="HomeRows.brs"/>
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -36,6 +36,7 @@ sub Main()
   m.overhang.showOptions = true
   group = CreateHomeGroup()
   group.userConfig = m.user.configuration
+  group.callFunc("loadLibraries")
   m.scene.appendChild(group)
 
   m.scene.observeField("backPressed", m.port)


### PR DESCRIPTION
Occasionally got an error m.top.userconfig was _invalid_ when `onLibrariesLoaded()` was called.   The interface value was being set in the main function, since the LoadLibraries task ran in the Init function, it seems like on some occasions this returned and called the `onLibrariesLoaded()` function before the User Config had been set.   This resulted in an application crash.

**Changes**
 - Moved the running of the LoadLibraries task to its own function that is called after the UserConfig is set, to ensure it is set first

**Issues**
refs #324 