### PR TITLE
Display dialog when a required transcode url is not provided by the server

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -173,3 +173,21 @@ sub resetTime()
     ' Passthrough to overhang
     m.overhang.callFunc("resetTime")
 end sub
+
+'
+' Display dialog to user with an OK button
+sub userMessage(title as string, message as string)
+    dialog = createObject("roSGNode", "Dialog")
+    dialog.title = title
+    dialog.message = message
+    dialog.buttons = [tr("OK")]
+    dialog.observeField("buttonSelected", "dismiss_dialog")
+    m.scene.dialog = dialog
+end sub
+
+'
+' Close currently displayed dialog
+sub dismiss_dialog()
+    print "Button Pressed"
+    m.scene.dialog.close = true
+end sub

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -6,6 +6,7 @@
     <function name="getActiveScene" />
     <function name="clearScenes" />
     <function name="resetTime" />
+    <function name="userMessage" />
     <field id="currentUser" type="string" onChange="updateUser" />
   </interface>
   <script type="text/brightscript" uri="SceneManager.brs" />

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -387,5 +387,15 @@
         <translation>…or enter server URL manually:</translation>
         <extracomment>Instructions on initial app launch when the user is asked to manually enter a server URL</extracomment>
     </message>
+    <message>
+        <source>Error Getting Playback Information</source>
+        <translation>Error Getting Playback Information</translation>
+        <extracomment>Dialog Title: Received error from server when trying to get information about the selected item for playback</extracomment>
+    </message>
+    <message>
+        <source>An error was encountered while playing this item.  Server did not provide required transcoding data.</source>
+        <translation>An error was encountered while playing this item.  Server did not provide required transcoding data.</translation>
+        <extracomment>Content of message box when trying to play an item which requires transcoding, and the server did not provide transcode url</extracomment>
+    </message>
 </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -379,5 +379,15 @@
         <translation>…or enter server URL manually:</translation>
         <extracomment>Instructions on initial app launch when the user is asked to manually enter a server URL</extracomment>
     </message>
+    <message>
+        <source>Error Getting Playback Information</source>
+        <translation>Error Getting Playback Information</translation>
+        <extracomment>Dialog Title: Received error from server when trying to get information about the selected item for playback</extracomment>
+    </message>
+    <message>
+        <source>An error was encountered while playing this item.  Server did not provide required transcoding data.</source>
+        <translation>An error was encountered while playing this item.  Server did not provide required transcoding data.</translation>
+        <extracomment>Content of message box when trying to play an item which requires transcoding, and the server did not provide transcode url</extracomment>
+    </message>
 </context>
 </TS>

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -107,6 +107,12 @@ sub AddVideoContent(video, audio_stream_idx = 1, subtitle_idx = -1, playbackPosi
         video.content.url = buildURL(Substitute("Videos/{0}/stream", video.id), params)
         video.isTranscoded = false
     else
+        ' If server does not provide a transcode URL, display a message to the user
+        if playbackInfo.MediaSources[0].TranscodingUrl = invalid
+            m.global.sceneManager.callFunc("userMessage", tr("Error Getting Playback Information"), tr("An error was encountered while playing this item.  Server did not provide required transcoding data."))
+            video.content = invalid
+            return
+        end if
 
         ' Get transcoding reason
         video.transcodeReasons = getTranscodeReasons(playbackInfo.MediaSources[0].TranscodingUrl)


### PR DESCRIPTION
When a media item does not support direct play, and the server does not provide a transcode url, then display a message to the user  rather than crashing

**Changes**
 - Capture an invalid video before trying to play it if transcode URL is required but not set
 - Create simple Message Box function in Scene Manager to display simple message dialog to user
 - Display message to user when transcode url is missing

**Issues**
fixes #502
