### PR TITLE
support mp4 container for direct stream

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -241,7 +241,12 @@ function directPlaySupported(meta as object) as boolean
     streamInfo.Profile = LCase(meta.json.MediaStreams[0].Profile)
   end if
   if meta.json.MediaSources[0].container <> invalid and meta.json.MediaSources[0].container.len() > 0  then
-    streamInfo.Container = meta.json.MediaSources[0].container
+    'CanDecodeVideo() requires the .container to be format: “mp4”, “hls”, “mkv”, “ism”, “dash”, “ts” if its to direct stream
+    if meta.json.MediaSources[0].container = "mov" then 
+        streamInfo.Container = "mp4"
+    else
+    	streamInfo.Container = meta.json.MediaSources[0].container
+    end if
   end if
   return devinfo.CanDecodeVideo(streamInfo).result
 end function


### PR DESCRIPTION
**Changes**
Related to "mp4 Container not support #303".  CanDecodeVideo() returns false when checking if can decode a direct stream that is sent to it. The code had it so that it would pass it the container information as a .mov which is not supported in the current Roku API, has to be mp4 specifically. Switch it so if it shows .mov as the contianer to send .mp4 and allow for direct stream.
**Issues**
Refs #303
