### PR TITLE
Correct Home Screen Selection Box size

### DIFF
--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -66,8 +66,8 @@ sub onLibrariesLoaded()
   nextUpRow.title = tr("Next Up >")
   sizeArray = [
     [464, 311], ' My Media
-    [464, 311], ' Continue Watching
-    [464, 311]  ' Next Up
+    [464, 331], ' Continue Watching
+    [464, 331]  ' Next Up
   ]
   ' validate library data
   if (m.libraryData <> invalid and m.libraryData.count() > 0) then


### PR DESCRIPTION
On the home screen, on "Continue Watching" and "Next up" rows the selection box was not tall enough, and hid the subtitle (i.e. Movie Rating & Year, or Episode Number and title)

**Changes**
Change height of selection box in Continue Watching and Next Up rows to be the same as the rows with subtitles, to stop information from being hidden.
