### PR TITLE
Add Channel Support

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -64,7 +64,7 @@ sub loadInitialItems()
        showTvGuid()
     end if
 
-  else if m.top.parentItem.collectionType = "CollectionFolder" OR m.top.parentItem.collectionType = "boxsets"  then
+  else if m.top.parentItem.collectionType = "CollectionFolder" OR m.top.parentItem.collectionType = "boxsets" or m.top.parentItem.Type = "Folder" or m.top.parentItem.Type = "Channel"  then
     ' Non-recursive, to not show subfolder contents
     m.loadItemsTask.recursive = false
   else if m.top.parentItem.collectionType = "Channel" then

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -59,7 +59,7 @@ sub loadItems()
       tmp = CreateObject("roSGNode", "CollectionData")
     else if item.Type = "TvChannel" then
       tmp = CreateObject("roSGNode", "ChannelData")
-    else if item.Type = "Folder" then
+    else if item.Type = "Folder" or item.Type = "ChannelFolderItem" then
       tmp = CreateObject("roSGNode", "FolderData")
     else if item.Type = "Video" then
       tmp = CreateObject("roSGNode", "VideoData")

--- a/components/data/MovieData.brs
+++ b/components/data/MovieData.brs
@@ -31,16 +31,18 @@ sub setPoster()
   else
 
     if m.top.json.ImageTags.Primary <> invalid then
-        
       imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag" : m.top.json.ImageTags.Primary }
       m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
-    else if m.top.json.BackdropImageTags <> invalid then
-      imgParams = { "maxHeight": 440, "Tag" : m.top.json.BackdropImageTags[0] }
+    else if m.top.json.BackdropImageTags[0] <> invalid then
+    imgParams = { "maxHeight": 440, "Tag" : m.top.json.BackdropImageTags[0] }
       m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
+    else if m.top.json.ParentThumbImageTag <> invalid and m.top.json.ParentThumbItemId <> invalid then
+      imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag" : m.top.json.ParentThumbImageTag }
+      m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
     end if
 
     ' Add Backdrop Image
-    if m.top.json.BackdropImageTags <> invalid then
+    if m.top.json.BackdropImageTags[0] <> invalid then
       imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag" : m.top.json.BackdropImageTags[0] }
       m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
     end if

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -60,6 +60,12 @@ sub itemContentChanged()
   if itemData.genres.count() > 0
     setFieldText("genres", tr("Genres") + ": " + itemData.genres.join(", "))
   end if
+
+  ' show tags if there are no genres to display
+  if itemData.genres.count() = 0 and itemData.tags.count() > 0
+    setFieldText("genres", tr("Tags") + ": " + itemData.tags.join(", "))
+  end if
+
   director = invalid
   for each person in itemData.people
     if person.type = "Director"
@@ -70,8 +76,13 @@ sub itemContentChanged()
   if director <> invalid
     setFieldText("director", tr("Director") + ": " + director)
   end if
-  setFieldText("video_codec", tr("Video") + ": " + itemData.mediaStreams[0].displayTitle)
-  setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[m.top.selectedAudioStreamIndex].displayTitle)
+
+  if itemData.mediaStreams[0] <> invalid
+    setFieldText("video_codec", tr("Video") + ": " + itemData.mediaStreams[0].displayTitle)
+  end if
+  if itemData.mediaStreams[m.top.selectedAudioStreamIndex] <> invalid
+    setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[m.top.selectedAudioStreamIndex].displayTitle)
+  end if
   ' TODO - cmon now. these are buttons, not words
   if itemData.taglines.count() > 0
     setFieldText("tagline", itemData.taglines[0])

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -103,7 +103,7 @@ sub Main()
     else if isNodeEvent(msg, "selectedItem")
       ' If you select a library from ANYWHERE, follow this flow
       selectedItem = msg.getData()
-      if selectedItem.type = "CollectionFolder" OR selectedItem.type = "UserView" OR selectedItem.type = "Folder"
+      if selectedItem.type = "CollectionFolder" OR selectedItem.type = "UserView" OR selectedItem.type = "Folder" OR selectedItem.type = "Channel"
         group.lastFocus = group.focusedChild
         group.setFocus(false)
         group.visible = false


### PR DESCRIPTION
Add support for Channel Plugins

**Changes**
 - Handle _ChannelFolderItem_ Types, and treat as _Folders_
 - When querying _Channels_ and _Folders_, specify non-recursive results
 - Display _Tags_ on Movie Details screen if _Genres_ not set
 - Test for Stream Information before trying trying to display in Movie Detail page
 - Update Movie Item Type to use _Parent Thumb Image_ image for poster if Primary and Backdrop are not set

**Issues**
fixes #384
