### PR TITLE
User setting screen

### DIFF
--- a/app.mk
+++ b/app.mk
@@ -108,6 +108,7 @@ prep_staging:
 	cp -r $(SOURCEREL)/source $(STAGINGREL)
 	cp -r $(SOURCEREL)/components $(STAGINGREL)
 	cp -r $(SOURCEREL)/images $(STAGINGREL)
+	cp -r $(SOURCEREL)/settings $(STAGINGREL)
 	
 	# Copy only supported languages over to staging
 	mkdir $(STAGINGREL)/locale

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,8 @@
         "components/**/*.*",
         "images/**/*.*",
         "resources/**/*.*",
-        "locale/**/*.*"
+        "locale/**/*.*",
+        "settings/*.*"
     ],
     "plugins": [ "@rokucommunity/bslint" ]
 }

--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -114,6 +114,12 @@ sub clearScenes()
     m.groups = []
 end sub
 
+'
+' Display user/device settings screen
+sub settings()
+    settingsScreen = createObject("roSGNode", "Settings")
+    pushScene(settingsScreen)
+end sub
 
 '
 ' Register observers for overhang data

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -3,6 +3,7 @@
   <interface>
     <function name="pushScene" />
     <function name="popScene" />
+    <function name="settings" />
     <function name="getActiveScene" />
     <function name="clearScenes" />
     <function name="resetTime" />

--- a/components/settings/setting.xml
+++ b/components/settings/setting.xml
@@ -1,0 +1,5 @@
+<component name="Setting" extends="ContentNode">
+    <interface>
+        <field id="type" type="string" />
+    </interface>
+</component>

--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -1,0 +1,141 @@
+sub init()
+
+    m.top.overhangTitle = tr("Settings")
+    m.top.optionsAvailable = false
+
+    m.userLocation = []
+
+    m.settingsMenu = m.top.findNode("settingsMenu")
+    m.settingDetail = m.top.findNode("settingDetail")
+    m.settingDesc = m.top.findNode("settingDesc")
+    m.settingTitle = m.top.findNode("settingTitle")
+    m.path = m.top.findNode("path")
+
+    m.boolSetting = m.top.findNode("boolSetting")
+
+    m.settingsMenu.setFocus(true)
+    m.settingsMenu.observeField("itemFocused", "settingFocused")
+    m.settingsMenu.observeField("itemSelected", "settingSelected")
+
+    m.boolSetting.observeField("checkedItem", "boolSettingChanged")
+
+    ' Load Configuration Tree
+    m.configTree = GetConfigTree()
+    LoadMenu({ children: m.configTree })
+end sub
+
+
+sub LoadMenu(configSection)
+
+    if configSection.children = invalid
+        ' Load parent menu
+        m.userLocation.pop()
+        configSection = m.userLocation.peek()
+    else
+        if m.userLocation.Count() > 0 then m.userLocation.peek().selectedIndex = m.settingsMenu.itemFocused
+        m.userLocation.push(configSection)
+    end if
+
+    result = CreateObject("roSGNode", "ContentNode")
+
+    for each item in configSection.children
+        listItem = result.CreateChild("ContentNode")
+        listItem.title = tr(item.title)
+        listItem.Description = tr(item.description)
+        listItem.id = item.id
+    end for
+
+    m.settingsMenu.content = result
+
+    if configSection.selectedIndex <> invalid and configSection.selectedIndex > -1
+        m.settingsMenu.jumpToItem = configSection.selectedIndex
+    end if
+
+    ' Set Path display
+    m.path.text = ""
+    for each level in m.userLocation
+        if level.title <> invalid then m.path.text += " / " + tr(level.title)
+    end for
+end sub
+
+
+
+sub settingFocused()
+
+    selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
+    m.settingDesc.text = tr(selectedSetting.Description)
+    m.settingTitle.text = tr(selectedSetting.Title)
+
+    ' Hide Settings
+    m.boolSetting.visible = false
+
+    if selectedSetting.type = invalid
+        return
+    else if selectedSetting.type = "bool"
+
+        m.boolSetting.visible = true
+
+        if get_user_setting(selectedSetting.settingName) = "true"
+            m.boolSetting.checkedItem = 1
+        else
+            m.boolSetting.checkedItem = 0
+        end if
+    else
+        print "Unknown setting type " + selectedSetting.type
+    end if
+
+end sub
+
+
+sub settingSelected()
+
+    selectedItem = m.userLocation.peek().children[m.settingsMenu.itemFocused]
+
+
+    if selectedItem.type <> invalid ' Show setting
+        if selectedItem.type = "bool"
+            m.boolSetting.setFocus(true)
+        end if
+    else if selectedItem.children <> invalid and selectedItem.children.Count() > 0 ' Show sub menu
+        LoadMenu(selectedItem)
+        m.settingsMenu.setFocus(true)
+    else
+        return
+    end if
+
+    m.settingDesc.text = m.settingsMenu.content.GetChild(m.settingsMenu.itemFocused).Description
+
+end sub
+
+
+sub boolSettingChanged()
+
+    if m.boolSetting.focusedChild = invalid then return
+    selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
+
+    if m.boolSetting.checkedItem
+        set_user_setting(selectedSetting.settingName, "true")
+    else
+        set_user_setting(selectedSetting.settingName, "false")
+    end if
+
+end sub
+
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
+    if (key = "back" or key = "left") and m.settingsMenu.focusedChild <> invalid and m.userLocation.Count() > 1
+        LoadMenu({})
+        return true
+    else if (key = "back" or key = "left") and m.settingDetail.focusedChild <> invalid
+        m.settingsMenu.setFocus(true)
+        return true
+    end if
+
+    if key = "right"
+        settingSelected()
+    end if
+
+    return false
+end function

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -31,7 +31,7 @@
                itemSpacings="[50]"
              >
 
-                <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" width="750" />
+                <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" maxWidth="750" />
 
                 <Label id="settingDesc" width="750" wrap = "true" />
 

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Settings" extends="JFGroup">
+  <children>
+
+         <Label id="path" translation = "[95,175]" font="font:SmallestBoldSystemFont" />
+
+        <LabelList
+            translation = "[120,250]"
+            id = "settingsMenu"
+            itemSize = "[440,48]"
+            vertFocusAnimationStyle = "floatingFocus"
+            focusBitmapBlendColor = "#006fab"
+            focusedColor = "#ffffff"
+            itemSpacing = "[0,5]"
+            />
+
+            <Poster
+               translation = "[710,250]"
+               id="testRectangle"
+               width="880"
+               height="700"
+               uri="pkg:/images/white.9.png"
+               blendColor = "#3f3f3f"
+             />
+
+             <LayoutGroup
+               translation = "[1150,275]"
+               id="settingDetail"
+               vertAlignment="top"
+               horizAlignment="center"
+               itemSpacings="[50]"
+             >
+
+                <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" width="750" />
+
+                <Label id="settingDesc" width="750" wrap = "true" />
+
+                <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus">
+                  <ContentNode role="content">
+                    <ContentNode title="Disabled" />
+                    <ContentNode title="Enabled" />
+                  </ContentNode>
+                </RadioButtonList>
+
+             </LayoutGroup>
+
+
+  </children>
+  <script type="text/brightscript" uri="settings.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+</component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -470,5 +470,28 @@
         <source>Version</source>
         <translation>Version</translation>
     </message>
+    <message>
+        <source>Playback</source>
+        <translation>Playback</translation>
+        <extracomment>Title for Playback section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>MPEG 2 Support</source>
+        <translation>MPEG 2 Support</translation>
+        <extracomment>Settings Menu - Title for option</extracomment>
+    </message>
+    <message>
+        <source>Support direct play of MPEG 2 content (e.g. Live TV). This will prevent transcoding of MPEG 2 content, but uses significantly more bandwidth</source>
+        <translation>Support direct play of MPEG 2 content (e.g. Live TV). This will prevent transcoding of MPEG 2 content, but uses significantly more bandwidth</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Enabled</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Disabled</translation>
+    </message>
 </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,0 +1,15 @@
+[
+    {
+        "title": "Playback",
+        "description": "Settings related to playback and supported codec and media types",
+        "children": [
+            {
+                "title": "MPEG 2 Support",
+                "description": "Support direct play of MPEG 2 content (e.g. Live TV). This will prevent transcoding of MPEG 2 content, but uses significantly more bandwidth",
+                "settingName": "playback.mpeg2",
+                "type": "bool",
+                "default": "false"
+            }        
+        ]
+    }
+]

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -284,6 +284,16 @@ sub Main (args as dynamic) as void
                     button.title = tr("MPEG2 Support: On")
                 end if
                 set_setting("playback.mpeg2", playMpeg2)
+            else if button.id = "settings"
+                ' Exit out of the side panel
+                panel = group.findNode("options")
+                panel.visible = false
+                if group.lastFocus <> invalid
+                    group.lastFocus.setFocus(true)
+                else
+                    group.setFocus(true)
+                end if
+                sceneManager.callFunc("settings")
             end if
         else if isNodeEvent(msg, "selectSubtitlePressed")
             node = m.scene.focusedChild

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -10,6 +10,13 @@ sub Main (args as dynamic) as void
     ' Set global constants
     setConstants()
 
+    ' Temporary code to migrate MPEG2 setting from device setting to user setting
+    ' Added for 1.4.13 release and should probably be removed for 1.4.15
+    if get_setting("playback.mpeg2") <> invalid and registry_read("playback.mpeg2", get_setting("active_user")) = invalid
+        set_user_setting("playback.mpeg2", get_setting("playback.mpeg2"))
+    end if
+    ' End Temporary code
+
     m.port = CreateObject("roMessagePort")
     m.screen.setMessagePort(m.port)
     m.scene = m.screen.CreateScene("JFScene")
@@ -274,16 +281,6 @@ sub Main (args as dynamic) as void
                 SignOut()
                 sceneManager.callFunc("clearScenes")
                 goto app_start
-            else if button.id = "play_mpeg2"
-                playMpeg2 = get_setting("playback.mpeg2")
-                if playMpeg2 = "true"
-                    playMpeg2 = "false"
-                    button.title = tr("MPEG2 Support: Off")
-                else
-                    playMpeg2 = "true"
-                    button.title = tr("MPEG2 Support: On")
-                end if
-                set_setting("playback.mpeg2", playMpeg2)
             else if button.id = "settings"
                 ' Exit out of the side panel
                 panel = group.findNode("options")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -258,7 +258,7 @@ function CreateHomeGroup()
         new_options.push(o)
     end for
 
-    ' Add temporary settings option to menu
+    ' Add settings option to menu
     o = CreateObject("roSGNode", "OptionsButton")
     o.title = "Settings"
     o.id = "settings"

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -258,22 +258,6 @@ function CreateHomeGroup()
         new_options.push(o)
     end for
 
-    ' Add option for mpeg-2 playback
-    playMpeg2 = get_setting("playback.mpeg2")
-    if playMpeg2 = invalid
-        playMpeg2 = "true"
-        set_setting("playback.mpeg2", playMpeg2)
-    end if
-    o = CreateObject("roSGNode", "OptionsButton")
-    if playMpeg2 = "true"
-        o.title = tr("MPEG2 Support: On")
-    else
-        o.title = tr("MPEG2 Support: Off")
-    end if
-    o.id = "play_mpeg2"
-    o.observeField("optionSelected", m.port)
-    new_options.push(o)
-
     ' Add temporary settings option to menu
     o = CreateObject("roSGNode", "OptionsButton")
     o.title = "Settings"

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -274,6 +274,13 @@ function CreateHomeGroup()
     o.observeField("optionSelected", m.port)
     new_options.push(o)
 
+    ' Add temporary settings option to menu
+    o = CreateObject("roSGNode", "OptionsButton")
+    o.title = "Settings"
+    o.id = "settings"
+    o.observeField("optionSelected", m.port)
+    new_options.push(o)
+
     ' And a profile button
     user_node = CreateObject("roSGNode", "OptionsData")
     user_node.id = "active_user"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -17,7 +17,7 @@ end function
 
 
 function getDeviceProfile() as object
-    playMpeg2 = get_setting("playback.mpeg2") = "true"
+    playMpeg2 = get_user_setting("playback.mpeg2") = "true"
 
     'Check if 5.1 Audio Output connected
     maxAudioChannels = 2
@@ -165,7 +165,7 @@ function GetDirectPlayProfiles() as object
     mkvAudio = "mp3,pcm,lpcm,wav"
     audio = "mp3,pcm,lpcm,wav"
 
-    playMpeg2 = get_setting("playback.mpeg2") = "true"
+    playMpeg2 = get_user_setting("playback.mpeg2") = "true"
 
     di = CreateObject("roDeviceInfo")
 


### PR DESCRIPTION
Create a new user setting screen to allow setting and storing preferences on the Roku Device on a per user basis.

Screen it accessible via the * button on the home screen for now, under the "Settings" option.  A folder/item type view is displayed which is built from the `settings/settings.json` file, meaning new settings can easily be added without having to update the settings page.  

The `settings.json` is an array of _configItem_ objects with the following properties

`title` : Short title for display in Menu & Top of setting panel
`description` : Description of the setting
`settingName` : Unique id to use when storing the setting in the registry
`type` : Type of setting (e.g. `bool`, `number`, `text`, etc)
`default` : Optional default value for setting
`children` : Array of _configItem_ objects to appear under setting

It can be though of as a tree, with branches being the folders and the leaf nodes being the actual properties being set.  For branches, `type`, `default` and `settingName` would not be set, and for lead nodes `children` would not be set.

Currently only type of `bool` is supported.  This should be easy to extend with other types as they are needed and validation can be added in.

The `MPEG 2 Support` option has been moved into the new setting screen, and has also been moved from the application setting to a user setting (hence the migration code in the `Main.brs` file.

Once a new setting has been defined in the `settings.json` file, it can be accessed using the existing `get_user_setting("key") method in config.brs file.  They key is the `settingName` from the entry in settings.json.