### PR TITLE
Add Max Audio Channel condition to supported codecs

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -38,12 +38,13 @@ function getDeviceProfile() as object
         tsAudioCodecs = "aac"
     end if
 
+    DirectPlayProfile = GetDirectPlayProfiles()
 
     return {
         "MaxStreamingBitrate": 120000000,
         "MaxStaticBitrate": 100000000,
         "MusicStreamingTranscodingBitrate": 192000,
-        "DirectPlayProfiles": GetDirectPlayProfiles(),
+        "DirectPlayProfiles": DirectPlayProfile,
         "TranscodingProfiles": [
             {
                 "Container": "aac",
@@ -107,6 +108,18 @@ function getDeviceProfile() as object
                         "Condition": "Equals",
                         "Property": "IsSecondaryAudio",
                         "Value": "false",
+                        "IsRequired": false
+                    }
+                ]
+            },
+            {
+                "Type": "VideoAudio",
+                "Codec": DirectPlayProfile[1].AudioCodec,  ' Use supported MKV Audio list
+                "Conditions": [
+                    {
+                        "Condition": "LessThanEqual",
+                        "Property": "AudioChannels",
+                        "Value": StrI(maxAudioChannels) ' Currently Jellyfin server expects this as a string
                         "IsRequired": false
                     }
                 ]

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -114,7 +114,7 @@ function getDeviceProfile() as object
             },
             {
                 "Type": "VideoAudio",
-                "Codec": DirectPlayProfile[1].AudioCodec,  ' Use supported MKV Audio list
+                "Codec": DirectPlayProfile[1].AudioCodec, ' Use supported MKV Audio list
                 "Conditions": [
                     {
                         "Condition": "LessThanEqual",


### PR DESCRIPTION
Server was not providing a transcoding URL when the number of Audio Channels in the media was greater than was supported on the device.

Added a Codec Condition to the Device Profile to specify Audio Channels must be less than or equal to the number supported by the client.

**Issues**
fixes #491
fixes #267
