### PR TITLE
Change ReportPlayback() function to sub

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -317,7 +317,7 @@ function getAudioInfo(meta as object) as object
   return results
 end function
 
-function ReportPlayback(video, state = "update" as string)
+sub ReportPlayback(video, state = "update" as string)
 
   if video = invalid or video.position = invalid then return
 
@@ -333,7 +333,7 @@ function ReportPlayback(video, state = "update" as string)
     })
   end if
   PlaystateUpdate(video.id, state, params)
-end function
+end sub
 
 function StopPlayback()
   video = m.scene.focusedchild


### PR DESCRIPTION
#434 removed the return value from the function.  I should have spotted that the correct thing to do was to change the `function` to a `sub` since this function returns no value.

**Changes**
- Change ReportPlayback() from a `function` to a `sub` to remove requirement for return value

