### PR TITLE
Make checks for http and https case insensitive

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -34,11 +34,11 @@ function CreateServerGroup()
       if node = "submit"
         'Append default ports
         maxSlashes = 0
-        if left(server_hostname.value,8) = "https://" or left(server_hostname.value,7) = "http://" then maxSlashes = 2
+        if left(lcase(server_hostname.value),8) = "https://" or left(lcase(server_hostname.value),7) = "http://" then maxSlashes = 2
         'Check to make sure entry has no extra slashes before adding default ports.
         if Instr(0, server_hostname.value, "/") = maxSlashes then
           if server_hostname.value.len() > 5 and mid(server_hostname.value, server_hostname.value.len()-4,1) <> ":" and mid(server_hostname.value, server_hostname.value.len()-5,1) <> ":" then
-            if left(server_hostname.value ,5) = "https" then
+            if left(lcase(server_hostname.value) ,5) = "https" then
               server_hostname.value = server_hostname.value + ":8920"
             else
               server_hostname.value = server_hostname.value + ":8096"
@@ -46,12 +46,12 @@ function CreateServerGroup()
           end if
         end if
         'Append http:// to server
-        if left(server_hostname.value,4) <> "http" then server_hostname.value = "http://" + server_hostname.value
+        if left(lcase(server_hostname.value),4) <> "http" then server_hostname.value = "http://" + server_hostname.value
         'If this is a different server from what we know, reset username/password setting
         if get_setting("server") <> server_hostname.value then
           set_setting("username", "")
           set_setting("password", "")
-        endif
+        end if
         set_setting("server", server_hostname.value)
         if ServerInfo() = invalid then
           ' Maybe don't unset setting, but offer as a prompt


### PR DESCRIPTION
When user enters server URL, if a protocol is not specified (i.e. http, https) then the client adds http automatically.   When looking for http and https it was using a case sensitive search string, meaning if user entered `HTTP://192...` the client would still prepend http to get `http://HTTP://192...`

**Changes**
- Lowercase input server url before looking for protocol string

**Issues**
fixes #400
