### PR TITLE
Check overhang is not invalid before setting user

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -176,7 +176,7 @@ end sub
 ' Update username in overhang
 sub updateUser()
     ' Passthrough to overhang
-    m.overhang.currentUser = m.top.currentUser
+    if m.overhang <> invalid then m.overhang.currentUser = m.top.currentUser
 end sub
 
 


### PR DESCRIPTION
Ensure overhang has been initialised before trying to set user name

**Changes**
 - Perform check that overhang is not invalid

**Issues**
fixes #544
