### PR TITLE
Add video and audio codec info to TV show details

### DIFF
--- a/components/tvshows/TVEpisodeRow.brs
+++ b/components/tvshows/TVEpisodeRow.brs
@@ -18,7 +18,7 @@ sub updateSize()
     m.top.translation = [border, 75 + 115]
 
     itemWidth = (dimensions["width"] - border * 2)
-    itemHeight = 300
+    itemHeight = 400
 
     m.top.visible = true
 

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -31,9 +31,9 @@ sub itemContentChanged()
         videoIdx = invalid
         audioIdx = invalid
         for i = 0 to itemData.MediaStreams.Count() - 1
-            if itemData.MediaStreams[i].Type = "Video"
+            if itemData.MediaStreams[i].Type = "Video" and videoIdx = invalid
                 videoIdx = i
-            else if itemData.MediaStreams[i].Type = "Audio"
+            else if itemData.MediaStreams[i].Type = "Audio" and audioIdx = invalid
                 audioIdx = i
             end if
             if videoIdx <> invalid and audioIdx <> invalid then exit for

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -19,11 +19,32 @@ sub itemContentChanged()
         m.top.findNode("runtime").text = stri(getRuntime()).trim() + " mins"
         m.top.findNode("endtime").text = tr("Ends at %1").Replace("%1", getEndTime())
     end if
+
     if itemData.communityRating <> invalid
         m.top.findNode("star").visible = true
         m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
     else
         m.top.findNode("star").visible = false
+    end if
+
+    if itemData.MediaStreams <> invalid
+        videoIdx = invalid
+        audioIdx = invalid
+        for i = 0 to itemData.MediaStreams.Count() - 1
+            if itemData.MediaStreams[i].Type = "Video"
+                videoIdx = i
+            else if itemData.MediaStreams[i].Type = "Audio"
+                audioIdx = i
+            end if
+            if videoIdx <> invalid and audioIdx <> invalid then exit for
+        end for
+        m.top.findNode("video_codec").text = tr("Video") + ": " + itemData.mediaStreams[videoIdx].DisplayTitle
+        m.top.findNode("audio_codec").text = tr("Audio") + ": " + itemData.mediaStreams[audioIdx].DisplayTitle
+        m.top.findNode("video_codec").visible = true
+        m.top.findNode("audio_codec").visible = true
+    else
+        m.top.findNode("video_codec").visible = false
+        m.top.findNode("audio_codec").visible = false
     end if
 end sub
 

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -3,7 +3,7 @@
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
-        <Poster id="poster" width="534" height="300" />
+        <Poster id="poster" width="534" height="400" />
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />
@@ -17,6 +17,10 @@
             <Label id="endtime" font="font:SmallestSystemFont" />
           </LayoutGroup>
           <Label id="overview" wrap="true" height="170" width="1200" maxLines="4" ellipsizeOnBoundary="true"/>
+          <LayoutGroup layoutDirection="horiz" itemSpacings="[15]">
+            <Label id="video_codec" />
+            <Label id="audio_codec" />
+          </LayoutGroup>
         </LayoutGroup>
       </LayoutGroup>
     </LayoutGroup>

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -143,7 +143,7 @@ end function
 
 function TVEpisodes(show_id as string, season_id as string)
     url = Substitute("Shows/{0}/Episodes", show_id)
-    resp = APIRequest(url, { "seasonId": season_id, "UserId": get_setting("active_user") })
+    resp = APIRequest(url, { "seasonId": season_id, "UserId": get_setting("active_user"), "fields": "MediaStreams" })
 
     data = getJson(resp)
     results = []


### PR DESCRIPTION
Add Video / Audio codec information to TV Show (recordings) details

**Changes**
* Adds two new labels to TVListDetails
* Increases list height from 300 to 400 to accommodate new information 

**Issues**
Fixes: #264 