### PR TITLE
Prevent crash in Scenemanager

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -110,7 +110,7 @@ end function
 '
 ' Clear all content from group stack
 sub clearScenes()
-    m.content.removeChildrenIndex(m.content.getChildCount(), 0)
+    if m.content <> invalid then m.content.removeChildrenIndex(m.content.getChildCount(), 0)
     m.groups = []
 end sub
 


### PR DESCRIPTION
Roku Crash Report:

> Interface not a member of BrightScript Component (runtime error &hf3) in pkg:/components/data/SceneManager.brs(113) 

**Changes**
* Check `m.content` is set before accessing
