### PR TITLE
Remove data from home task nodes after use

### DIFF
--- a/components/ItemGrid2/ItemGrid2.brs
+++ b/components/ItemGrid2/ItemGrid2.brs
@@ -162,6 +162,8 @@ sub ItemDataLoaded(msg)
 
   itemData = msg.GetData()
   data = msg.getField()
+  m.loadItemsTask.unobserveField("content")
+  m.loadItemsTask.content = []
 
   if itemData = invalid then
     m.Loading = false
@@ -258,6 +260,7 @@ sub loadMoreData()
 
   m.Loading = true
   m.loadItemsTask.startIndex = m.loadedItems
+  m.loadItemsTask.observeField("content", "ItemDataLoaded")
   m.loadItemsTask.control = "RUN"
 end sub
 

--- a/components/ItemGrid2/ItemGrid2.xml
+++ b/components/ItemGrid2/ItemGrid2.xml
@@ -37,5 +37,6 @@
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
   <script type="text/brightscript" uri="ItemGrid2.brs" />
 </component>

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -55,6 +55,7 @@ sub onLibrariesLoaded()
   ' save data for other functions
   m.libraryData = m.LoadLibrariesTask.content
   m.LoadLibrariesTask.unobserveField("content")
+  m.LoadLibrariesTask.content = []
   ' create My Media, Continue Watching, and Next Up rows
   content = CreateObject("roSGNode", "ContentNode")
   mediaRow = content.CreateChild("HomeRow")
@@ -101,8 +102,9 @@ function updateHomeRows()
 end function
 
 function updateContinueItems()
-  m.LoadContinueTask.unobserveField("content")
   itemData = m.LoadContinueTask.content
+  m.LoadContinueTask.unobserveField("content")
+  m.LoadContinueTask.content = []
 
   if itemData = invalid then return false
 
@@ -141,8 +143,9 @@ function updateContinueItems()
 end function
 
 function updateNextUpItems()
-  m.LoadNextUpTask.unobserveField("content")
   itemData = m.LoadNextUpTask.content
+  m.LoadNextUpTask.unobserveField("content")
+  m.LoadNextUpTask.content = []
 
   if itemData = invalid then return false
 
@@ -209,6 +212,7 @@ function updateLatestItems(msg)
   data = msg.getField()
   node = msg.getRoSGNode()
   node.unobserveField("content")
+  node.content = []
 
   if itemData = invalid then return false
 


### PR DESCRIPTION
I noticed while debugging `HomeRows `we were keeping the task node's content around even after we'd used it. No point in saving it and it just wastes memory space. This resets the content field to a blank array after grabbing it.

May be worth checking out the other task nodes to see if we're doing the same thing in other places.