### PR TITLE
Stop handling video position change ourselves (Fix for issue #353)

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -415,17 +415,6 @@ sub Main()
           changeSubtitleDuringPlayback(trackSelected)
         end if
       end if
-    else if isNodeEvent(msg, "position")
-      video = msg.getRoSGNode()
-      if video.position >= video.duration and not video.content.live then
-        stopPlayback()
-        if video.showID = invalid then
-          RemoveCurrentGroup()
-        else
-          MarkItemWatched(video.id)
-          autoPlayNextEpisode(video.id, video.showID)
-        end if
-      end if
     else if isNodeEvent(msg, "fire")
       ReportPlayback(group, "update")
     else if isNodeEvent(msg, "state")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -385,7 +385,6 @@ function CreateVideoPlayerGroup(video_id, audio_stream_idx = 1)
   video.observeField("backPressed", m.port)
   video.observeField("selectSubtitlePressed", m.port)
   video.observeField("state", m.port)
-  video.observeField("position", m.port)
   timer.control = "start"
   timer.observeField("fire", m.port)
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Previously, Jellyfin was listening to the video.position value to determine whether playback had finished. This caused problems when video.position was set to the max value for a 64-bit integer. My best guess is that this was being treated as -1 internally, but I couldn't find anything related to it in the docs. In any case, the node fires a "finished" event when playback reaches the end so we shouldn't override that behavior. I've verified that videos finishing are still handled as they should be, including autoplay.

Thanks to Neil in the Matrix chat for his help!!

**Issues**
Fixes #353 
