### PR TITLE
Remove Overhang Background

### DIFF
--- a/components/JFOverhang.brs
+++ b/components/JFOverhang.brs
@@ -1,8 +1,5 @@
 sub init()
   m.top.id = "overhang"
-  ' set opacity
-  bgg = m.top.findNode("overlayBackgroundGroup")
-  bgg.opacity = 0.333
   ' hide seperators till they're needed
   leftSeperator = m.top.findNode("overlayLeftSeperator")
   leftSeperator.visible = "false"

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="JFOverhang" extends="Group">
   <children>
-    <LayoutGroup id="overlayBackgroundGroup" layoutDirection="horiz" translation="[0, 0]" >
-      <Rectangle
-        id="overlayBackground"
-        color="#000000"
-        width="1920"
-        height="125"
-        translation="[0,0]" />
-    </LayoutGroup>
     <Poster id="overlayLogo"
       uri="pkg:/images/logo.png"
       translation="[70, 53]"


### PR DESCRIPTION
Removed overhang background, after checking it is not required in current screens.   As mentioned in #308, in the new ItemGrid page the whole backdrop has a opacity applied, meaning the text is still visible on pure white backdrops.


**Issues**
closes #308