### PR TITLE
Set MediaSourceId to the correct value, not the videoId

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -56,12 +56,12 @@ sub AddVideoContent(video, audio_stream_idx = 1, subtitle_idx = -1, playbackPosi
     video.content.PlayStart = int(playbackPosition / 10000000)
 
     ' Call PlayInfo from server
-    mediaSourceId = video.id
+    mediaSourceId = video.mediaSourceId
     if meta.live then mediaSourceId = "" ' Don't send mediaSourceId for Live media
     playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
 
     video.videoId = video.id
-    video.mediaSourceId = video.id
+    video.mediaSourceId = video.mediaSourceId
     video.audioIndex = audio_stream_idx
 
     if playbackInfo = invalid

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -61,7 +61,6 @@ sub AddVideoContent(video, audio_stream_idx = 1, subtitle_idx = -1, playbackPosi
     playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
 
     video.videoId = video.id
-    video.mediaSourceId = video.mediaSourceId
     video.audioIndex = audio_stream_idx
 
     if playbackInfo = invalid


### PR DESCRIPTION
Roku client is incorrectly setting the `MediaSourceId` to the video id

**Changes**
 - Set `MediaSourceId` to the correct value

**Issues**
fixes #467 
fixes #397
