### PR TITLE
Select appropriate default subtitles based on user preferences

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -364,7 +364,7 @@ end sub
 
 function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_idx = 1)
     ' Video is Playing
-    video = VideoPlayer(video_id, mediaSourceId, audio_stream_idx)
+    video = VideoPlayer(video_id, mediaSourceId, audio_stream_idx, defaultSubtitleTrackFromVid(video_id))
     if video = invalid then return invalid
     video.observeField("selectSubtitlePressed", m.port)
     video.observeField("state", m.port)

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -184,7 +184,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     video.content.SubtitleTracks = subtitles["text"]
 
     ' 'TODO: allow user selection of subtitle track before playback initiated, for now set to no subtitles
-    video.SelectedSubtitle = -1
 
     video.directPlaySupported = playbackInfo.MediaSources[0].SupportsDirectPlay
     fully_external = false
@@ -234,6 +233,10 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
 
     video.content.setCertificatesFile("common:/certs/ca-bundle.crt")
     video.audioTrack = (audio_stream_idx + 1).ToStr() ' Roku's track indexes count from 1. Our index is zero based
+
+    ' Perform relevant setup work for selected subtitle, and return the index of the subtitle
+    ' is enabled/will be enabled, indexed on the provided list of subtitles
+    video.SelectedSubtitle = setupSubtitle(video, video.Subtitles, subtitle_idx)
 
     if not fully_external
         video.content = authorize_request(video.content)

--- a/source/utils/Subtitles.brs
+++ b/source/utils/Subtitles.brs
@@ -1,3 +1,90 @@
+' Identify the default subtitle track for a given video id
+' returns the server-side track index for the appriate subtitle
+function defaultSubtitleTrackFromVid(video_id) as integer
+    meta = ItemMetaData(video_id)
+    if meta = invalid then return invalid
+    subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
+    default_text_subs = defaultSubtitleTrack(subtitles["all"], true) ' Find correct subtitle track (forced text)
+    if default_text_subs <> -1
+        return default_text_subs
+    else
+        return defaultSubtitleTrack(subtitles["all"]) ' if no appropriate text subs exist, allow non-text
+    end if
+end function
+
+
+' Identify the default subtitle track
+' if "requires_text" is true, only return a track if it is textual
+'     This allows forcing text subs, since roku requires transcoding of non-text subs
+' returns the server-side track index for the appriate subtitle
+function defaultSubtitleTrack(sorted_subtitles, require_text = false) as integer
+    if m.user.Configuration.SubtitleMode = "None"
+        return -1 ' No subtitles desired: select none
+    end if
+
+    for each item in sorted_subtitles
+        ' Only auto-select subtitle if language matches preference
+        languageMatch = (m.user.Configuration.SubtitleLanguagePreference = item.Track.Language)
+        ' Ensure textuality of subtitle matches preferenced passed as arg
+        matchTextReq = ((require_text and item.IsTextSubtitleStream) or not require_text)
+        if languageMatch and matchTextReq
+            if m.user.Configuration.SubtitleMode = "Default" and (item.isForced or item.IsDefault or item.IsExternal)
+                return item.Index ' Finds first forced, or default, or external subs in sorted list
+            else if m.user.Configuration.SubtitleMode = "Always" and not item.IsForced
+                return item.Index ' Select the first non-forced subtitle option in the sorted list
+            else if m.user.Configuration.SubtitleMode = "OnlyForced" and item.IsForced
+                return item.Index ' Select the first forced subtitle option in the sorted list
+            else if m.user.Configuration.SubtitlePlaybackMode = "Smart" and (item.isForced or item.IsDefault or item.IsExternal)
+                ' Simplified "Smart" logic here mimics Default (as that is fallback behavior normally)
+                ' Avoids detecting preferred audio language (as is utilized in main client)
+                return item.Index
+            end if
+        end if
+    end for
+    return -1 ' Keep current default behavior of "None", if no correct subtitle is identified
+end function
+
+' Given a set of subtitles, and a subtitle index (the index on the server, not in the list provided)
+' this will set all relevant settings for roku (mainly closed captions) and return the index of the
+' subtitle track specified, but indexed based on the provided list of subtitles
+function setupSubtitle(video, subtitles, subtitle_idx = -1) as integer
+    if subtitle_idx = -1
+        ' If we are not using text-based subtitles, turn them off
+        video.globalCaptionMode = "Off"
+        return -1
+    end if
+
+    ' Translate the raw index to one relative to the provided list
+    subtitleSelIdx = getSubtitleSelIdxFromSubIdx(subtitles, subtitle_idx)
+
+    selectedSubtitle = subtitles[subtitleSelIdx]
+
+    if selectedSubtitle.IsEncoded
+        ' With encoded subtitles, turn off captions
+        video.globalCaptionMode = "Off"
+    else
+        ' If this is a text-based subtitle, set relevant settings for roku captions
+        video.globalCaptionMode = "On"
+        video.subtitleTrack = video.availableSubtitleTracks[selectedSubtitle.TextIndex].TrackName
+    end if
+
+    return subtitleSelIdx
+
+end function
+
+' The subtitle index on the server differs from the index we track locally
+' This function converts the former into the latter
+function getSubtitleSelIdxFromSubIdx(subtitles, sub_idx) as integer
+    selIdx = 0
+    if sub_idx = -1 then return -1
+    for each item in subtitles
+        if item.Index = sub_idx
+            return selIdx
+        end if
+        selIdx = selIdx + 1
+    end for
+    return -1
+end function
 
 function selectSubtitleTrack(tracks, current = -1) as integer
     video = m.scene.focusedChild.focusedChild
@@ -45,26 +132,13 @@ sub changeSubtitleDuringPlayback(newid)
     currentSubtitles = video.Subtitles[video.SelectedSubtitle]
     newSubtitles = video.Subtitles[newid]
 
-    if newSubtitles.IsEncoded
-
-        ' Switching to Encoded Subtitle stream
+    if newSubtitles.IsEncoded or (currentSubtitles <> invalid and currentSubtitles.IsEncoded)
+        ' With encoded subtitles we need to stop/start playback
         video.control = "stop"
         AddVideoContent(video, video.mediaSourceId, video.audioIndex, newSubtitles.Index, video.position * 10000000)
         video.control = "play"
-        video.globalCaptionMode = "Off" ' Using encoded subtitles - so turn off text subtitles
-
-    else if currentSubtitles <> invalid and currentSubtitles.IsEncoded
-
-        ' Switching from an Encoded stream to a text stream
-        video.control = "stop"
-        AddVideoContent(video, video.mediaSourceId, video.audioIndex, -1, video.position * 10000000)
-        video.control = "play"
-        video.globalCaptionMode = "On"
-        video.subtitleTrack = video.availableSubtitleTracks[newSubtitles.TextIndex].TrackName
-
     else
-
-        ' Switch to Text Subtitle Track
+        ' Switching from text to text (or none to text) does not require stopping playback
         video.globalCaptionMode = "On"
         video.subtitleTrack = video.availableSubtitleTracks[newSubtitles.TextIndex].TrackName
     end if


### PR DESCRIPTION
**Changes**
Logic for selecting a default subtitle track when starting playback is now added. This logic is based off of the existing logic in the base Jellyfin repo, with 2 minor modifications:
- Text-based subtitles are preferred (within the confines of the user's preferred subtitle mode)
  - If no text-based subtitles exist that match the preferred mode, then non-text-based subtitles are used anyway
  - This behavior was added sinc the roku video player is known to not support graphical subtitles, so using such subtitles would require transcoding in all cases
- "Smart" mode subtitles behave the same as default subtitles (the fallback behavior in Jellyfin itself)
  - This is done, as the full implementation relies on knowledge about audio language preferences

**Rationale**
Generally I use "OnlyForced" subtitle mode for my playback, since it is mildly annoying to watch a movie with some foreign language parts that don't get subtitles (Ex Elysium, which is partially in Spanish). This works well on other clients, but based on the source here, we are currently assuming no-subtitles is the correct default option, which does not match other clients (web, android app, etc). 

This patchset attempts to rectify this issue by porting over the as much of the logic from the other clients as possible.

Additionally, the reason text-based subtitles are explicitly preferred here, when that is not necessarily the behavior elsewhere, is that watching a 4k rip with forced subtitles is not very doable when the server is attempting to transcode the whole thing. :smile: 
