### PR TITLE
Add protection to avoid eating valid button presses

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -61,11 +61,6 @@ sub Main()
     if type(msg) = "roSGScreenEvent" and msg.isScreenClosed() then
       print "CLOSING SCREEN"
       return
-    else if isNodeEvent(msg, "buttonSelected")
-      ' Dialog Button Selected - If not handled more locally, just close the dialog
-      dialog = msg.getRoSGNode()
-      dialog.unobserveField("buttonSelected")
-      dialog.close = true
     else if isNodeEvent(msg, "backPressed")
       n = m.scene.getChildCount() - 1
       if msg.getRoSGNode().focusedChild <> invalid and msg.getRoSGNode().focusedChild.isSubtype("JFVideo")
@@ -189,6 +184,7 @@ sub Main()
           m.overhang.visible = false
         else 
           dialog = createObject("roSGNode", "Dialog")
+          dialog.id = "OKDialog"
           dialog.title = tr("Error loading Channel Data")
           dialog.message = tr("Unable to load Channel Data from the server")
           dialog.buttons = [tr("OK")]
@@ -340,6 +336,13 @@ sub Main()
           MarkItemFavorite(movie.id)
         end if
         movie.favorite = not movie.favorite
+      else
+        ' If there are no other button matches, check if this is a simple "OK" Dialog & Close if so
+        dialog = msg.getRoSGNode() 
+        if dialog.id = "OKDialog" then
+          dialog.unobserveField("buttonSelected")
+          dialog.close = true
+        end if
       end if
     else if isNodeEvent(msg, "optionSelected")
       button = msg.getRoSGNode()


### PR DESCRIPTION
Commit [9e77bc9](https://github.com/jellyfin/jellyfin-roku/pull/382/commits/9e77bc9a60715b0f9cf9a2837fc429c223fa9747) introduced a bug whereby if a Button Presses reached the main even handler, then it was assumed to be an unhandled dialog button pressed, and an attempt was made to close the dialog.

This was happening before the main even loop had a chance to handle the button presses if they were known, resulting in some functionality stopping working.  Check added in that commit should have been placed **after** the existing button press checks.

**Changes**
Moved handler for _unknown_ buttons to after check for known buttons.  Also added safeguard so that only known dialogs (with id `OKDialog`) are closed.

**Issues**
fixes #394
