### PR TITLE
Enable Favourite Filtering on LiveTV and TV Shows

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -61,7 +61,6 @@ sub loadInitialItems()
         m.top.imageDisplayMode = "scaleToFit"
 
         if get_user_setting("display.livetv.landing") = "guide" and m.options.view <> "livetv"
-            print "Showing Guid from Init"
             showTvGuide()
         end if
 

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -328,6 +328,7 @@ sub showTVGuide()
         m.top.signalBeacon("EPGLaunchInitiate") ' Required Roku Performance monitoring
     end if
     m.tvGuide.observeField("watchChannel", "onChannelSelected")
+    m.tvGuide.filter = m.options.filter
     m.top.appendChild(m.tvGuide)
     m.tvGuide.lastFocus.setFocus(true)
 end sub

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -131,7 +131,10 @@ sub SetUpOptions()
             { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
             { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
         ]
-        options.filter = []
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
+        ]
         'Live TV
     else if m.top.parentItem.collectionType = "livetv"
         options.views = [
@@ -141,7 +144,10 @@ sub SetUpOptions()
         options.sort = [
             { "Title": tr("TITLE"), "Name": "SortName" }
         ]
-        options.filter = []
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
+        ]
     else
         options.views = [
             { "Title": tr("Default"), "Name": "default" }

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -60,8 +60,9 @@ sub loadInitialItems()
         'For LiveTV, we want to "Fit" the item images, not zoom
         m.top.imageDisplayMode = "scaleToFit"
 
-        if get_user_setting("display.livetv.landing") = "guide"
-            showTvGuid()
+        if get_user_setting("display.livetv.landing") = "guide" and m.options.view <> "livetv"
+            print "Showing Guid from Init"
+            showTvGuide()
         end if
 
     else if m.top.parentItem.collectionType = "CollectionFolder" or m.top.parentItem.collectionType = "boxsets" or m.top.parentItem.Type = "Folder" or m.top.parentItem.Type = "Channel"
@@ -288,7 +289,7 @@ end sub
 sub optionsClosed()
 
     if m.options.view = "tvGuide"
-        showTVGuid()
+        showTVGuide()
         return
     else if m.tvGuide <> invalid
         ' Try to hide the TV Guide
@@ -315,7 +316,7 @@ sub optionsClosed()
     m.itemGrid.setFocus(true)
 end sub
 
-sub showTVGuid()
+sub showTVGuide()
     m.top.signalBeacon("EPGLaunchInitiate") ' Required Roku Performance monitoring
     if m.tvGuide = invalid
         m.tvGuide = createObject("roSGNode", "Schedule")

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -323,9 +323,9 @@ sub optionsClosed()
 end sub
 
 sub showTVGuide()
-    m.top.signalBeacon("EPGLaunchInitiate") ' Required Roku Performance monitoring
     if m.tvGuide = invalid
         m.tvGuide = createObject("roSGNode", "Schedule")
+        m.top.signalBeacon("EPGLaunchInitiate") ' Required Roku Performance monitoring
     end if
     m.tvGuide.observeField("watchChannel", "onChannelSelected")
     m.top.appendChild(m.tvGuide)

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -30,7 +30,7 @@ sub loadItems()
         ' do nothing
     else if filter = "Favorites"
         params.append({ Filters: "IsFavorite" })
-        params.append({ isFavorite: true})
+        params.append({ isFavorite: true })
     end if
 
     if m.top.ItemType <> ""

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -30,6 +30,7 @@ sub loadItems()
         ' do nothing
     else if filter = "Favorites"
         params.append({ Filters: "IsFavorite" })
+        params.append({ isFavorite: true})
     end if
 
     if m.top.ItemType <> ""
@@ -38,6 +39,7 @@ sub loadItems()
 
     if m.top.ItemType = "LiveTV"
         url = "LiveTv/Channels"
+        params.append({ userId: get_setting("active_user") })
     else
         url = Substitute("Users/{0}/Items/", get_setting("active_user"))
     end if

--- a/components/liveTv/LoadChannelsTask.brs
+++ b/components/liveTv/LoadChannelsTask.brs
@@ -7,10 +7,12 @@ sub loadChannels()
     results = []
 
     params = {
-        UserId: get_setting("active_user")
-        'limit: m.top.limit,
-        'StartIndex: m.top.startIndex
+        UserId: get_setting("active_user"),
     }
+
+    if m.top.filter = "Favorites"
+        params.append({ isFavorite: true })
+    end if
 
     url = "LiveTv/Channels"
 

--- a/components/liveTv/LoadChannelsTask.xml
+++ b/components/liveTv/LoadChannelsTask.xml
@@ -4,6 +4,7 @@
   <interface>
     <field id="limit" type="integer" value="" />
     <field id="startIndex" type="integer" value="0" />
+    <field id="filter" type="string" value="All" />
     
     <!-- Total records available from server-->
     <field id="channels" type="array" />

--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -28,6 +28,17 @@ sub init()
     m.channelIndex = {}
 end sub
 
+sub channelFilterSet()
+    print "Channel Filter set"
+    if m.top.filter <> invalid and m.LoadChannelsTask.filter <> m.top.filter
+        if m.LoadChannelsTask.state = "run" then m.LoadChannelsTask.control = "stop"
+
+        m.LoadChannelsTask.filter = m.top.filter
+        m.LoadChannelsTask.control = "RUN"
+    end if
+
+end sub
+
 ' Initial list of channels loaded
 sub onChannelsLoaded()
     gridData = createObject("roSGNode", "ContentNode")

--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -1,5 +1,6 @@
 sub init()
 
+    m.EPGLaunchCompleteSignaled = false
     m.scheduleGrid = m.top.findNode("scheduleGrid")
     m.detailsPane = m.top.findNode("detailsPane")
 
@@ -55,7 +56,10 @@ sub onChannelsLoaded()
     m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
 
     m.scheduleGrid.setFocus(true)
-    m.top.signalBeacon("EPGLaunchComplete") ' Required Roku Performance monitoring
+    if m.EPGLaunchCompleteSignaled = false
+        m.top.signalBeacon("EPGLaunchComplete") ' Required Roku Performance monitoring
+        m.EPGLaunchCompleteSignaled = true
+    end if
     m.LoadChannelsTask.channels = []
 end sub
 

--- a/components/liveTv/schedule.xml
+++ b/components/liveTv/schedule.xml
@@ -18,6 +18,7 @@
   </children>
   <interface>
         <field id="watchChannel" type="node" alwaysNotify="false" />
+        <field id="filter" type="string" value="All" onChange="channelFilterSet" />
   </interface>
   <script type="text/brightscript" uri="schedule.brs" />
 </component>


### PR DESCRIPTION
**Changes**
 - Prevent auto switching to TV Guide when channel list selected
 - Correct function name (`ShowTVGuid` -> `ShowTVGuide`)
 - Add Favourite Filtering to LiveTV Channels & Guide Item Grid
 - Add Favourite Filtering to TV Shows Item Grid
 - Avoid sending multiple EPG Performance Monitoring beacons 

**Issues**
fixes #474