### PR TITLE
Recommend brightscript extension in VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+      "RokuCommunity.brightscript"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+  }


### PR DESCRIPTION
Ensure the brightscript extension is recommended to users in VSCode.

**Changes**
Create `.vscode/extensions.json` file

**Issues**
extends #610
