### PR TITLE
Displays multiple directors instead of just one

### DIFF
--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -16,7 +16,6 @@ sub itemContentChanged()
   item = m.top.itemContent
   itemData = item.json
   m.top.id = itemData.id
-
   m.top.findNode("moviePoster").uri = m.top.itemContent.posterURL
 
   ' Find first Audio Stream and set that as default
@@ -66,15 +65,14 @@ sub itemContentChanged()
     setFieldText("genres", tr("Tags") + ": " + itemData.tags.join(", "))
   end if
 
-  director = invalid
+  directors = []
   for each person in itemData.people
     if person.type = "Director"
-      director = person.name
-      exit for
+      directors.push(person.name)
     end if
   end for
-  if director <> invalid
-    setFieldText("director", tr("Director") + ": " + director)
+  if directors.count() > 0
+    setFieldText("director", tr("Director") + ": " + directors.join(", "))
   end if
 
   if itemData.mediaStreams[0] <> invalid


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
In the case where a movie has multiple directors, only one is currently shown. Now instead of quitting the loop after the first "Director" is found, the loop will create an list of all names with type "Director" and then print them all.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
