### PR TITLE
Fix variable name causing Subtitle selection to crash

### DIFF
--- a/source/utils/Subtitles.brs
+++ b/source/utils/Subtitles.brs
@@ -2,7 +2,7 @@
 function selectSubtitleTrack(tracks, current = -1) as integer
   video = m.scene.focusedChild
   trackSelected = selectSubtitleTrackDialog(video.Subtitles, video.SelectedSubtitle)
-  if trackSelected = invalid or tackSelected = -1 then 	' back pressed in Dialog - no selection made
+  if trackSelected = invalid or trackSelected = -1 then 	' back pressed in Dialog - no selection made
     return -2
   else
     return trackSelected - 1


### PR DESCRIPTION
**Changes**
 - Fix typo in `TackSelected` variable name
