### PR TITLE
Don't pre-populate password field

### DIFF
--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -26,6 +26,8 @@ end function
 function SignOut()
   if get_setting("active_user") <> invalid
     unset_user_setting("token")
+    unset_setting("username")
+    unset_setting("password")
   end if
   unset_setting("active_user")
   m.overhang.currentUser = ""


### PR DESCRIPTION
As reported by _igbo_ on matrix, the password field was pre-populated when logging in, meaning that a user could not securely "sign out" as when they username/password box were shown again they were pre-populated with last login details.

This was a result of #355, to prevent having to re-enter details where there was a transient server availability error.

**Changes**
 - When user selects **Sign Out** from the menu, remove cached username and password