### PR TITLE
Remember Login Credentials on Server disconnect

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -111,11 +111,18 @@ function CreateSigninGroup(user = "")
   username_field.label = tr("Username")
   username_field.field = "username"
   username_field.type = "string"
-  username_field.value = user
+  if user = "" and get_setting("username") <> invalid
+    username_field.value = get_setting("username")
+  else
+    username_field.value = user
+  end if
   password_field = CreateObject("roSGNode", "ConfigData")
   password_field.label = tr("Password")
   password_field.field = "password"
   password_field.type = "password"
+  if get_setting("password") <> invalid
+    password_field.value = get_setting("password")
+  end if
   items = [ username_field, password_field ]
   config.configItems = items
 
@@ -143,7 +150,11 @@ function CreateSigninGroup(user = "")
       if node = "submit"
         ' Validate credentials
         get_token(username.value, password.value)
-        if get_setting("active_user") <> invalid then return "true"
+        if get_setting("active_user") <> invalid
+          set_setting("username", username.value)
+          set_setting("password", password.value)
+          return "true"
+        end if
         print "Login attempt failed..."
         group.findNode("alert").text = tr("Login attempt failed.")
       end if

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -47,6 +47,11 @@ function CreateServerGroup()
         end if
         'Append http:// to server
         if left(server_hostname.value,4) <> "http" then server_hostname.value = "http://" + server_hostname.value
+        'If this is a different server from what we know, reset username/password setting
+        if get_setting("server") <> server_hostname.value then
+          set_setting("username", "")
+          set_setting("password", "")
+        endif
         set_setting("server", server_hostname.value)
         if ServerInfo() = invalid then
           ' Maybe don't unset setting, but offer as a prompt


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Only server URL was saved and username/password had to be re-entered every time there was a disconnect.

To solve the problem, when active_user is set (which I thought was when there was a successful auth) username and password is saved as a setting. And the next time this screen is shown, username and password is populated from that setting.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #346 
