### PR TITLE
Prevent Login Screens hiding main Scene

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -365,7 +365,6 @@ function LoginFlow(startOver = false as boolean)
                 publicUsersNodes.push(user)
             end for
             userSelected = CreateUserSelectGroup(publicUsersNodes)
-            m.scene.focusedChild.visible = false
             if userSelected = "backPressed"
                 SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
                 return LoginFlow(true)
@@ -385,7 +384,6 @@ function LoginFlow(startOver = false as boolean)
         passwordEntry = CreateSigninGroup(userSelected)
         SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
         if passwordEntry = "backPressed"
-            m.scene.focusedChild.visible = false
             return LoginFlow(true)
         end if
     end if


### PR DESCRIPTION
New Scene Manager implemented in #492 now handles the visibility of screens in the screen stack, and individual screens should not be showing/hiding screens themselves.

The login screens were still doing then when the user was selected and when back was pressed, resulting in the login process showing blank screens.

**Changes**
 - Prevent login screens from hiding themselves and leave to Scene Manager
