### PR TITLE
Better checking of CanDecodeVideo call for OS10

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -176,7 +176,7 @@ function getTranscodeParameters(meta as object, audio_stream_idx = 1)
   devinfo = CreateObject("roDeviceInfo")
   res = devinfo.CanDecodeVideo(streamInfo)
 
-  if res.result = false then
+  if res = invalid or res.result = invalid or res.result = false then
     params.Append({"VideoCodec": "h264"})
     streamInfo.Profile = "h264"
     streamInfo.Container = "ts"


### PR DESCRIPTION
Crash statistics are showing the in Roku OS10, some calls to `CanDecodeVideo()` appear to be returning `invalid`.  In previous OS versions we seemed to always get a valid response.

This fix should handle invalid responses, and assume transcoding is required.  Given we don't as yet know the reason for the invalid return values, this may result in some media being transcoded that was not in earlier OS releases.  The call to this function should be being removed shortly, so this will be a temporary fix.

**Changes**
Additional checking on the return value from `CanDecodeVideo()`, and if an `invalid` response is received assume that the video requires transcoding.

