### PR TITLE
Allow user to quick play items with play button

### DIFF
--- a/components/ItemGrid2/ItemGrid2.brs
+++ b/components/ItemGrid2/ItemGrid2.brs
@@ -340,6 +340,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
       optionsClosed()
       return true
     end if
+  else if key = "play" then
+    markupGrid = m.top.getChild(2)
+    itemToPlay = markupGrid.content.getChild(markupGrid.itemFocused)
+    if itemToPlay <> invalid and (itemToPlay.type = "Movie" or itemToPlay.type = "Episode") then
+      m.top.quickPlayNode = itemToPlay
+    end if
+    return true
   end if
   return false
 end function

--- a/components/ItemGrid2/ItemGrid2.xml
+++ b/components/ItemGrid2/ItemGrid2.xml
@@ -33,6 +33,7 @@
   <interface>
     <field id="parentItem" type="node" onChange="loadInitialItems" />
     <field id="selectedItem" type="node" alwaysNotify="true" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
     <field id="imageDisplayMode" type="string" value="scaleToZoom" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/components/data/TVEpisodeData.xml
+++ b/components/data/TVEpisodeData.xml
@@ -8,6 +8,7 @@
     <field id="showID" type="string" />
     <field id="seasonID" type="string" />
     <field id="overview" type="string" />
+    <field id="type" type="string" value="Episode" />
     <field id="json" type="associativearray" onChange="setFields" />
     <function name="loadSeasons" />
   </interface>

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -7,6 +7,7 @@
   <interface>
     <field id="selectedItem" alias="homeRows.selectedItem" />
     <field id="userConfig" alias="homeRows.userConfig" />
+    <field id="quickPlayNode" alias="homeRows.quickPlayNode" />
     <field id="timeLastRefresh" type="integer" />
     <function name="refresh" />
   </interface>

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -306,7 +306,17 @@ function itemSelected()
 end function
 
 function onKeyEvent(key as string, press as boolean) as boolean
-  return false
+  handled = false
+  if press then
+    if key = "play" then
+      itemToPlay = m.top.content.getChild(m.top.rowItemFocused[0]).getChild(m.top.rowItemFocused[1])
+      if itemToPlay <> invalid and (itemToPlay.type = "Movie" or itemToPlay.type = "Episode") then
+        m.top.quickPlayNode = itemToPlay
+      end if
+      handled = true
+    end if
+  end if
+  return handled
 end function
 
 function filterNodeArray(nodeArray as object, nodeKey as string, excludeArray as object) as object

--- a/components/home/HomeRows.xml
+++ b/components/home/HomeRows.xml
@@ -3,6 +3,7 @@
   <interface>
     <field id="selectedItem" type="node" alwaysNotify="true" />
     <field id="userConfig" type="assocarray" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
     <function name="updateHomeRows" />
   </interface>
   <script type="text/brightscript" uri="HomeRows.brs"/>

--- a/components/tvshows/TVEpisodes.brs
+++ b/components/tvshows/TVEpisodes.brs
@@ -5,3 +5,17 @@ end sub
 sub setSeason()
   m.top.overhangTitle = m.top.seasonData.SeriesName + " - " + m.top.seasonData.name
 end sub
+
+function onKeyEvent(key as string, press as boolean) as boolean
+  handled = false
+  if press then
+    if key = "play" then
+      itemToPlay = m.top.focusedChild.content.getChild(m.top.focusedChild.rowItemFocused[0]).getChild(0)
+      if itemToPlay <> invalid and itemToPlay.id <> "" then
+        m.top.quickPlayNode = itemToPlay
+      end if
+      handled = true
+    end if
+  end if
+  return handled
+end function

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -5,6 +5,7 @@
   </children>
   <interface>
     <field id="episodeSelected" alias="picker.itemSelected" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
     <field id="seasonData" type="associativearray" onChange="setSeason" />
     <field id="objects" alias="picker.objects" />
   </interface>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -80,6 +80,24 @@ sub Main()
       else
         group.setFocus(true)
       end if
+    else if isNodeEvent(msg, "quickPlayNode")
+      reportingNode = msg.getRoSGNode()
+      itemNode = reportingNode.quickPlayNode
+      if itemNode = invalid or itemNode.id = "" then return
+      if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video" then
+        video = CreateVideoPlayerGroup(itemNode.id)
+        if video <> invalid then
+          group.lastFocus = group.focusedChild
+          group.setFocus(false)
+          group.visible = false
+          group = video
+          m.scene.appendChild(group)
+          group.setFocus(true)
+          group.control = "play"
+          ReportPlayback(group, "start")
+          m.overhang.visible = false
+        end if
+      end if
     else if isNodeEvent(msg, "selectedItem")
       ' If you select a library from ANYWHERE, follow this flow
       selectedItem = msg.getData()

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -159,6 +159,7 @@ function CreateHomeGroup()
   group = CreateObject("roSGNode", "Home")
 
   group.observeField("selectedItem", m.port)
+  group.observeField("quickPlayNode", m.port)
 
   sidepanel = group.findNode("options")
   sidepanel.observeField("closeSidePanel", m.port)

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -283,6 +283,7 @@ function CreateSeasonDetailsGroup(series, season)
   group.objects = TVEpisodes(series.id, season.id)
 
   group.observeField("episodeSelected", m.port)
+  group.observeField("quickPlayNode", m.port)
 
   return group
 end function

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -200,6 +200,7 @@ function CreateMovieListGroup(libraryItem)
   group.parentItem = libraryItem
 
   group.observeField("selectedItem", m.port)
+  group.observeField("quickPlayNode", m.port)
 
   sidepanel = group.findNode("options")
   movie_options = [
@@ -292,6 +293,7 @@ function CreateCollectionsList(libraryItem)
   group.parentItem = libraryItem
 
   group.observeField("selectedItem", m.port)
+  group.observeField("quickPlayNode", m.port)
 
   sidepanel = group.findNode("options")
 


### PR DESCRIPTION
This allows the user to "quick play" an item with type "Movie" or "Episode" from the home screen, itemgrid2, and the tv season episode list using the play button on the remote.

**Changes**
Create field `quickPlayNode` to hold selected (focused) item node
Create observers on the `quickPlayNode ` fields that report to main loop
Validate and play video from main loop

**Issues**
N/A
