### PR TITLE
Enable basic deep linking

### DIFF
--- a/locale/default/translations.ts
+++ b/locale/default/translations.ts
@@ -305,6 +305,16 @@
         <translation>Connecting to Server</translation>
         <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
     </message>
+    <message>
+        <source>Not found</source>
+        <translation>Not found</translation>
+        <extracomment>Title of message box when the requested content is not found on the server</extracomment>
+    </message>
+    <message>
+        <source>The requested content does not exist on the server</source>
+        <translation>The requested content does not exist on the server</translation>
+        <extracomment>Content of message box when the requested content is not found on the server</extracomment>
+    </message>
 </context>
 <context>
     <name></name>

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -419,5 +419,15 @@
             <translation>Connecting to Server</translation>
             <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
         </message>
+        <message>
+            <source>Not found</source>
+            <translation>Not found</translation>
+            <extracomment>Title of message box when the requested content is not found on the server</extracomment>
+        </message>
+        <message>
+            <source>The requested content does not exist on the server</source>
+            <translation>The requested content does not exist on the server</translation>
+            <extracomment>Content of message box when the requested content is not found on the server</extracomment>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -419,5 +419,15 @@
             <translation>Connecting to Server</translation>
             <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
         </message>
+        <message>
+            <source>Not found</source>
+            <translation>Not found</translation>
+            <extracomment>Title of message box when the requested content is not found on the server</extracomment>
+        </message>
+        <message>
+            <source>The requested content does not exist on the server</source>
+            <translation>The requested content does not exist on the server</translation>
+            <extracomment>Content of message box when the requested content is not found on the server</extracomment>
+        </message>
     </context>
 </TS>

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -20,6 +20,7 @@ function VideoContent(video, audio_stream_idx = 1) as object
   params = {}
 
   meta = ItemMetaData(video.id)
+  if meta = invalid return invalid
   video.content.title = meta.title
   video.showID = meta.showID
   

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -61,6 +61,7 @@ function ItemMetaData(id as string)
   url = Substitute("Users/{0}/Items/{1}", get_setting("active_user"), id)
   resp = APIRequest(url)
   data = getJson(resp)
+  if data = invalid then return invalid
   imgParams = {}
   if data.UserData.PlayedPercentage <> invalid then
     param = { "PercentPlayed": data.UserData.PlayedPercentage }

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -16,8 +16,8 @@ end function
 
 function getButton(msg, subnode = "buttons" as string) as object
   buttons = msg.getRoSGNode().findNode(subnode)
+  if buttons = invalid return invalid
   active_button = buttons.focusedChild
-
   return active_button
 end function
 


### PR DESCRIPTION
Add basic Deep Linking specifically to pass Static Analysis testing for Roku store releases.

This works in a basic fashion, and as long as `mediaType` and `contentId` are passed in, it will attempt to play the content from the current server/user.  If content doesn't exist on the server a message box will be shown to the user.  Several things to note though:

 - mediaType is ignore.  It just has to be specified - we don't currently care what type it is
 - contentId is the ItemId on the server.  It will play the default Audio track

There's a lot needing done to properly implement deep linking (such as including and parsing user id and server ids) and handling other data types (TV Shows / Seasons, music, etc).


**Changes**
 - Additional checks for invalid objects due to how video players can be created
 - Capture start-up args and launch video if contentId passed in
 - Handle `roInput` events and launch video if contentId passed in

**Issues**
refs #422
refs #42