### PR TITLE
Add Random Episode Play Button to TV Season page

### DIFF
--- a/components/tvshows/TVEpisodeRow.brs
+++ b/components/tvshows/TVEpisodeRow.brs
@@ -15,7 +15,7 @@ sub updateSize()
     m.top.translation = [450, 180]
 
     itemWidth = 1360
-    itemHeight = 250
+    itemHeight = 300
 
     m.top.visible = true
 

--- a/components/tvshows/TVEpisodeRow.brs
+++ b/components/tvshows/TVEpisodeRow.brs
@@ -12,18 +12,16 @@ sub init()
 end sub
 
 sub updateSize()
-    dimensions = m.top.getScene().currentDesignResolution
+    m.top.translation = [450, 180]
 
-    border = 96
-    m.top.translation = [border, 75 + 115]
-
-    itemWidth = (dimensions["width"] - border * 2)
-    itemHeight = 400
+    itemWidth = 1360
+    itemHeight = 250
 
     m.top.visible = true
 
     ' Size of the individual rows
-    m.top.itemSize = [dimensions["width"] - border * 2, itemHeight]
+    m.top.itemSize = [itemWidth, itemHeight]
+
     ' Spacing between Rows
     m.top.itemSpacing = [0, 40]
 

--- a/components/tvshows/TVEpisodes.brs
+++ b/components/tvshows/TVEpisodes.brs
@@ -2,6 +2,11 @@ sub init()
     m.top.optionsAvailable = false
 
     m.rows = m.top.findNode("picker")
+    m.poster = m.top.findNode("seasonPoster")
+    m.Random = m.top.findNode("Random")
+    m.tvEpisodeRow = m.top.findNode("tvEpisodeRow")
+
+
     m.rows.observeField("doneLoading", "updateSeason")
 end sub
 
@@ -10,11 +15,33 @@ sub setSeasonLoading()
 end sub
 
 sub updateSeason()
+    imgParams = { "maxHeight": 450, "maxWidth": 300 }
+    m.poster.uri = ImageURL(m.top.seasonData.Id, "Primary", imgParams)
     m.top.overhangTitle = m.top.seasonData.SeriesName + " - " + m.top.seasonData.name
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
     handled = false
+
+    if key = "left" and not m.Random.hasFocus()
+        m.Random.setFocus(true)
+        return true
+    end if
+
+    if key = "right" and not m.tvEpisodeRow.hasFocus()
+        m.tvEpisodeRow.setFocus(true)
+        return true
+    end if
+
+
+    if key = "OK" or key = "play"
+        if m.Random.hasFocus()
+            randomEpisode = Rnd(m.rows.getChild(0).objects.items.count()) - 1
+            m.top.quickPlayNode = m.rows.getChild(0).objects.items[randomEpisode]
+            return true
+        end if
+    end if
+
 
     focusedChild = m.top.focusedChild.focusedChild
     if focusedChild.content = invalid then return handled

--- a/components/tvshows/TVEpisodes.brs
+++ b/components/tvshows/TVEpisodes.brs
@@ -17,6 +17,7 @@ end sub
 sub updateSeason()
     imgParams = { "maxHeight": 450, "maxWidth": 300 }
     m.poster.uri = ImageURL(m.top.seasonData.Id, "Primary", imgParams)
+    m.Random.visible = true
     m.top.overhangTitle = m.top.seasonData.SeriesName + " - " + m.top.seasonData.name
 end sub
 

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -2,7 +2,7 @@
 <component name="TVEpisodes" extends="JFGroup">
   <children>
     <Poster id="seasonPoster" width="300" height="450" translation="[95,175]" />
-    <JFButton id="Random" text="Play Random" translation="[90, 640]"></JFButton>
+    <JFButton id="Random" text="Play Random" translation="[90, 640]" visible="false"></JFButton>
     <TVEpisodeRowWithOptions id="picker" visible="true" />
   </children>
   <interface>

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="TVEpisodes" extends="JFGroup">
   <children>
+    <Poster id="seasonPoster" width="300" height="450" translation="[95,175]" />
+    <JFButton id="Random" text="Play Random" translation="[90, 640]"></JFButton>
     <TVEpisodeRowWithOptions id="picker" visible="true" />
   </children>
   <interface>
@@ -10,4 +12,7 @@
     <field id="objects" alias="picker.objects" />
   </interface>
   <script type="text/brightscript" uri="TVEpisodes.brs" />
+  <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -3,11 +3,11 @@
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
-        <Poster id="poster" width="534" height="400" />
+        <Poster id="poster" width="350" height="250" />
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />
-          <ScrollingLabel id="title" font="font:LargeBoldSystemFont" maxWidth="1200" />
+          <ScrollingLabel id="title" font="font:MediumBoldSystemFont" maxWidth="950" />
           <LayoutGroup layoutDirection="horiz" itemSpacings="[20]">
             <Label id="runtime" font="font:SmallestSystemFont" />
             <LayoutGroup layoutDirection="horiz" itemSpacings="[-5]">
@@ -16,8 +16,8 @@
             </LayoutGroup>
             <Label id="endtime" font="font:SmallestSystemFont" />
           </LayoutGroup>
-          <Label id="overview" wrap="true" height="170" width="1200" maxLines="4" ellipsizeOnBoundary="true"/>
-          <LayoutGroup layoutDirection="horiz" itemSpacings="[15]">
+          <Label id="overview" font="font:SmallestSystemFont" wrap="true" height="150" width="950" maxLines="3" ellipsizeOnBoundary="true"/>
+          <LayoutGroup layoutDirection="horiz" itemSpacings="[15]" visible="false">
             <Label id="video_codec" />
             <ScrollingLabel id="audio_codec" />
             <label id="audio_codec_count" font="font:smallestSystemFont" vertAlign="top" color="#ceffff" />

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -3,7 +3,7 @@
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
-        <Poster id="poster" width="350" height="250" />
+        <Poster id="poster" width="350" height="300" />
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />
@@ -16,10 +16,10 @@
             </LayoutGroup>
             <Label id="endtime" font="font:SmallestSystemFont" />
           </LayoutGroup>
-          <Label id="overview" font="font:SmallestSystemFont" wrap="true" height="150" width="950" maxLines="3" ellipsizeOnBoundary="true"/>
-          <LayoutGroup layoutDirection="horiz" itemSpacings="[15]" visible="false">
-            <Label id="video_codec" />
-            <ScrollingLabel id="audio_codec" />
+          <Label id="overview" font="font:SmallestSystemFont" wrap="true" height="130" width="950" maxLines="3" ellipsizeOnBoundary="true"/>
+          <LayoutGroup layoutDirection="horiz" itemSpacings="[15]">
+            <Label id="video_codec" font="font:SmallestSystemFont" />
+            <ScrollingLabel id="audio_codec" font="font:SmallestSystemFont" />
             <label id="audio_codec_count" font="font:smallestSystemFont" vertAlign="top" color="#ceffff" />
           </LayoutGroup>
         </LayoutGroup>

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -264,7 +264,7 @@ function TVEpisodes(show_id as string, season_id as string)
     data = getJson(resp)
     results = []
     for each item in data.Items
-        imgParams = { "AddPlayedIndicator": item.UserData.Played, "maxWidth": 712, "maxheight": 400 }
+        imgParams = { "AddPlayedIndicator": item.UserData.Played, "maxWidth": 400, "maxheight": 250 }
         if item.UserData.PlayedPercentage <> invalid
             param = { "PercentPlayed": item.UserData.PlayedPercentage }
             imgParams.Append(param)
@@ -272,7 +272,7 @@ function TVEpisodes(show_id as string, season_id as string)
         tmp = CreateObject("roSGNode", "TVEpisodeData")
         tmp.image = PosterImage(item.id, imgParams)
         if tmp.image <> invalid
-            tmp.image.posterDisplayMode = "scaleToFit"
+            tmp.image.posterDisplayMode = "scaleToZoom"
         end if
         tmp.json = item
         tmp.overview = ItemMetaData(item.id).overview


### PR DESCRIPTION
**Changes**
I added a button to the TV Season page that selects a random episode and plays it. 

To accommodate the button, and planning for future buttons such ask shuffle play, I had to adjust the layout/design of the TV Season page slightly to create room for the action buttons. 

One important note, I did hide the codec information at the bottom of each episode item to help reduce the height. Does anyone see this as required information that needs to be worked back in? It's not info that's shown on the season web client screen.