### PR TITLE
Remove recursive option when loading boxset detail

### DIFF
--- a/components/ItemGrid2/ItemGrid2.brs
+++ b/components/ItemGrid2/ItemGrid2.brs
@@ -65,7 +65,7 @@ sub loadInitialItems()
        showTvGuid()
     end if
 
-  else if m.top.parentItem.collectionType = "CollectionFolder" then
+  else if m.top.parentItem.collectionType = "CollectionFolder" OR m.top.parentItem.collectionType = "boxsets"  then
     ' Non-recursive, to not show subfolder contents
     m.loadItemsTask.recursive = false
   else if m.top.parentItem.collectionType = "Channel" then


### PR DESCRIPTION
When entering "Collections" library an additional Collections "folder" was displayed, rather than just the list of collections.

**Changes**
 - Removed recursive option when loading boxset detail

**Issues**
refs #375