### PR TITLE
Check Focused item is valid when Selecting Server

### DIFF
--- a/components/PlaystateTask.brs
+++ b/components/PlaystateTask.brs
@@ -41,8 +41,11 @@ function PlaystateDefaults(params = {} as object)
         '"PlaySessionId": "",
         '"RepeatMode": "RepeatNone"
     }
-    for each p in params.items()
-        new_params[p.key] = p.value
+
+    paramsArray = params.items()
+    for i = 0 to paramsArray.count() - 1
+        item = paramsArray[i]
+        new_params[item.key] = item.value
     end for
     return FormatJson(new_params)
 end function

--- a/components/config/SetServerScreen.brs
+++ b/components/config/SetServerScreen.brs
@@ -38,11 +38,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "down" and m.serverUrlContainer.hasFocus()
         m.submit.setFocus(true)
     else if key = "options"
-        serverName = m.serverPicker.content.getChild(m.serverPicker.itemFocused).name
-        if m.servers.Count() > 0 and Instr(1, serverName, "Saved") > 0
-            'Can only delete previously saved servers, not locally discovered ones
-            'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
-            handled = false
+        if m.serverPicker.itemFocused >= 0 and m.serverPicker.itemFocused < m.serverPicker.content.getChildCount()
+            serverName = m.serverPicker.content.getChild(m.serverPicker.itemFocused).name
+            if m.servers.Count() > 0 and Instr(1, serverName, "Saved") > 0
+                'Can only delete previously saved servers, not locally discovered ones
+                'So if we are on a "Saved" item, let the options dialog be shown (handled elsewhere)
+                handled = false
+            end if
         end if
     else
         handled = false


### PR DESCRIPTION
**Changes**
Added condition to check if itemFocused index is valid before accessing to the content of the focused item.

**Issues**
When a user selects the "*" option on SetServerScreen and the server list is empty app crashes.
