### PR TITLE
578 - Missing Text To Speech

### DIFF
--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -5,6 +5,8 @@ sub init()
 
     m.backdrop = m.top.findNode("backdrop")
 
+    m.deviceInfo = CreateObject("roDeviceInfo")
+
     ' Randmomise the background colors
     posterBackgrounds = m.global.constants.poster_bg_pallet
     m.backdrop.color = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
@@ -67,6 +69,13 @@ sub focusChanged()
         m.title.repeatCount = -1
         m.staticTitle.visible = false
         m.title.visible = true
+
+        ' text to speech for accessibility
+        if m.deviceInfo.IsAudioGuideEnabled() = true
+            txt2Speech = CreateObject("roTextToSpeech")
+            txt2Speech.Flush()
+            txt2Speech.Say(m.title.text)
+        end if
 
     else
         m.title.repeatCount = 0

--- a/components/extras/ExtrasItem.brs
+++ b/components/extras/ExtrasItem.brs
@@ -16,7 +16,7 @@ sub showContent()
         m.posterImg.width = cont.imageWidth
         m.role.Text = cont.subTitle
     else
-        m.role.text = "Who??"
+        m.role.text = tr("Unknown")
         m.posterImg.uri = "pkg:/images/baseline_person_white_48dp.png"
     end if
 end sub

--- a/components/extras/ExtrasItem.brs
+++ b/components/extras/ExtrasItem.brs
@@ -1,0 +1,31 @@
+sub init()
+    m.posterImg = m.top.findNode("posterImg")
+    m.name = m.top.findNode("pLabel")
+    m.role = m.top.findNode("subTitle")
+
+    m.deviceInfo = CreateObject("roDeviceInfo")
+end sub
+
+sub showContent()
+    if m.top.itemContent <> invalid
+        cont = m.top.itemContent
+        m.name.text = cont.labelText
+        m.name.maxWidth = cont.imageWidth
+        m.role.Width = cont.imageWidth
+        m.posterImg.uri = cont.posterUrl
+        m.posterImg.width = cont.imageWidth
+        m.role.Text = cont.subTitle
+    else
+        m.role.text = "Who??"
+        m.posterImg.uri = "pkg:/images/baseline_person_white_48dp.png"
+    end if
+end sub
+
+sub focusChanged()
+    if m.deviceInfo.IsAudioGuideEnabled() = true
+        txt2Speech = CreateObject("roTextToSpeech")
+        txt2Speech.Flush()
+        txt2Speech.Say(m.name.text)
+        txt2Speech.Say(m.role.text)
+    end if
+end sub

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -2,31 +2,9 @@
 <component name="ExtrasItem" extends="JFGroup">
   <interface>
     <field id="itemContent" type="node" onChange="showContent" />
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>
-  <script type="text/brightscript">
-  <![CDATA[
-    function init() as void
-      m.posterImg = m.top.findNode("posterImg")
-      m.name = m.top.findNode("pLabel")
-      m.role = m.top.findNode("subTitle")
-    end function
-
-    sub showContent()
-      if m.top.itemContent <> Invalid
-        cont = m.top.itemContent
-        m.name.text = cont.labelText
-        m.name.maxWidth = cont.imageWidth
-        m.role.Width = cont.imageWidth
-        m.posterImg.uri = cont.posterUrl
-        m.posterImg.width = cont.imageWidth
-        m.role.Text = cont.subTitle
-      else
-        m.role.text = "Who??"
-        m.posterImg.uri = "pkg:/images/baseline_person_white_48dp.png"
-      end if
-    end sub
-  ]]>
-  </script>
+  <script type="text/brightscript" uri="ExtrasItem.brs" />
   <children>
     <LayoutGroup layoutDirection="vert" >
       <Poster id="posterImg" width="234" height="300" translation="[8,243]" failedBitmapUri="pkg:/images/baseline_person_white_48dp.png" />

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -1,6 +1,9 @@
 sub init()
     m.title = m.top.findNode("title")
     m.title.text = tr("Loading...")
+    m.overview = m.top.findNode("overview")
+
+    m.deviceInfo = CreateObject("roDeviceInfo")
 end sub
 
 sub itemContentChanged()
@@ -11,9 +14,9 @@ sub itemContentChanged()
     else
         indexNumber = ""
     end if
-    m.top.findNode("title").text = indexNumber + item.title
+    m.title.text = indexNumber + item.title
     m.top.findNode("poster").uri = item.posterURL
-    m.top.findNode("overview").text = item.overview
+    m.overview.text = item.overview
 
     if type(itemData.RunTimeTicks) = "LongInteger"
         m.top.findNode("runtime").text = stri(getRuntime()).trim() + " mins"
@@ -65,3 +68,15 @@ function getEndTime() as string
 
     return formatTime(date)
 end function
+
+sub focusChanged()
+    if m.top.itemHasFocus = true
+        ' text to speech for accessibility
+        if m.deviceInfo.IsAudioGuideEnabled() = true
+            txt2Speech = CreateObject("roTextToSpeech")
+            txt2Speech.Flush()
+            txt2Speech.Say(m.title.text)
+            txt2Speech.Say(m.overview.text)
+        end if
+    end if
+end sub

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -27,6 +27,7 @@
   </children>
   <interface>
     <field id="itemContent" type="node" onChange="itemContentChanged"/>
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>
   <script type="text/brightscript" uri="TVListDetails.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/components/tvshows/TVShowDetails.brs
+++ b/components/tvshows/TVShowDetails.brs
@@ -135,17 +135,22 @@ function round(f as float) as integer
 end function
 
 function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
+    overview = m.top.findNode("overview")
     topGrp = m.top.findNode("seasons")
     bottomGrp = m.top.findNode("extrasGrid")
 
-
-    if key = "down" and topGrp.isinFocusChain()
+    if key = "down" and overview.hasFocus()
+        topGrp.setFocus(true)
+        return true
+    else if key = "down" and topGrp.hasFocus()
         bottomGrp.setFocus(true)
         m.top.findNode("VertSlider").reverse = false
         m.top.findNode("extrasFader").reverse = false
         m.top.findNode("pplAnime").control = "start"
         return true
-    else if key = "up" and bottomGrp.isinFocusChain()
+    else if key = "up" and bottomGrp.hasFocus()
         if bottomGrp.itemFocused = 0
             m.top.findNode("VertSlider").reverse = true
             m.top.findNode("extrasFader").reverse = true
@@ -153,6 +158,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
             topGrp.setFocus(true)
             return true
         end if
+    else if key = "up" and topGrp.hasFocus()
+        overview.setFocus(true)
+        return true
     end if
+
     return false
 end function

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -432,6 +432,11 @@
         <extracomment>Title of message box when the requested content is not found on the server</extracomment>
     </message>
     <message>
+        <source>Unknown</source>
+        <translation>Unknown</translation>
+        <extracomment>Title for a cast member for which we have no information for</extracomment>
+    </message>
+    <message>
         <source>The requested content does not exist on the server</source>
         <translation>The requested content does not exist on the server</translation>
         <extracomment>Content of message box when the requested content is not found on the server</extracomment>


### PR DESCRIPTION
This add text to speech to: TV Season posters, TV Season Episodes and Extras (Cast and Crew).

It appears that the built in text to speech for Roku will only read the Title of a Row (RowList).  Unless you are using a PosterGrid or MarkupGrid as your Row template (which we are not).

**Issues**
Fixes: #578 
