### PR TITLE
Roku OS 10 Fix - Handle invalid result from CanDecodeVideo

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -263,7 +263,10 @@ function directPlaySupported(meta as object) as boolean
     	streamInfo.Container = meta.json.MediaSources[0].container
     end if
   end if
-  return devinfo.CanDecodeVideo(streamInfo).result
+
+  decodeResult = devinfo.CanDecodeVideo(streamInfo)
+  return decodeResult <> invalid and decodeResult.result
+
 end function
 
 function decodeAudioSupported(meta as object, audio_stream_idx = 1) as boolean


### PR DESCRIPTION
OS10 Failure is happening due to call to `CanDecodeVideo()` not passing in known Codecs.  In OS 9 if the codec was unknown, the function would return a valid response informing that codec was not supported.  In OS 10 it throws an error trying to case Codec, and returns an invalid response.

Calls to `CanDecodeVideo()` have been removed in in-progress change to using PlaybackInfo call to determine if we need to transcode, so this is a temporary fix to resolve the error in OS 10.

**Changes**
 - Check for Invalid response and assume that transcoding required if invalid
