### PR TITLE
Fix observed field when sorting/filtering items in grid

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -33,7 +33,6 @@ sub init()
   m.filter = "All"
 
   m.loadItemsTask = createObject("roSGNode", "LoadItemsTask2")
-  m.loadItemsTask.observeField("content", "ItemDataLoaded")
 
 end sub
 
@@ -74,6 +73,7 @@ sub loadInitialItems()
     print "Unknown Type: " m.top.parentItem
   end if
 
+  m.loadItemsTask.observeField("content", "ItemDataLoaded")
   m.loadItemsTask.control = "RUN"
 
   SetUpOptions()


### PR DESCRIPTION
When sorting or filtering items from the ItemGrid (using the Option menu) the items were not loaded.   This is due was introduced in an earlier commit when the Observable was unset after the initial loading of the grid items.

**Changes**
- Set observable before each call to LoadItems task
