### PR TITLE
Fixed Mark Watched functionality

### DIFF
--- a/source/api/UserLibrary.brs
+++ b/source/api/UserLibrary.brs
@@ -13,15 +13,10 @@ end function
 
 sub MarkItemWatched(id as string)
     date = CreateObject("roDateTime")
-    dateStr = stri(date.getYear()).trim()
-    dateStr += leftPad(stri(date.getMonth()).trim(), "0", 2)
-    dateStr += leftPad(stri(date.getDayOfMonth()).trim(), "0", 2)
-    dateStr += leftPad(stri(date.getHours()).trim(), "0", 2)
-    dateStr += leftPad(stri(date.getMinutes()).trim(), "0", 2)
-    dateStr += leftPad(stri(date.getSeconds()).trim(), "0", 2)
-
+    dateStr = date.ToISOString()
     url = Substitute("Users/{0}/PlayedItems/{1}", get_setting("active_user"), id)
-    APIRequest(url, { "DatePlayed": dateStr })
+    req = APIRequest(url)
+    postVoid(req, FormatJson({ "DatePlayed": dateStr }))
 end sub
 
 function UnmarkItemWatched(id as string)

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -76,13 +76,20 @@ function getJson(req)
     return json
 end function
 
-function postVoid(req, data = "" as string)
-    status = req.PostFromString(data)
-    if status = 200
-        return true
-    else
+function postVoid(req, data = "" as string) as boolean
+    req.setMessagePort(CreateObject("roMessagePort"))
+    req.AddHeader("Content-Type", "application/json")
+    req.AsyncPostFromString(data)
+    resp = wait(30000, req.GetMessagePort())
+    if type(resp) <> "roUrlEvent"
         return false
     end if
+
+    if resp.GetResponseCode() = 200
+        return true
+    end if
+
+    return false
 end function
 
 function postJson(req, data = "" as string)


### PR DESCRIPTION
Mark Watched call was using a GET request to the server which is now failing.  Request needs to be sent as a POST request.

**Changes**
 - Change Mark Watched to use POST request to server
 - Updated `postVoid` function to use Async call
 - Updated Mark Watched to use inbuild date `ToIsoString()`, rather than building ISO date manually