### PR TITLE
Ensure Movie Details focus returns to button row

### DIFF
--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -14,6 +14,7 @@ sub init()
 
     m.buttonGrp = m.top.findNode("buttons")
     m.buttonGrp.setFocus(true)
+    m.top.lastFocus = m.buttonGrp
 
     m.top.observeField("itemContent", "itemContentChanged")
 end sub

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -231,6 +231,10 @@ sub Main (args as dynamic) as void
                 if video <> invalid
                     sceneManager.callFunc("pushScene", video)
                 end if
+
+                if group.lastFocus <> invalid
+                    group.lastFocus.setFocus(true)
+                end if
             else if btn <> invalid and btn.id = "watched-button"
                 movie = group.itemContent
                 if movie.watched


### PR DESCRIPTION
Resolve issue when Resume/Restart dialog was displayed when playing a partially watched movie from the Movie Details page.  It dialog cancelled then focus was not returned to buttons correctly.

**Changes**
 - Set `lastFocus` to Movie Details button group
 - After video group is created, set focus back to button group
 
**Issues**
- fixes #545
- refs #489
