### PR TITLE
Improve server connection process and feedback

### DIFF
--- a/components/config/ConfigScene.xml
+++ b/components/config/ConfigScene.xml
@@ -19,8 +19,10 @@
       translation="[150, 450]" />
     <label text=""
       id="alert"
+      wrap="true"
+      width="1620"
       font="font:MediumSystemFont"
-      translation="[150, 555]" />
+      translation="[150, 580]" />
   </children>
   <script type="text/brightscript" uri="ConfigScene.brs"/>
 </component>

--- a/locale/default/translations.ts
+++ b/locale/default/translations.ts
@@ -300,6 +300,11 @@
         <translation>TV Guide</translation>
         <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
     </message>
+    <message>
+        <source>Connecting to Server</source>
+        <translation>Connecting to Server</translation>
+        <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
+    </message>
 </context>
 <context>
     <name></name>

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -414,6 +414,10 @@
             <translation>TV Guide</translation>
             <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
         </message>
-
+        <message>
+            <source>Connecting to Server</source>
+            <translation>Connecting to Server</translation>
+            <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -414,6 +414,10 @@
             <translation>TV Guide</translation>
             <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
         </message>
-
+        <message>
+            <source>Connecting to Server</source>
+            <translation>Connecting to Server</translation>
+            <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
+        </message>
     </context>
 </TS>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -455,7 +455,7 @@ function LoginFlow(startOver = false as boolean)
         dialog.close = true
   end if
 
-  if serverInfoResult.Error or startOver  then
+  if startOver or serverInfoResult.Error  then
     print "Get server details"
     SendPerformanceBeacon("AppDialogInitiate")  ' Roku Performance monitoring - Dialog Starting
     serverSelection = CreateServerGroup()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -441,7 +441,21 @@ function LoginFlow(startOver = false as boolean)
   end if
   'Collect Jellyfin server and user information
   start_login:
-  if get_setting("server") = invalid or ServerInfo() = invalid or startOver = true then
+
+  if get_setting("server") = invalid then startOver = true
+
+  if not startOver then
+        ' Show Connecting to Server spinner
+        dialog = createObject("roSGNode", "ProgressDialog")
+        dialog.title = tr("Connecting to Server")
+        m.scene.dialog = dialog
+
+        serverInfoResult = ServerInfo()
+
+        dialog.close = true
+  end if
+
+  if serverInfoResult.Error or startOver  then
     print "Get server details"
     SendPerformanceBeacon("AppDialogInitiate")  ' Roku Performance monitoring - Dialog Starting
     serverSelection = CreateServerGroup()

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -53,11 +53,33 @@ function CreateServerGroup()
           set_setting("password", "")
         endif
         set_setting("server", server_hostname.value)
-        if ServerInfo() = invalid then
+        
+        ' Show Connecting to Server spinner
+        dialog = createObject("roSGNode", "ProgressDialog")
+        dialog.title = tr("Connecting to Server")
+        m.scene.dialog = dialog
+
+        serverInfoResult = ServerInfo()
+
+        dialog.close = true
+
+        if serverInfoResult = invalid then
           ' Maybe don't unset setting, but offer as a prompt
           ' Server not found, is it online? New values / Retry
           print "Server not found, is it online? New values / Retry"
           group.findNode("alert").text = tr("Server not found, is it online?")
+          SignOut()
+        else if serverInfoResult.Error <> invalid and serverInfoResult.Error
+          ' If server redirected received, update the URL
+          if serverInfoResult.UpdatedUrl <> invalid then
+            server_hostname.value = serverInfoResult.UpdatedUrl
+          end if
+          ' Display Error Message to user
+          message = tr("Error: ")
+          if serverInfoResult.ErrorCode <> invalid then
+            message = message + "[" + serverInfoResult.ErrorCode.toStr() + "] "
+          end if
+          group.findNode("alert").text = message + tr(serverInfoResult.ErrorMessage)
           SignOut()
         else
           group.visible = false


### PR DESCRIPTION
Improve server connection process and user feedback

- Show "Connecting to Server" dialog while attempting to connect to server
- Follow `location` header in server to response and follow redirect if API path matches
- Display reason for failure to server (e.g. Self Signed Certificate, DNS Resolution, Timeout, etc etc)

**Issues**
fixes #218
fixes #316
fixes #399