### PR TITLE
Added 2000 channel Limit

### DIFF
--- a/components/liveTv/LoadChannelsTask.xml
+++ b/components/liveTv/LoadChannelsTask.xml
@@ -2,7 +2,7 @@
 
 <component name="LoadChannelsTask" extends="Task">
   <interface>
-    <field id="limit" type="integer" value="500" />
+    <field id="limit" type="integer" value="2000" />
     <field id="startIndex" type="integer" value="0" />
     
     <!-- Total records available from server-->


### PR DESCRIPTION
Updated the load channels task to have a limit of 2000

Changed 
 from <field id="limit" type="integer" value="500" />
to   <field id="limit" type="integer" value="2000" />

**Changes**
Updated the load channels task to include 2000 channels
No visual preformace was noticed when loading 2000 channels 

**Issues**
Fixes some channels missing from guide. 
I would think we should call via api the number of live tv channels then set the limit. As most M3U or tuners have different amount of channels. 
