### PR TITLE
Tell Roku which Audio Track to play

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -127,6 +127,7 @@ function VideoContent(video, audio_stream_idx = 1) as object
     video.content.streamformat = container
     video.content.switchingStrategy = ""
     video.isTranscode = False
+    video.audioTrack = audio_stream_idx + 1 ' Tell Roku what Audio Track to play (convert from 0 based index for roku)
   else
     video.content.url = buildURL(Substitute("Videos/{0}/master.m3u8", video.id), transcodeParams)
     video.isTranscoded = true


### PR DESCRIPTION
Current not telling the Roku device which audio track to use (i.e. which one was selected by the user).  As a result Roku chooses the "best" track itself, based on the preferred language set the user in the OS. 

**Changes**
Set the Audio Track index to use when not transcoding.

**Issues**
fixes #351
