### PR TITLE
Remove Tag query parameter 

### DIFF
--- a/components/data/ChannelData.brs
+++ b/components/data/ChannelData.brs
@@ -11,10 +11,10 @@ sub setPoster()
     if m.top.image <> invalid
         m.top.posterURL = m.top.image.url
     else if m.top.json.ImageTags <> invalid and m.top.json.ImageTags.Primary <> invalid
-        imgParams = { "maxHeight": 60, "Tag": m.top.json.ImageTags.Primary }
+        imgParams = { "maxHeight": 60 }
         m.top.hdsmalliconurl = ImageURL(m.top.json.id, "Primary", imgParams)
 
-        imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+        imgParams = { "maxHeight": 440, "maxWidth": 295 }
         m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
     end if
 end sub

--- a/components/data/CollectionData.brs
+++ b/components/data/CollectionData.brs
@@ -18,16 +18,16 @@ sub setPoster()
     else
 
         if m.top.json.ImageTags.Primary <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if m.top.json.BackdropImageTags <> invalid
-            imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags <> invalid
-            imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 720, "maxWidth": 1280 }
             m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 

--- a/components/data/FolderData.brs
+++ b/components/data/FolderData.brs
@@ -18,7 +18,7 @@ sub setPoster()
     if m.top.image <> invalid
         m.top.posterURL = m.top.image.url
     else if m.top.json.ImageTags.Primary <> invalid
-        imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+        imgParams = { "maxHeight": 440, "maxWidth": 295 }
         m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
     end if
 end sub

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -16,7 +16,7 @@ sub setData()
     ' Set appropriate Images for Wide and Tall based on type
 
     if datum.type = "CollectionFolder" or datum.type = "UserView"
-        params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
+        params = { "maxHeight": 261, "maxWidth": 464 }
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
 
@@ -37,22 +37,14 @@ sub setData()
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 464 })
 
-        if datum.ImageTags.Primary <> invalid
-            param = { "Tag": datum.ImageTags.Primary }
-            imgParams.Append(param)
-        end if
-
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", imgParams)
 
         ' Add Wide Poster  (Series Backdrop)
         if datum.ParentThumbImageTag <> invalid
-            imgParams["Tag"] = datum.ParentThumbImageTag
             m.top.widePosterUrl = ImageURL(datum.ParentThumbItemId, "Thumb", imgParams)
         else if datum.ParentBackdropImageTags <> invalid
-            imgParams["Tag"] = datum.ParentBackdropImageTags[0]
             m.top.widePosterUrl = ImageURL(datum.ParentBackdropItemId, "Backdrop", imgParams)
         else if datum.ImageTags.Primary <> invalid
-            imgParams["Tag"] = datum.SeriesPrimaryImageTag
             m.top.widePosterUrl = ImageURL(datum.id, "Primary", imgParams)
         end if
 
@@ -64,18 +56,12 @@ sub setData()
             imgParams["UnplayedCount"] = datum.UserData.UnplayedItemCount
         end if
 
-        if datum.ImageTags.Primary <> invalid
-            imgParams["Tag"] = datum.ImageTags.Primary
-        end if
-
         m.top.posterURL = ImageURL(datum.id, "Primary", imgParams)
 
         ' Add Wide Poster  (Series Backdrop)
         if datum.ImageTags <> invalid and datum.imageTags.Thumb <> invalid
-            imgParams["Tag"] = datum.imageTags.Thumb
             m.top.widePosterUrl = ImageURL(datum.Id, "Thumb", imgParams)
         else if datum.BackdropImageTags <> invalid
-            imgParams["Tag"] = datum.BackdropImageTags[0]
             m.top.widePosterUrl = ImageURL(datum.Id, "Backdrop", imgParams)
         end if
 
@@ -89,21 +75,14 @@ sub setData()
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 175 })
 
-        if datum.ImageTags.Primary <> invalid
-            param = { "Tag": datum.ImageTags.Primary }
-            imgParams.Append(param)
-        end if
-
         m.top.posterURL = ImageURL(datum.id, "Primary", imgParams)
 
         ' For wide image, use backdrop
         imgParams["maxWidth"] = 464
 
         if datum.ImageTags <> invalid and datum.imageTags.Thumb <> invalid
-            imgParams["Tag"] = datum.imageTags.Thumb
             m.top.thumbnailUrl = ImageURL(datum.Id, "Thumb", imgParams)
         else if datum.BackdropImageTags[0] <> invalid
-            imgParams["Tag"] = datum.BackdropImageTags[0]
             m.top.thumbnailUrl = ImageURL(datum.id, "Backdrop", imgParams)
         end if
 
@@ -117,31 +96,24 @@ sub setData()
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 175 })
 
-        if datum.ImageTags.Primary <> invalid
-            param = { "Tag": datum.ImageTags.Primary }
-            imgParams.Append(param)
-        end if
-
         m.top.posterURL = ImageURL(datum.id, "Primary", imgParams)
 
         ' For wide image, use backdrop
         imgParams["maxWidth"] = 464
 
         if datum.ImageTags <> invalid and datum.imageTags.Thumb <> invalid
-            imgParams["Tag"] = datum.imageTags.Thumb
             m.top.thumbnailUrl = ImageURL(datum.Id, "Thumb", imgParams)
         else if datum.BackdropImageTags[0] <> invalid
-            imgParams["Tag"] = datum.BackdropImageTags[0]
             m.top.thumbnailUrl = ImageURL(datum.id, "Backdrop", imgParams)
         end if
     else if datum.type = "MusicAlbum"
-        params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 261 }
+        params = { "maxHeight": 261, "maxWidth": 261 }
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
         m.top.posterUrl = m.top.thumbnailURL
 
     else if datum.type = "TvChannel" or datum.type = "Channel"
-        params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
+        params = { "maxHeight": 261, "maxWidth": 464 }
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
         m.top.iconUrl = "pkg:/images/media_type_icons/live_tv_white.png"

--- a/components/data/MovieData.brs
+++ b/components/data/MovieData.brs
@@ -38,19 +38,19 @@ sub setPoster()
     else
 
         if m.top.json.ImageTags.Primary <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         else if m.top.json.ParentThumbImageTag <> invalid and m.top.json.ParentThumbItemId <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ParentThumbImageTag }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
         end if
 
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 720, "maxWidth": 1280 }
             m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 

--- a/components/data/PersonData.brs
+++ b/components/data/PersonData.brs
@@ -12,19 +12,19 @@ sub setPoster()
     else
 
         if m.top.json.ImageTags.Primary <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         else if m.top.json.ParentThumbImageTag <> invalid and m.top.json.ParentThumbItemId <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ParentThumbImageTag }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
         end if
 
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 720, "maxWidth": 1280 }
             m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 

--- a/components/data/PhotoData.brs
+++ b/components/data/PhotoData.brs
@@ -14,19 +14,19 @@ sub setPoster()
     else
 
         if m.top.json.ImageTags.Primary <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         else if m.top.json.ParentThumbImageTag <> invalid and m.top.json.ParentThumbItemId <> invalid
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ParentThumbImageTag }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
         end if
 
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags[0] <> invalid
-            imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 720, "maxWidth": 1280 }
             m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 

--- a/components/data/ScheduleProgramData.brs
+++ b/components/data/ScheduleProgramData.brs
@@ -36,7 +36,7 @@ sub setPoster()
         m.top.posterURL = m.top.image.url
     else
         if m.top.json.ImageTags <> invalid and m.top.json.ImageTags.Thumb <> invalid
-            imgParams = { "maxHeight": 500, "maxWidth": 500, "Tag": m.top.json.ImageTags.Thumb }
+            imgParams = { "maxHeight": 500, "maxWidth": 500 }
             m.top.posterURL = ImageURL(m.top.json.id, "Thumb", imgParams)
         end if
     end if

--- a/components/data/SeriesData.brs
+++ b/components/data/SeriesData.brs
@@ -32,16 +32,16 @@ sub setPoster()
 
         if m.top.json.ImageTags.Primary <> invalid
 
-            imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if m.top.json.BackdropImageTags <> invalid
-            imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags <> invalid
-            imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }
+            imgParams = { "maxHeight": 720, "maxWidth": 1280 }
             m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 

--- a/components/data/VideoData.brs
+++ b/components/data/VideoData.brs
@@ -15,7 +15,7 @@ sub setPoster()
     if m.top.image <> invalid
         m.top.posterURL = m.top.image.url
     else if m.top.json.ImageTags.Primary <> invalid
-        imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+        imgParams = { "maxHeight": 440, "maxWidth": 295 }
         m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
     end if
 end sub


### PR DESCRIPTION
Remove "Tag" from query parameter.  Having "Tag" results in full size posters being returned (> 1920x1080) and if there are enough items on the screen, they all flicker / re-load non-stop.

**Issues**
Fixes: #598 

Question:
Apparently the "Tag" parameter is for caching, however, this is (I believe) only for the Web Client as it modifies the return headers.  I don't believe Roku uses these.  Testing so far has not resulted in noticeable delays in retrieving items.