### PR TITLE
Avoid marking item played twice (for trakt, etc)

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -334,7 +334,6 @@ end function
 
 function StopPlayback()
   video = m.scene.focusedchild
-  if video.state = "finished" then MarkItemWatched(video.id)
   video.control = "stop"
   m.device.EnableAppFocusEvent(False)
   video.findNode("playbackTimer").control = "stop"

--- a/source/api/UserLibrary.brs
+++ b/source/api/UserLibrary.brs
@@ -13,7 +13,6 @@ end function
 
 function MarkItemWatched(id as String)
   date = CreateObject("roDateTime")
-  date.toLocalTime()
   dateStr = stri(date.getYear()).trim()
   dateStr += leftPad(stri(date.getMonth()).trim(), "0", 2)
   dateStr += leftPad(stri(date.getDayOfMonth()).trim(), "0", 2)


### PR DESCRIPTION
When a video plays to the end the Roku client calls the server to mark the item as played.  This is done automatically by the server and the Roku call results in duplicate calls in trakt.

**Changes**
 - Remove call to mark played when video completes (handled automatically by the server)
 - Update mark played call to pass Date Time as UTC

**Issues**
fixes #431
