### PR TITLE
Fix hvec transcoding when not required

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -146,8 +146,8 @@ function GetDirectPlayProfiles() as object
 
     'Check for Supported Video Codecs
     if di.CanDecodeVideo({ Codec: "hevc" }).Result = true
-        mp4Video = mp4Video + ",h265"
-        mkvVideo = mkvVideo + ",h265"
+        mp4Video = mp4Video + ",h265,hevc"
+        mkvVideo = mkvVideo + ",h265,hevc"
     end if
 
     if di.CanDecodeVideo({ Codec: "vp9" }).Result = true

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -201,6 +201,8 @@ function GetDirectPlayProfiles() as object
 
     if di.CanDecodeAudio({ Codec: "eac3" }).result
         mkvAudio = mkvAudio + ",eac3"
+        mp4Audio = mp4Audio + ",eac3"
+        audio = audio + ",eac3"
     end if
 
     return [


### PR DESCRIPTION
Now Roku is using PlayBackInfo to let the server decide when transcoding is required, the information we send to the server on supported codecs is more important.  Seemingly "hevc" requires to be sent (we were just sending h265") when hevc is supported by the Roku device

**Changes**
 - Add `hevc` to list of supported codecs when hardware supported
 - Support `eac3` in mp4 container

**Issues**
refs #455