### PR TITLE
Change field type associativearray to assocarray

### DIFF
--- a/components/ItemGrid.xml
+++ b/components/ItemGrid.xml
@@ -3,7 +3,7 @@
   <interface>
     <field id="itemsPerRow" type="int" />
     <field id="rowsPerPage" type="int" value="2" />
-    <field id="objects" type="associativearray" onChange="setupRows" />
+    <field id="objects" type="assocarray" onChange="setupRows" />
     <field id="escapeButton" type="string" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="ItemGrid.brs" />

--- a/components/ItemGrid2/ItemGridOptions.xml
+++ b/components/ItemGrid2/ItemGridOptions.xml
@@ -25,7 +25,7 @@
   </children>
   <interface>
     <field id="buttons" type="nodearray" />
-    <field id="options" type="associativearray" onChange="optionsSet" />
+    <field id="options" type="assocarray" onChange="optionsSet" />
 
     <field id="view" type="string" />
     <field id="sortField" type="string" value="SortName" />

--- a/components/ItemGrid2/LoadItemsTask2.xml
+++ b/components/ItemGrid2/LoadItemsTask2.xml
@@ -6,7 +6,7 @@
     <field id="startIndex" type="integer" value="0" />
     <field id="itemType" type="string" value="" />
     <field id="limit" type="integer" value="36" />
-    <field id="metadata" type="associativearray" />
+    <field id="metadata" type="assocarray" />
     <field id="sortField" type="string" value="SortName" />
     <field id="sortAscending" type="boolean" value="true" />
     <field id="recursive" type="boolean" value="true" />

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -7,7 +7,7 @@
     <field id="Subtitles" type="array" />
     <field id="SelectedSubtitle" type="integer" />
     <field id="captionMode" type="string" />
-    <field id="transcodeParams" type="associativearray" />
+    <field id="transcodeParams" type="assocarray" />
     <field id="container" type="string" />
     <field id="directPlaySupported" type="boolean" />
     <field id="decodeAudioSupported" type="boolean" />

--- a/components/collections/CollectionDetail.xml
+++ b/components/collections/CollectionDetail.xml
@@ -6,7 +6,7 @@
   <interface>
     <field id="collectionId" type="string" onChange="collectionIdChanged" />
     <field id="selectedItem" type="node" alwaysNotify="true" />
-    <field id="objects" type="associativearray" onChange="setupRows" />
+    <field id="objects" type="assocarray" onChange="setupRows" />
   </interface>
   <script type="text/brightscript" uri="CollectionDetail.brs" />
 </component>

--- a/components/data/AlbumData.xml
+++ b/components/data/AlbumData.xml
@@ -3,7 +3,7 @@
   <interface>
     <field id="id" type="string" />
     <field id="title" type="string" />
-    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="json" type="assocarray" onChange="setFields" />
   </interface>
   <script type="text/brightscript" uri="AlbumData.brs" />
 </component>

--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -8,7 +8,7 @@
     <field id="posterURL" type="string" />
     <field id="widePosterURL" type="string" />
     <field id="type" type="string" />
-    <field id="json" type="associativearray" onChange="setData" />
+    <field id="json" type="assocarray" onChange="setData" />
     <field id="collectionType" type="string" />
     <field id="imageWidth" type="integer" value="464" />
     <field id="usePoster" type="bool" value="false" />

--- a/components/data/ImageData.xml
+++ b/components/data/ImageData.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="ImageData" extends="ContentNode">
   <interface>
-    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="json" type="assocarray" onChange="setFields" />
     <field id="imagetype" type="string" />
     <field id="size" type="string" />
     <field id="height" type="integer" />

--- a/components/data/JFContentItem.xml
+++ b/components/data/JFContentItem.xml
@@ -8,6 +8,6 @@
         <field id="SubTitle" type="string" value="" />
         <field id="iconUrl" type="string" value="" />
         <field id="Type" type="string" value="" />
-        <field id="json" type="associativearray" onChange="setFields" />
+        <field id="json" type="assocarray" onChange="setFields" />
     </interface>
 </component>

--- a/components/data/MovieData.xml
+++ b/components/data/MovieData.xml
@@ -3,7 +3,7 @@
   <interface>
     <field id="image" type="node" onChange="setPoster" />
     <field id="movieID" type="string" />
-    <field id="seasons" type="associativearray" />
+    <field id="seasons" type="assocarray" />
     <field id="container" type="string" />
   </interface>
   <script type="text/brightscript" uri="MovieData.brs" />

--- a/components/data/SearchData.xml
+++ b/components/data/SearchData.xml
@@ -6,7 +6,7 @@
     <field id="title" type="string" />
     <field id="image" type="node" onChange="setPoster" />
     <field id="posterURL" type="string" />
-    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="json" type="assocarray" onChange="setFields" />
   </interface>
   <script type="text/brightscript" uri="SearchData.brs" />
 </component>

--- a/components/data/SeriesData.xml
+++ b/components/data/SeriesData.xml
@@ -2,8 +2,8 @@
 <component name="SeriesData" extends="JFContentItem">
   <interface>
     <field id="overview" type="string" />
-    <field id="seasons" type="associativearray" />
-    <field id="nextup" type="associativearray" />
+    <field id="seasons" type="assocarray" />
+    <field id="nextup" type="assocarray" />
     <field id="image" type="node" onChange="setPoster" />
     <function name="loadSeasons" />
   </interface>

--- a/components/data/TVEpisodeData.xml
+++ b/components/data/TVEpisodeData.xml
@@ -9,7 +9,7 @@
     <field id="seasonID" type="string" />
     <field id="overview" type="string" />
     <field id="type" type="string" value="Episode" />
-    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="json" type="assocarray" onChange="setFields" />
     <function name="loadSeasons" />
   </interface>
   <script type="text/brightscript" uri="TVEpisodeData.brs" />

--- a/components/data/TVSeasonData.xml
+++ b/components/data/TVSeasonData.xml
@@ -6,7 +6,7 @@
     <field id="image" type="node" onChange="setPoster" />
     <field id="posterURL" type="string" />
     <field id="overview" type="string" />
-    <field id="json" type="associativearray" onChange="setFields" />
+    <field id="json" type="assocarray" onChange="setFields" />
     <function name="getPoster" />
   </interface>
   <script type="text/brightscript" uri="TVSeasonData.brs" />

--- a/components/data/UserData.xml
+++ b/components/data/UserData.xml
@@ -5,7 +5,7 @@
     <field id="username" type="string" />
     <field id="token" type="string" />
     <field id="server" type="string" />
-    <field id="json" type="associativearray" onChange="setDataFromJSON" />
+    <field id="json" type="assocarray" onChange="setDataFromJSON" />
     <function name="setServer" />
     <function name="getPreference" />
     <function name="setPreference" />

--- a/components/home/LoadItemsTask.xml
+++ b/components/home/LoadItemsTask.xml
@@ -4,7 +4,7 @@
   <interface>
     <field id="itemsToLoad" type="string" value="libraries" />
     <field id="itemId" type="string" />
-    <field id="metadata" type="associativearray" />
+    <field id="metadata" type="assocarray" />
     <field id="content" type="array" />
   </interface>
   <script type="text/brightscript" uri="LoadItemsTask.brs" />

--- a/components/movies/MovieOptions.xml
+++ b/components/movies/MovieOptions.xml
@@ -30,7 +30,7 @@
   </children>
   <interface>
     <field id="buttons" type="nodearray" />
-    <field id="options" type="associativearray" onChange="optionsSet" />
+    <field id="options" type="assocarray" onChange="optionsSet" />
     <field id="audioSteamIndex" type="integer" />
   </interface>
   <script type="text/brightscript" uri="MovieOptions.brs" />

--- a/components/search/SearchRow.xml
+++ b/components/search/SearchRow.xml
@@ -2,7 +2,7 @@
 <component name="SearchRow" extends="RowList">
   <interface>
     <field id="rowSize" type="int" />
-    <field id="itemData" type="associativeArray" onChange="getData" />
+    <field id="itemData" type="assocarray" onChange="getData" />
     <field id="query" type="string" />
     <field id="itemSelected" type="int" />
   </interface>

--- a/components/tvshows/TVEpisodeRow.xml
+++ b/components/tvshows/TVEpisodeRow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="TVEpisodeRow" extends="RowList">
   <interface>
-    <field id="objects" type="associativearray" onChange="setupRows" />
+    <field id="objects" type="assocarray" onChange="setupRows" />
     <field id="escapeButton" type="string" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="TVEpisodeRow.brs" />

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -6,7 +6,7 @@
   <interface>
     <field id="episodeSelected" alias="picker.itemSelected" />
     <field id="quickPlayNode" type="node" alwaysNotify="true" />
-    <field id="seasonData" type="associativearray" onChange="setSeason" />
+    <field id="seasonData" type="assocarray" onChange="setSeason" />
     <field id="objects" alias="picker.objects" />
   </interface>
   <script type="text/brightscript" uri="TVEpisodes.brs" />

--- a/components/tvshows/TVSeasonRow.xml
+++ b/components/tvshows/TVSeasonRow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="TVSeasonRow" extends="RowList">
   <interface>
-    <field id="TVSeasonData" type="associativearray" onChange="getData" />
+    <field id="TVSeasonData" type="assocarray" onChange="getData" />
   </interface>
   <script type="text/brightscript" uri="TVSeasonRow.brs" />
 </component>

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -24,7 +24,7 @@
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged" />
-    <field id="seasonData" type="associativearray" alias="seasons.TVSeasonData" />
+    <field id="seasonData" type="assocarray" alias="seasons.TVSeasonData" />
     <field id="seasonSelected" alias="seasons.rowItemSelected" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Many of the XML interface fields had type `"associativearray"`, which is not a supported interface field type. According to the [brightscript docs](https://developer.roku.com/docs/references/scenegraph/xml-elements/interface.md), it should be `"assocarray"`.
![image](https://user-images.githubusercontent.com/2544493/106366350-46495a80-6309-11eb-89fe-cfe6a6e1dbd7.png)


