### PR TITLE
Solved error which happens when server list is empty and user press *

### DIFF
--- a/components/config/SetServerScreen.brs
+++ b/components/config/SetServerScreen.brs
@@ -38,11 +38,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "down" and m.serverUrlContainer.hasFocus()
         m.submit.setFocus(true)
     else if key = "options"
-        serverName = m.serverPicker.content.getChild(m.serverPicker.itemFocused).name
-        if m.servers.Count() > 0 and Instr(1, serverName, "Saved") > 0
-            'Can only delete previously saved servers, not locally discovered ones
-            'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
-            handled = false
+        if m.serverPicker.itemFocused >= 0
+            serverName = m.serverPicker.content.getChild(m.serverPicker.itemFocused).name
+            if m.servers.Count() > 0 and Instr(1, serverName, "Saved") > 0
+                'Can only delete previously saved servers, not locally discovered ones
+                'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
+                handled = false
+            end if
+        else 
+            ' when m.serverPicker.itemFocused = -1, this case can only happen when server list is empty
         end if
     else
         handled = false


### PR DESCRIPTION
**Changes**
Added condition to check if `m.serverPicker.itemFocused = -1` because when `m.serverPicker.itemFocused = -1` then the list is empty which means that there are no server seleced.

**Issues**
When a user is on SetServerScreen and the server list is empty and the user presses the "*" button then an error occurs because 
`m.serverPicker.content.getChild(m.serverPicker.itemFocused).name` is same as `m.serverPicker.content.getChild(-1).name` which is invalid.
