### PR TITLE
Check if Actor Role is invalid before using it

### DIFF
--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -49,7 +49,7 @@ sub onPeopleLoaded()
         row = data.createChild("ContentNode")
         row.Title = tr("Cast & Crew")
         for each person in people
-            if person.json.type = "Actor"
+            if person.json.type = "Actor" and person.json.Role <> invalid
                 person.subTitle = "as " + person.json.Role
             else
                 person.subTitle = person.json.Type


### PR DESCRIPTION
To avoid crash to Home screen from:
  Type Mismatch. Operator "+" can't be applied to "String" and "Invalid". (runtime error &h18) in pkg:/components/extras/ExtrasRowList.brs(53)

This has been crashing my Jellyfin Roku app for a few weeks now for every TV Show/Series that had an actor listed. I'm running the latest stable Jellyfin Docker container.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
