### PR TITLE
Add DeviceId to TransCode Params

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -182,6 +182,7 @@ function getTranscodeParameters(meta as object, audio_stream_idx = 1)
   end if
 
   params.Append({"MediaSourceId": meta.id})
+  params.Append({"DeviceId": devinfo.getChannelClientID()})
 
   return params
 end function


### PR DESCRIPTION
Add `DeviceId` to TransCode Params list to allow better reporting of transcoding information on server dashboard.

**Issues**
fixes #378