### PR TITLE
Handle CollectionFolder to allow browsing Folder Library Type

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -70,7 +70,7 @@ sub loadInitialItems()
   else if m.top.parentItem.collectionType = "Channel" then
     m.top.imageDisplayMode = "scaleToFit"
   else
-    print "Unknown Type: " m.top.parentItem
+    print "[ItemGrid] Unknown Type: " m.top.parentItem
   end if
 
   m.loadItemsTask.observeField("content", "ItemDataLoaded")

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -59,12 +59,12 @@ sub loadItems()
       tmp = CreateObject("roSGNode", "CollectionData")
     else if item.Type = "TvChannel" then
       tmp = CreateObject("roSGNode", "ChannelData")
-    else if item.Type = "Folder" or item.Type = "ChannelFolderItem" then
+    else if item.Type = "Folder" or item.Type = "ChannelFolderItem" or item.Type = "CollectionFolder" then
       tmp = CreateObject("roSGNode", "FolderData")
     else if item.Type = "Video" then
       tmp = CreateObject("roSGNode", "VideoData")
     else
-      print "Unknown Type: " item.Type
+      print "[LoadItems] Unknown Type: " item.Type
     end if
 
     if tmp <> invalid then

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -23,6 +23,8 @@ sub setData()
         ' Add Icon URLs for display if there is no Poster
         if datum.CollectionType = "livetv" then
             m.top.iconUrl = "pkg:/images/media_type_icons/live_tv_white.png"
+        else if datum.CollectionType = "folders" then
+            m.top.iconUrl = "pkg:/images/media_type_icons/folder_white.png"
         end if
 
     else if datum.type = "Episode" then


### PR DESCRIPTION
Allow browsing of Folder Library Type

**Changes**
 - Support CollectionFolder type to allow browsing of Folder Library type
 - Display Folder icon for Folder Library Type
 - Update debug messages for Invalid Type to show where type was found

**Issues**
fixes #287
