### PR TITLE
Feature/482 add livetv onnow

### DIFF
--- a/components/ItemGrid/GridItem.brs
+++ b/components/ItemGrid/GridItem.brs
@@ -49,7 +49,7 @@ sub itemContentChanged()
         m.itemPoster.uri = itemData.PosterUrl
         m.itemText.text = itemData.Title
     else
-        print "Unhandled Item Type: " + itemData.type
+        print "Unhandled Grid Item Type: " + itemData.type
     end if
 
     'If Poster not loaded, ensure "blue box" is shown until loaded

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -59,7 +59,7 @@ sub itemContentChanged()
     ' "Program" is from clicking on an "On Now" item on the Home Screen
     if itemData.type = "Program"
         m.itemText.Text = itemData.json.name
-        if (itemData.json.ImageURL <> invalid)
+        if itemData.json.ImageURL <> invalid
             m.itemPoster.uri = itemData.json.ImageURL
         end if
 

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -56,6 +56,7 @@ sub itemContentChanged()
     m.itemTextExtra.visible = true
     m.itemTextExtra.font.size = 22
 
+    ' "Program" is from clicking on an "On Now" item on the Home Screen
     if itemData.type = "Program"
         m.itemText.Text = itemData.json.name
         if (itemData.json.ImageURL <> invalid)

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -56,6 +56,19 @@ sub itemContentChanged()
     m.itemTextExtra.visible = true
     m.itemTextExtra.font.size = 22
 
+    if itemData.type = "Program"
+        m.itemText.Text = itemData.json.name
+        if (itemData.json.ImageURL <> invalid)
+            m.itemPoster.uri = itemData.json.ImageURL
+        end if
+
+        ' Set Episode title if available 
+        if itemData.json.EpisodeTitle <> invalid
+            m.itemTextExtra.text = itemData.json.EpisodeTitle
+        end if
+
+        return
+    end if
 
     if itemData.type = "Episode"
         m.itemText.text = itemData.json.SeriesName
@@ -156,7 +169,7 @@ sub itemContentChanged()
         return
     end if
 
-    print "Unhandled Item Type: " + itemData.type
+    print "Unhandled Home Item Type: " + itemData.type
 
 end sub
 

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -63,7 +63,7 @@ sub itemContentChanged()
             m.itemPoster.uri = itemData.json.ImageURL
         end if
 
-        ' Set Episode title if available 
+        ' Set Episode title if available
         if itemData.json.EpisodeTitle <> invalid
             m.itemTextExtra.text = itemData.json.EpisodeTitle
         end if

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -12,4 +12,7 @@
     <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>
   <script type="text/brightscript" uri="HomeItem.brs" />
+  <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -25,7 +25,7 @@ sub init()
     m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadNextUpTask.itemsToLoad = "nextUp"
     m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
-    m.LoadOnNowTask.itemsToLoad = "onNow" 
+    m.LoadOnNowTask.itemsToLoad = "onNow"
 end sub
 
 sub loadLibraries()
@@ -100,7 +100,7 @@ sub onLibrariesLoaded()
     m.LoadContinueTask.control = "RUN"
 
     ' If we have Live TV access, load "On Now" data
-    if haveLiveTV 
+    if haveLiveTV
         m.LoadOnNowTask.observeField("content", "updateOnNowItems")
         m.LoadOnNowTask.control = "RUN"
     end if

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -24,8 +24,6 @@ sub init()
     m.LoadContinueTask.itemsToLoad = "continue"
     m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadNextUpTask.itemsToLoad = "nextUp"
-    m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
-    m.LoadOnNowTask.itemsToLoad = "onNow"
 end sub
 
 sub loadLibraries()
@@ -83,9 +81,13 @@ sub onLibrariesLoaded()
                 sizeArray.Push([464, 331])
             else if lib.collectionType = "livetv"
                 ' If we have Live TV, add "On Now"
+                m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
+                m.LoadOnNowTask.itemsToLoad = "onNow" 
                 onNowRow = content.CreateChild("HomeRow")
                 onNowRow.title = tr("On Now")
                 sizeArray.Push([464, 331])
+                m.LoadOnNowTask.observeField("content", "updateOnNowItems")
+                m.LoadOnNowTask.control = "RUN"                    
             end if
         end for
     end if
@@ -212,9 +214,6 @@ sub updateNextUpItems()
             loadLatest.control = "RUN"
         end if
     end for
-
-    m.LoadOnNowTask.observeField("content", "updateOnNowItems")
-    m.LoadOnNowTask.control = "RUN"    
 end sub
 
 sub updateLatestItems(msg)

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -100,7 +100,7 @@ sub onLibrariesLoaded()
     m.LoadContinueTask.control = "RUN"
 
     ' If we have Live TV access, load "On Now" data
-    if haveLiveTV then
+    if haveLiveTV 
         m.LoadOnNowTask.observeField("content", "updateOnNowItems")
         m.LoadOnNowTask.control = "RUN"
     end if

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -99,7 +99,7 @@ sub onLibrariesLoaded()
     m.LoadContinueTask.observeField("content", "updateContinueItems")
     m.LoadContinueTask.control = "RUN"
 
-    ' If we have Live TV access, load On Now data
+    ' If we have Live TV access, load "On Now" data
     if haveLiveTV then
         m.LoadOnNowTask.observeField("content", "updateOnNowItems")
         m.LoadOnNowTask.control = "RUN"

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -24,6 +24,8 @@ sub init()
     m.LoadContinueTask.itemsToLoad = "continue"
     m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadNextUpTask.itemsToLoad = "nextUp"
+    m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
+    m.LoadOnNowTask.itemsToLoad = "onNow"
 end sub
 
 sub loadLibraries()
@@ -78,6 +80,11 @@ sub onLibrariesLoaded()
             if lib.collectionType <> "boxsets" and lib.collectionType <> "livetv"
                 latestInRow = content.CreateChild("HomeRow")
                 latestInRow.title = tr("Latest in") + " " + lib.name + " >"
+                sizeArray.Push([464, 331])
+            else if lib.collectionType = "livetv"
+                ' If we have Live TV, add "On Now"
+                onNowRow = content.CreateChild("HomeRow")
+                onNowRow.title = tr("On Now")
                 sizeArray.Push([464, 331])
             end if
         end for
@@ -192,7 +199,7 @@ sub updateNextUpItems()
     userConfig = m.top.userConfig
     filteredLatest = filterNodeArray(m.libraryData, "id", userConfig.LatestItemsExcludes)
     for each lib in filteredLatest
-        if lib.collectionType <> "livetv" and lib.collectionType <> "boxsets"
+        if lib.collectionType <> "livetv" and lib.collectionType <> "boxsets" and lib.json.CollectionType <> "Program"
             loadLatest = createObject("roSGNode", "LoadItemsTask")
             loadLatest.itemsToLoad = "latest"
             loadLatest.itemId = lib.id
@@ -205,6 +212,9 @@ sub updateNextUpItems()
             loadLatest.control = "RUN"
         end if
     end for
+
+    m.LoadOnNowTask.observeField("content", "updateOnNowItems")
+    m.LoadOnNowTask.control = "RUN"    
 end sub
 
 sub updateLatestItems(msg)
@@ -256,6 +266,44 @@ sub updateLatestItems(msg)
             ' replace the old row
             updateSizeArray(itemSize, rowIndex, "replace")
             homeRows.replaceChild(row, rowIndex)
+        end if
+    end if
+end sub
+
+sub updateOnNowItems()
+    itemData = m.LoadOnNowTask.content
+    m.LoadOnNowTask.unobserveField("content")
+    m.LoadOnNowTask.content = []
+
+    if itemData = invalid then return
+
+    homeRows = m.top.content
+    onNowRowIndex = getRowIndex("On Now")
+
+    if itemData.count() < 1
+        if onNowRowIndex <> invalid
+            ' remove the row
+            deleteFromSizeArray(onNowRowIndex)
+            homeRows.removeChildIndex(onNowRowIndex)
+        end if
+    else
+        ' remake row using the new data
+        row = CreateObject("roSGNode", "HomeRow")
+        row.title = tr("On Now")
+        itemSize = [464, 331]
+        for each item in itemData
+            item.usePoster = row.usePoster
+            item.imageWidth = row.imageWidth
+            row.appendChild(item)
+        end for
+
+        if onNowRowIndex = invalid
+            ' insert new row under "My Media"
+            updateSizeArray(itemSize, 1)
+            homeRows.insertChild(row, 1)
+        else
+            ' replace the old row
+            homeRows.replaceChild(row, onNowRowIndex)
         end if
     end if
 end sub

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -24,6 +24,8 @@ sub init()
     m.LoadContinueTask.itemsToLoad = "continue"
     m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadNextUpTask.itemsToLoad = "nextUp"
+    m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
+    m.LoadOnNowTask.itemsToLoad = "onNow" 
 end sub
 
 sub loadLibraries()
@@ -64,6 +66,7 @@ sub onLibrariesLoaded()
         [464, 331], ' Continue Watching
         [464, 331] ' Next Up
     ]
+    haveLiveTV = false
     ' validate library data
     if m.libraryData <> invalid and m.libraryData.count() > 0
         userConfig = m.top.userConfig
@@ -81,13 +84,10 @@ sub onLibrariesLoaded()
                 sizeArray.Push([464, 331])
             else if lib.collectionType = "livetv"
                 ' If we have Live TV, add "On Now"
-                m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
-                m.LoadOnNowTask.itemsToLoad = "onNow" 
                 onNowRow = content.CreateChild("HomeRow")
                 onNowRow.title = tr("On Now")
                 sizeArray.Push([464, 331])
-                m.LoadOnNowTask.observeField("content", "updateOnNowItems")
-                m.LoadOnNowTask.control = "RUN"                    
+                haveLiveTV = true
             end if
         end for
     end if
@@ -98,6 +98,12 @@ sub onLibrariesLoaded()
     ' Load the Continue Watching Data
     m.LoadContinueTask.observeField("content", "updateContinueItems")
     m.LoadContinueTask.control = "RUN"
+
+    ' If we have Live TV access, load On Now data
+    if haveLiveTV then
+        m.LoadOnNowTask.observeField("content", "updateOnNowItems")
+        m.LoadOnNowTask.control = "RUN"
+    end if
 end sub
 
 sub updateHomeRows()

--- a/components/home/LoadItemsTask.brs
+++ b/components/home/LoadItemsTask.brs
@@ -74,7 +74,28 @@ sub loadItems()
             tmp.json = item
             results.push(tmp)
         end for
+
+    else if m.top.itemsToLoad = "onNow" 
+        url =  "LiveTv/Programs/Recommended"
+        params = {}
+        params["userId"] = get_setting("active_user")
+        params["isAiring"] = true
+        params["limit"] = 16
+        params["imageTypeLimit"] = 1
+        params["enableImageTypes"] = "Primary,Thumb,Backdrop"
+        params["enableTotalRecordCount"] = false
+        params["fields"] = "ChannelInfo,PrimaryImageAspectRatio"
+
+        resp = APIRequest(url, params)
+        data = getJson(resp)
+        for each item in data.Items
+            tmp = CreateObject("roSGNode", "HomeData")
+            item.ImageURL = ImageURL(item.Id)
+            tmp.json = item
+            results.push(tmp)
+        end for
     end if
+
     m.top.content = results
 
 end sub

--- a/components/home/LoadItemsTask.brs
+++ b/components/home/LoadItemsTask.brs
@@ -80,7 +80,7 @@ sub loadItems()
         params = {}
         params["userId"] = get_setting("active_user")
         params["isAiring"] = true
-        params["limit"] = 16
+        params["limit"] = 16    ' 16 to be consistent with "Latest In"
         params["imageTypeLimit"] = 1
         params["enableImageTypes"] = "Primary,Thumb,Backdrop"
         params["enableTotalRecordCount"] = false

--- a/components/home/LoadItemsTask.brs
+++ b/components/home/LoadItemsTask.brs
@@ -75,12 +75,12 @@ sub loadItems()
             results.push(tmp)
         end for
 
-    else if m.top.itemsToLoad = "onNow" 
-        url =  "LiveTv/Programs/Recommended"
+    else if m.top.itemsToLoad = "onNow"
+        url = "LiveTv/Programs/Recommended"
         params = {}
         params["userId"] = get_setting("active_user")
         params["isAiring"] = true
-        params["limit"] = 16    ' 16 to be consistent with "Latest In"
+        params["limit"] = 16 ' 16 to be consistent with "Latest In"
         params["imageTypeLimit"] = 1
         params["enableImageTypes"] = "Primary,Thumb,Backdrop"
         params["enableTotalRecordCount"] = false

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -109,6 +109,10 @@
         <translation>Latest in</translation>
     </message>
     <message>
+        <source>On Now</source>
+        <translation>On Now</translation>
+    </message>    
+    <message>
         <source>Home</source>
         <translation>Home</translation>
     </message>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -112,7 +112,7 @@ sub Main (args as dynamic) as void
             else if selectedItem.type = "Movie"
                 ' open movie detail page
                 group = CreateMovieDetailsGroup(selectedItem)
-            else if selectedItem.type = "TvChannel" or selectedItem.type = "Video"
+            else if selectedItem.type = "TvChannel" or selectedItem.type = "Video" or selectedItem.type = "Program"
                 ' play channel feed
                 video_id = selectedItem.id
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -26,6 +26,14 @@ sub AddVideoContent(video, audio_stream_idx = 1, subtitle_idx = -1, playbackPosi
         return
     end if
 
+    ' Special handling for "Programs" launched from "On Now"
+    if meta.json.type = "Program"
+        meta.title = meta.json.EpisodeTitle
+        meta.showID = meta.json.id
+        meta.live = true
+        video.id = meta.json.ChannelId
+    end if
+
     video.content.title = meta.title
     video.showID = meta.showID
 

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -107,7 +107,7 @@ function ItemMetaData(id as string)
         tmp.image = PosterImage(data.id)
         tmp.json = data
         return tmp
-    else if data.type = "TvChannel"
+    else if data.type = "TvChannel" or data.type = "Program"
         tmp = CreateObject("roSGNode", "ChannelData")
         tmp.image = PosterImage(data.id)
         tmp.json = data


### PR DESCRIPTION
Adds "On Now" section to the Home Screen if the user has access to Live TV 

Issues
Fixes #482 

Known Issue:
Just like the web version, if the server does not have poster/thumbnails for the "On Now" data, you just get a blue square (but still with Title / Episode data below the square).  When images are present they display correctly.