### PR TITLE
Support MPEG2 codec when available

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -380,6 +380,16 @@ sub Main (args as dynamic) as void
                 SignOut()
                 wipe_groups()
                 goto app_start
+            else if button.id = "play_mpeg2"
+                playMpeg2 = get_setting("playback.mpeg2")
+                if playMpeg2 = "true"
+                    playMpeg2 = "false"
+                    button.title = tr("MPEG2 Support: Off")
+                else
+                    playMpeg2 = "true"
+                    button.title = tr("MPEG2 Support: On")
+                end if
+                set_setting("playback.mpeg2", playMpeg2)
             end if
         else if isNodeEvent(msg, "selectSubtitlePressed")
             node = m.scene.focusedChild

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -194,6 +194,22 @@ function CreateHomeGroup()
         new_options.push(o)
     end for
 
+    ' Add option for mpeg-2 playback
+    playMpeg2 = get_setting("playback.mpeg2")
+    if playMpeg2 = invalid
+        playMpeg2 = "true"
+        set_setting("playback.mpeg2", playMpeg2)
+    end if
+    o = CreateObject("roSGNode", "OptionsButton")
+    if playMpeg2 = "true"
+        o.title = tr("MPEG2 Support: On")
+    else
+        o.title = tr("MPEG2 Support: Off")
+    end if
+    o.id = "play_mpeg2"
+    o.observeField("optionSelected", m.port)
+    new_options.push(o)
+
     ' And a profile button
     user_node = CreateObject("roSGNode", "OptionsData")
     user_node.id = "active_user"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -17,6 +17,7 @@ end function
 
 
 function getDeviceProfile() as object
+    playMpeg2 = get_setting("playback.mpeg2") = "true"
 
     'Check if 5.1 Audio Output connected
     maxAudioChannels = 2
@@ -24,6 +25,19 @@ function getDeviceProfile() as object
     if di.GetAudioOutputChannel() = "5.1 surround"
         maxAudioChannels = 6
     end if
+
+    if playMpeg2 and di.CanDecodeVideo({ Codec: "mpeg2" }).Result = true
+        tsVideoCodecs = "h264,mpeg2video"
+    else
+        tsVideoCodecs = "h264"
+    end if
+
+    if di.CanDecodeAudio({ Codec: "ac3" }).result
+        tsAudioCodecs = "aac,ac3"
+    else
+        tsAudioCodecs = "aac"
+    end if
+
 
     return {
         "MaxStreamingBitrate": 120000000,
@@ -66,8 +80,8 @@ function getDeviceProfile() as object
             {
                 "Container": "ts",
                 "Type": "Video",
-                "AudioCodec": "aac",
-                "VideoCodec": "h264",
+                "AudioCodec": tsAudioCodecs,
+                "VideoCodec": tsVideoCodecs,
                 "Context": "Streaming",
                 "Protocol": "hls",
                 "MaxAudioChannels": StrI(maxAudioChannels) ' Currently Jellyfin server expects this as a string
@@ -142,6 +156,8 @@ function GetDirectPlayProfiles() as object
     mkvAudio = "mp3,pcm,lpcm,wav"
     audio = "mp3,pcm,lpcm,wav"
 
+    playMpeg2 = get_setting("playback.mpeg2") = "true"
+
     di = CreateObject("roDeviceInfo")
 
     'Check for Supported Video Codecs
@@ -152,6 +168,11 @@ function GetDirectPlayProfiles() as object
 
     if di.CanDecodeVideo({ Codec: "vp9" }).Result = true
         mkvVideo = mkvVideo + ",vp9"
+    end if
+
+    if playMpeg2 and di.CanDecodeVideo({ Codec: "mpeg2" }).Result = true
+        mp4Video = mp4Video + ",mpeg2video"
+        mkvVideo = mkvVideo + ",mpeg2video"
     end if
 
     ' Check for supported Audio


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Support playing video using the MPEG-2 codec when supported by the device. Enabled by option since MPEG-2 requires high bandwidth and some users report issues with MPEG-2 decoding on some Roku models.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
