### PR TITLE
Feature/save servers

### DIFF
--- a/components/JFScene.brs
+++ b/components/JFScene.brs
@@ -11,7 +11,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else if key = "options"
         group = m.global.sceneManager.callFunc("getActiveScene")
-        if group.optionsAvailable
+        if group <> invalid and group.optionsAvailable
             group.lastFocus = group.focusedChild
             panel = group.findNode("options")
             panel.visible = true

--- a/components/config/ConfigScene.brs
+++ b/components/config/ConfigScene.brs
@@ -8,18 +8,24 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
     list = m.top.findNode("configOptions")
+    checkbox = m.top.findNode("onOff")
     button = m.top.findNode("submit")
     if key = "back"
         m.top.backPressed = true
-    else if key = "down" and button.focusedChild = invalid
+    else if key = "down" and checkbox.focusedChild = invalid and button.focusedChild = invalid
         limit = list.content.getChildren(-1, 0).count() - 1
 
         if limit = list.itemFocused
-            m.top.setFocus(false)
-            button.setFocus(true)
+            checkbox.setFocus(true)
             return true
         end if
+    else if key = "down" and button.focusedChild = invalid
+        button.setFocus(true)
+        return true
     else if key = "up" and button.focusedChild <> invalid
+        checkbox.setFocus(true)
+        return true
+    else if key = "up" and checkbox.focusedChild <> invalid
         list.setFocus(true)
         return true
     end if

--- a/components/config/ConfigScene.xml
+++ b/components/config/ConfigScene.xml
@@ -8,21 +8,20 @@
     <ConfigList
       id="configOptions"
       translation="[150, 240]" />
-    <label text=""
-      id="example"
-      font="font:smallSystemFont"
-      translation="[150, 350]" />
+    <CheckList
+      id="onOff"
+      translation="[200, 450]" />
     <Button
       id="submit"
       text="Submit"
       showFocusFootprint="false"
-      translation="[150, 450]" />
+      translation="[150, 550]" />
     <label text=""
       id="alert"
       wrap="true"
       width="1620"
       font="font:MediumSystemFont"
-      translation="[150, 580]" />
+      translation="[150, 680]" />
   </children>
   <script type="text/brightscript" uri="ConfigScene.brs"/>
 </component>

--- a/components/config/SetServerScreen.brs
+++ b/components/config/SetServerScreen.brs
@@ -38,7 +38,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "down" and m.serverUrlContainer.hasFocus()
         m.submit.setFocus(true)
     else if key = "options"
-        if m.serverPicker.content.getChild(m.serverPicker.itemFocused).name = "Saved"
+        serverName = m.serverPicker.content.getChild(m.serverPicker.itemFocused).name
+        if m.servers.Count() > 0 and Instr(1, serverName, "Saved") > 0
             'Can only delete previously saved servers, not locally discovered ones
             'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
             handled = false
@@ -76,13 +77,14 @@ sub ScanForServersComplete(event)
         for each server in savedServers.serverList
             alreadyListed = false
             for each listed in m.servers
-                if listed.baseUrl = server.baseUrl
+                if LCase(listed.baseUrl) = server.baseUrl 'saved server data is always lowercase
                     alreadyListed = true
                     exit for
                 end if
             end for
             if alreadyListed = false
                 items.update([server], true)
+                m.servers.push(server)
             end if
         end for
     end if

--- a/components/config/SetServerScreen.brs
+++ b/components/config/SetServerScreen.brs
@@ -37,12 +37,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         'focus the submit button from serverUrl
     else if key = "down" and m.serverUrlContainer.hasFocus()
         m.submit.setFocus(true)
-    else if key = "options" 
+    else if key = "options"
         if m.serverPicker.content.getChild(m.serverPicker.itemFocused).name = "Saved"
             'Can only delete previously saved servers, not locally discovered ones
             'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
             handled = false
-        end if            
+        end if
     else
         handled = false
     end if
@@ -83,7 +83,7 @@ sub ScanForServersComplete(event)
             end for
             if alreadyListed = false
                 items.update([server], true)
-            end if 
+            end if
         end for
     end if
 

--- a/components/config/SetServerScreen.brs
+++ b/components/config/SetServerScreen.brs
@@ -14,7 +14,7 @@ sub init()
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    print "SetServerScren onKeyEvent", key, press
+    print "SetServerScreen onKeyEvent", key, press
 
     if not press then return true
     handled = true

--- a/components/config/SetServerScreen.xml
+++ b/components/config/SetServerScreen.xml
@@ -33,8 +33,10 @@
       </LayoutGroup>
     </LayoutGroup>
 
+    <OptionsSlider id="options" />
   </children>
 
   <script type="text/brightscript" uri="SetServerScreen.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 
 </component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -93,6 +93,10 @@
         <translation>Profile</translation>
     </message>
     <message>
+        <source>Save Credentials?</source>
+        <translation>Save Credentials?</translation>
+    </message>    
+    <message>
         <source>Delete Saved</source>
         <translation>Delete Saved</translation>
     </message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -93,6 +93,10 @@
         <translation>Profile</translation>
     </message>
     <message>
+        <source>Delete Saved</source>
+        <translation>Delete Saved</translation>
+    </message>
+    <message>
         <source>My Media</source>
         <translation>My Media</translation>
     </message>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -415,9 +415,9 @@ sub SaveServerList()
     entryCount = 0
     addNewEntry = true
     savedServers = { serverList: [] }
-    if saved <> invalid 
+    if saved <> invalid
         savedServers = ParseJson(saved)
-        entryCount = savedServers.serverList.Count() 
+        entryCount = savedServers.serverList.Count()
         if savedServers.serverList <> invalid and entryCount > 0
             for each item in savedServers.serverList
                 if item.baseUrl = LCase(server) 'Saved server data is always lowercase
@@ -427,9 +427,9 @@ sub SaveServerList()
             end for
         end if
     end if
-   
+
     if addNewEntry
-        if entryCount = 0 
+        if entryCount = 0
             set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
         else
             savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -412,6 +412,9 @@ sub SaveServerList()
     'Save off this server to our list of saved servers for easier navigation between servers
     server = get_setting("server")
     saved = get_setting("saved_servers")
+    if server <> invalid
+        server = LCase(server)'Saved server data is always lowercase
+    end if
     entryCount = 0
     addNewEntry = true
     savedServers = { serverList: [] }
@@ -420,7 +423,7 @@ sub SaveServerList()
         entryCount = savedServers.serverList.Count()
         if savedServers.serverList <> invalid and entryCount > 0
             for each item in savedServers.serverList
-                if item.baseUrl = LCase(server) 'Saved server data is always lowercase
+                if item.baseUrl = server
                     addNewEntry = false
                     exit for
                 end if
@@ -440,11 +443,14 @@ end sub
 
 sub DeleteFromServerList(urlToDelete)
     saved = get_setting("saved_servers")
+    if urlToDelete <> invalid
+        urlToDelete = LCase(urlToDelete)
+    end if
     if saved <> invalid
         savedServers = ParseJson(saved)
         newServers = { serverList: [] }
         for each item in savedServers.serverList
-            if item.baseUrl <> LCase(urlToDelete) 'saved server data is always lowercase
+            if item.baseUrl <> urlToDelete
                 newServers.serverList.Push(item)
             end if
         end for

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -433,7 +433,7 @@ sub SaveServerList()
 
     if addNewEntry
         if entryCount = 0
-            set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+            set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: server, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
         else
             savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -245,7 +245,7 @@ sub Main (args as dynamic) as void
             else if button.id = "change_server"
                 unset_setting("server")
                 unset_setting("port")
-                SignOut()
+                SignOut(false)
                 sceneManager.callFunc("clearScenes")
                 goto app_start
             else if button.id = "sign_out"
@@ -433,9 +433,9 @@ sub SaveServerList()
 
     if addNewEntry
         if entryCount = 0
-            set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+            set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: server, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
         else
-            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
+            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: server, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))
         end if
     end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -338,12 +338,13 @@ function LoginFlow(startOver = false as boolean)
         dialog.close = true
     end if
 
+    m.serverSelection = "Saved"
     if startOver or invalidServer
         print "Get server details"
         SendPerformanceBeacon("AppDialogInitiate") ' Roku Performance monitoring - Dialog Starting
-        serverSelection = CreateServerGroup()
+        m.serverSelection = CreateServerGroup()
         SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
-        if serverSelection = "backPressed"
+        if m.serverSelection = "backPressed"
             print "backPressed"
             m.global.sceneManager.callFunc("clearScenes")
             return false
@@ -416,17 +417,17 @@ sub SaveServerList()
     if saved <> invalid
         savedServers = ParseJson(saved)
         for each item in savedServers.serverList
-            if item.baseUrl = server
+            if item.baseUrl = LCase(server) 'Saved server data is always lowercase
                 alreadySaved = true
                 exit for
             end if
         end for
         if alreadySaved = false
-            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
+            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))
         end if
     else
-        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+        set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
     end if
 end sub
 
@@ -436,7 +437,7 @@ sub DeleteFromServerList(urlToDelete)
         savedServers = ParseJson(saved)
         newServers = { serverList: [] }
         for each item in savedServers.serverList
-            if item.baseUrl <> urlToDelete
+            if item.baseUrl <> LCase(urlToDelete) 'saved server data is always lowercase
                 newServers.serverList.Push(item)
             end if
         end for

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -373,6 +373,7 @@ function LoginFlow(startOver = false as boolean)
                 get_token(userSelected, "")
                 if get_setting("active_user") <> invalid
                     m.user = AboutMe()
+                    SaveServerList()
                     LoadUserPreferences()
                     SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
                     return true
@@ -395,6 +396,7 @@ function LoginFlow(startOver = false as boolean)
         goto start_login
     end if
 
+    SaveServerList()
     LoadUserPreferences()
     m.global.sceneManager.callFunc("clearScenes")
 
@@ -405,6 +407,42 @@ function LoginFlow(startOver = false as boolean)
     postJson(req, FormatJson(body))
     return true
 end function
+
+sub SaveServerList()
+    'Save off this server to our list of saved servers for easier navigation between servers
+    server = get_setting("server")
+    alreadySaved = false
+    saved = get_setting("saved_servers")
+    if saved <> invalid
+        savedServers = ParseJson(saved)
+        for each item in savedServers.serverList
+            if item.baseUrl = server
+                alreadySaved = true
+                exit for
+            end if
+        end for
+        if alreadySaved = false
+            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user})
+            set_setting("saved_servers", FormatJson(savedServers))
+        end if
+    else
+        set_setting("saved_servers", FormatJson({ serverList: [{name: "Saved", baseUrl: server, username: m.user}]}))
+    end if
+end sub
+
+sub DeleteFromServerList(urlToDelete)
+    saved = get_setting("saved_servers")
+    if saved <> invalid
+        savedServers = ParseJson(saved)
+        newServers = {serverList: []}
+        for each item in savedServers.serverList
+            if item.baseUrl <> urlToDelete
+                newServers.serverList.Push(item)
+            end if
+        end for
+        set_setting("saved_servers", FormatJson(newServers))
+    end if
+end sub
 
 sub RunScreenSaver()
     print "Starting screensaver..."

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -435,7 +435,7 @@ sub SaveServerList()
         if entryCount = 0
             set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: server, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
         else
-            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
+            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: server, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))
         end if
     end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -422,11 +422,11 @@ sub SaveServerList()
             end if
         end for
         if alreadySaved = false
-            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120})
+            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))
         end if
     else
-        set_setting("saved_servers", FormatJson({ serverList: [{name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120}]}))
+        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
     end if
 end sub
 
@@ -434,7 +434,7 @@ sub DeleteFromServerList(urlToDelete)
     saved = get_setting("saved_servers")
     if saved <> invalid
         savedServers = ParseJson(saved)
-        newServers = {serverList: []}
+        newServers = { serverList: [] }
         for each item in savedServers.serverList
             if item.baseUrl <> urlToDelete
                 newServers.serverList.Push(item)

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -422,11 +422,11 @@ sub SaveServerList()
             end if
         end for
         if alreadySaved = false
-            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user})
+            savedServers.serverList.Push({ name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120})
             set_setting("saved_servers", FormatJson(savedServers))
         end if
     else
-        set_setting("saved_servers", FormatJson({ serverList: [{name: "Saved", baseUrl: server, username: m.user}]}))
+        set_setting("saved_servers", FormatJson({ serverList: [{name: "Saved", baseUrl: server, username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120}]}))
     end if
 end sub
 

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -386,6 +386,7 @@ function LoginFlow(startOver = false as boolean)
         passwordEntry = CreateSigninGroup(userSelected)
         SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
         if passwordEntry = "backPressed"
+            m.global.sceneManager.callFunc("clearScenes")
             return LoginFlow(true)
         end if
     end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -349,6 +349,7 @@ function LoginFlow(startOver = false as boolean)
             m.global.sceneManager.callFunc("clearScenes")
             return false
         end if
+        SaveServerList()
     end if
 
     if get_setting("active_user") = invalid
@@ -374,7 +375,6 @@ function LoginFlow(startOver = false as boolean)
                 get_token(userSelected, "")
                 if get_setting("active_user") <> invalid
                     m.user = AboutMe()
-                    SaveServerList()
                     LoadUserPreferences()
                     SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
                     return true
@@ -397,7 +397,6 @@ function LoginFlow(startOver = false as boolean)
         goto start_login
     end if
 
-    SaveServerList()
     LoadUserPreferences()
     m.global.sceneManager.callFunc("clearScenes")
 
@@ -412,22 +411,30 @@ end function
 sub SaveServerList()
     'Save off this server to our list of saved servers for easier navigation between servers
     server = get_setting("server")
-    alreadySaved = false
     saved = get_setting("saved_servers")
-    if saved <> invalid
+    entryCount = 0
+    addNewEntry = true
+    savedServers = { serverList: [] }
+    if saved <> invalid 
         savedServers = ParseJson(saved)
-        for each item in savedServers.serverList
-            if item.baseUrl = LCase(server) 'Saved server data is always lowercase
-                alreadySaved = true
-                exit for
-            end if
-        end for
-        if alreadySaved = false
-            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
+        entryCount = savedServers.serverList.Count() 
+        if savedServers.serverList <> invalid and entryCount > 0
+            for each item in savedServers.serverList
+                if item.baseUrl = LCase(server) 'Saved server data is always lowercase
+                    addNewEntry = false
+                    exit for
+                end if
+            end for
+        end if
+    end if
+   
+    if addNewEntry
+        if entryCount = 0 
+            set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+        else
+            savedServers.serverList.Push({ name: m.serverSelection, baseUrl: LCase(server), iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 })
             set_setting("saved_servers", FormatJson(savedServers))
         end if
-    else
-        set_setting("saved_servers", FormatJson({ serverList: [{ name: m.serverSelection, baseUrl: LCase(server), username: m.user.name, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
     end if
 end sub
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -143,11 +143,14 @@ function CreateSigninGroup(user = "")
 
     'Load in any saved server data and see if we can just log them in...
     server = get_setting("server")
+    if server <> invalid
+        server = LCase(server)'Saved server data is always lowercase
+    end if
     saved = get_setting("saved_servers")
     if saved <> invalid
         savedServers = ParseJson(saved)
         for each item in savedServers.serverList
-            if item.baseUrl = LCase(server) and item.username <> invalid and item.password <> invalid
+            if item.baseUrl = server and item.username <> invalid and item.password <> invalid
                 get_token(item.username, item.password)
                 if get_setting("active_user") <> invalid
                     return "true"
@@ -369,13 +372,15 @@ sub UpdateSavedServerList()
         return
     end if
 
+    server = LCase(server)'Saved server data is always lowercase
+
     saved = get_setting("saved_servers")
     if saved <> invalid
         savedServers = ParseJson(saved)
         if savedServers.serverList <> invalid and savedServers.serverList.Count() > 0
             newServers = { serverList: [] }
             for each item in savedServers.serverList
-                if item.baseUrl = LCase(server) ' Saved server data is always lowercase
+                if item.baseUrl = server
                     item.username = username
                     item.password = password
                 end if

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -176,6 +176,16 @@ function CreateSigninGroup(user = "")
     if get_setting("password") <> invalid
         password_field.value = get_setting("password")
     end if
+    ' Add checkbox for saving credentials
+    checkbox = group.findNode("onOff") 
+    items = CreateObject("roSGNode", "ContentNode")
+    items.role = "content"
+    saveCheckBox = CreateObject("roSGNode", "ContentNode")
+    saveCheckBox.title = tr("Save Credentials?")
+    items.appendChild(saveCheckBox)
+    checkbox.content = items
+    checkbox.checkedState = [true]
+
     items = [username_field, password_field]
     config.configItems = items
 
@@ -206,8 +216,10 @@ function CreateSigninGroup(user = "")
                 if get_setting("active_user") <> invalid
                     set_setting("username", username.value)
                     set_setting("password", password.value)
-                    'Update our saved server list, so next time the user can just click and go
-                    UpdateSavedServerList()
+                    if checkbox.checkedState[0] = true
+                        'Update our saved server list, so next time the user can just click and go
+                        UpdateSavedServerList()
+                    end if
                     return "true"
                 end if
                 print "Login attempt failed..."

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -1,5 +1,6 @@
 function CreateServerGroup()
     screen = CreateObject("roSGNode", "SetServerScreen")
+    screen.optionsAvailable = true
     m.global.sceneManager.callFunc("pushScene", screen)
     port = CreateObject("roMessagePort")
     m.colors = {}
@@ -10,6 +11,17 @@ function CreateServerGroup()
     m.viewModel = {}
     button = screen.findNode("submit")
     button.observeField("buttonSelected", port)
+    'create delete saved server option
+    new_options = []
+    sidepanel = screen.findNode("options")
+    opt = CreateObject("roSGNode", "OptionsButton")
+    opt.title = tr("Delete Saved")
+    opt.id = "delete_saved" 
+    opt.observeField("optionSelected", port)
+    new_options.push(opt)
+    sidepanel.options = new_options
+    sidepanel.observeField("closeSidePanel", port)
+    
     screen.observeField("backPressed", port)
 
     while true
@@ -19,6 +31,10 @@ function CreateServerGroup()
             return "false"
         else if isNodeEvent(msg, "backPressed")
             return "backPressed"
+        else if isNodeEvent(msg, "closeSidePanel")
+            screen.setFocus(true)
+            serverPicker = screen.findNode("serverPicker")
+            serverPicker.setFocus(true)
         else if type(msg) = "roSGNodeEvent"
             node = msg.getNode()
             if node = "submit"
@@ -61,6 +77,16 @@ function CreateServerGroup()
                     screen.visible = false
                     return "true"
                 end if
+            else if node = "delete_saved"
+                serverPicker = screen.findNode("serverPicker")
+                itemToDelete = serverPicker.content.getChild(serverPicker.itemFocused)
+                urlToDelete = itemToDelete.baseUrl
+                if urlToDelete <> invalid
+                    DeleteFromServerList(urlToDelete)
+                    serverPicker.content.removeChild(itemToDelete)
+                    sidepanel.visible = false
+                    serverPicker.setFocus(true)
+                end if           
             end if
         end if
     end while

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -16,12 +16,12 @@ function CreateServerGroup()
     sidepanel = screen.findNode("options")
     opt = CreateObject("roSGNode", "OptionsButton")
     opt.title = tr("Delete Saved")
-    opt.id = "delete_saved" 
+    opt.id = "delete_saved"
     opt.observeField("optionSelected", port)
     new_options.push(opt)
     sidepanel.options = new_options
     sidepanel.observeField("closeSidePanel", port)
-    
+
     screen.observeField("backPressed", port)
 
     while true
@@ -86,7 +86,7 @@ function CreateServerGroup()
                     serverPicker.content.removeChild(itemToDelete)
                     sidepanel.visible = false
                     serverPicker.setFocus(true)
-                end if           
+                end if
             end if
         end if
     end while
@@ -140,7 +140,7 @@ function CreateSigninGroup(user = "")
     'Load in any saved server data and see if we can just log them in...
     server = get_setting("server")
     saved = get_setting("saved_servers")
-    if saved <> invalid 
+    if saved <> invalid
         savedServers = ParseJson(saved)
         for each item in savedServers.serverList
             if item.baseUrl = server and item.username <> invalid and item.password <> invalid
@@ -361,14 +361,14 @@ sub UpdateSavedServerList()
     username = get_setting("username")
     password = get_setting("password")
 
-    if server = invalid or username = invalid or password = invalid 
+    if server = invalid or username = invalid or password = invalid
         return
     end if
 
     saved = get_setting("saved_servers")
     if saved <> invalid
         savedServers = ParseJson(saved)
-        newServers = {serverList: []}
+        newServers = { serverList: [] }
         for each item in savedServers.serverList
             if item.baseUrl = server and item.username = username
                 item.password = password
@@ -377,6 +377,6 @@ sub UpdateSavedServerList()
         end for
         set_setting("saved_servers", FormatJson(newServers))
     else
-        set_setting("saved_servers", FormatJson({ serverList: [{name: "Saved", baseUrl: server, username: username, password: password, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120}]}))
+        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: server, username: username, password: password, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
     end if
 end sub

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -177,7 +177,7 @@ function CreateSigninGroup(user = "")
         password_field.value = get_setting("password")
     end if
     ' Add checkbox for saving credentials
-    checkbox = group.findNode("onOff") 
+    checkbox = group.findNode("onOff")
     items = CreateObject("roSGNode", "ContentNode")
     items.role = "content"
     saveCheckBox = CreateObject("roSGNode", "ContentNode")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -370,17 +370,18 @@ sub UpdateSavedServerList()
     end if
 
     saved = get_setting("saved_servers")
-    if saved <> invalid
+    if saved <> invalid 
         savedServers = ParseJson(saved)
-        newServers = { serverList: [] }
-        for each item in savedServers.serverList
-            if item.baseUrl = LCase(server) and item.username = username ' Saved server data is always lowercase
-                item.password = password
-            end if
-            newServers.serverList.Push(item)
-        end for
-        set_setting("saved_servers", FormatJson(newServers))
-    else
-        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: LCase(server), username: username, password: password, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+        if savedServers.serverList <> invalid and savedServers.serverList.Count() > 0
+            newServers = { serverList: [] }
+            for each item in savedServers.serverList
+                if item.baseUrl = LCase(server) ' Saved server data is always lowercase
+                    item.username = username
+                    item.password = password
+                end if
+                newServers.serverList.Push(item)
+            end for
+            set_setting("saved_servers", FormatJson(newServers))
+        end if
     end if
 end sub

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -370,7 +370,7 @@ sub UpdateSavedServerList()
     end if
 
     saved = get_setting("saved_servers")
-    if saved <> invalid 
+    if saved <> invalid
         savedServers = ParseJson(saved)
         if savedServers.serverList <> invalid and savedServers.serverList.Count() > 0
             newServers = { serverList: [] }

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -59,7 +59,7 @@ function CreateServerGroup()
                     ' Server not found, is it online? New values / Retry
                     print "Server not found, is it online? New values / Retry"
                     screen.errorMessage = tr("Server not found, is it online?")
-                    SignOut()
+                    SignOut(false)
                 else if serverInfoResult.Error <> invalid and serverInfoResult.Error
                     ' If server redirected received, update the URL
                     if serverInfoResult.UpdatedUrl <> invalid
@@ -72,7 +72,7 @@ function CreateServerGroup()
                         message = message + "[" + serverInfoResult.ErrorCode.toStr() + "] "
                     end if
                     screen.errorMessage = message + tr(serverInfoResult.ErrorMessage)
-                    SignOut()
+                    SignOut(false)
                 else
                     screen.visible = false
                     if serverInfoResult.serverName <> invalid

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -75,7 +75,11 @@ function CreateServerGroup()
                     SignOut()
                 else
                     screen.visible = false
-                    return "true"
+                    if serverInfoResult.serverName <> invalid
+                        return serverInfoResult.ServerName + " (Saved)"
+                    else
+                        return "Saved"
+                    end if
                 end if
             else if node = "delete_saved"
                 serverPicker = screen.findNode("serverPicker")
@@ -143,7 +147,7 @@ function CreateSigninGroup(user = "")
     if saved <> invalid
         savedServers = ParseJson(saved)
         for each item in savedServers.serverList
-            if item.baseUrl = server and item.username <> invalid and item.password <> invalid
+            if item.baseUrl = LCase(server) and item.username <> invalid and item.password <> invalid
                 get_token(item.username, item.password)
                 if get_setting("active_user") <> invalid
                     return "true"
@@ -370,13 +374,13 @@ sub UpdateSavedServerList()
         savedServers = ParseJson(saved)
         newServers = { serverList: [] }
         for each item in savedServers.serverList
-            if item.baseUrl = server and item.username = username
+            if item.baseUrl = LCase(server) and item.username = username ' Saved server data is always lowercase
                 item.password = password
             end if
             newServers.serverList.Push(item)
         end for
         set_setting("saved_servers", FormatJson(newServers))
     else
-        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: server, username: username, password: password, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
+        set_setting("saved_servers", FormatJson({ serverList: [{ name: "Saved", baseUrl: LCase(server), username: username, password: password, iconUrl: "pkg:/images/logo-icon120.jpg", iconWidth: 120, iconHeight: 120 }] }))
     end if
 end sub

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -21,11 +21,29 @@ function AboutMe()
     return getJson(resp)
 end function
 
-sub SignOut()
+sub SignOut(deleteSavedEntry = true as boolean)
     if get_setting("active_user") <> invalid
         unset_user_setting("token")
         unset_setting("username")
         unset_setting("password")
+        if deleteSavedEntry = true
+            'Also delete any credentials in the "saved servers" list
+            saved = get_setting("saved_servers")
+            server = get_setting("server")
+            if server <> invalid
+                server = LCase(server)
+                savedServers = ParseJson(saved)
+                newServers = { serverList: [] }
+                for each item in savedServers.serverList
+                    if item.baseUrl = server
+                        item.username = ""
+                        item.password = ""
+                    end if
+                    newServers.serverList.Push(item)
+                end for
+                set_setting("saved_servers", FormatJson(newServers))
+            end if
+        end if
     end if
     unset_setting("active_user")
     m.global.sceneManager.currentUser = ""
@@ -53,7 +71,7 @@ sub RemoveUser(id as string)
     user.id = id
     user.callFunc("removeFromRegistry")
 
-    if get_setting("active_user") = id then SignOut()
+    if get_setting("active_user") = id then SignOut(false)
 end sub
 
 function ServerInfo()


### PR DESCRIPTION
Saves successfully connected to servers.  Next time a user selects "Change Server" from the option menu, simply clicking on the server entry will log them right in (assuming they have logged in at least once before).

**Changes**
After the client scans for local servers, any saved servers will be added to the list as well.

Other changes, "options" are now enabled on the server list screen.  The option button will only work if the user is currently selecting a "Saved" server (not a locally discovered one).  If on a "Saved" entry, clicking on the options will allow the user to delete the saved entry.

Issues
Fixes #354  

Notes: I looked in to using a token, but the client is already saving the user's password.  If / when password saving is refactored in favor of a token, this new code an easily be changed from "password" to "token".