### PR TITLE
Jump to 1st item in folder

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -47,6 +47,11 @@ sub init()
 
     m.Alpha = m.top.findNode("AlphaMenu")
     m.AlphaSelected = m.top.findNode("AlphaSelected")
+
+    'Get reset folder setting
+    m.resetGrid = get_user_setting("itemgrid.reset") = "true"
+    print "reset grid setting: " m.resetGrid
+
 end sub
 
 '
@@ -555,7 +560,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
         m.Alpha.visible = true
         topGrp.setFocus(true)
         return true
+    else if key = "replay" and topGrp.isinFocusChain()
+        if m.resetGrid = true
+            m.itemGrid.animateToItem = 0
+        else
+            m.itemGrid.jumpToItem = 0
+        end if
     end if
+
     return false
 end function
 

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -560,12 +560,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else if key = "replay" and topGrp.isinFocusChain()
         if m.resetGrid = true
-        m.itemGrid.animateToItem = 0
+            m.itemGrid.animateToItem = 0
         else
-        m.itemGrid.jumpToItem = 0 
+            m.itemGrid.jumpToItem = 0
         end if
     end if
-    
+
     return false
 end function
 

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -50,8 +50,6 @@ sub init()
 
     'Get reset folder setting
     m.resetGrid = get_user_setting("itemgrid.reset") = "true"
-    print "reset grid setting: " m.resetGrid
-
 end sub
 
 '
@@ -562,12 +560,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else if key = "replay" and topGrp.isinFocusChain()
         if m.resetGrid = true
-            m.itemGrid.animateToItem = 0
+        m.itemGrid.animateToItem = 0
         else
-            m.itemGrid.jumpToItem = 0
+        m.itemGrid.jumpToItem = 0 
         end if
     end if
-
+    
     return false
 end function
 

--- a/components/ItemGrid/ItemGrid.xml
+++ b/components/ItemGrid/ItemGrid.xml
@@ -40,6 +40,7 @@
     <field id="imageDisplayMode" type="string" value="scaleToZoom" />
     <field id="AlphaSelected" type="string" alias="AlphaMenu.itemAlphaSelected" alwaysNotify="true" onChange="onItemAlphaSelected" />
     <field id="alphaActive" type="boolean" value="false" />
+    <field id="jumpToItem" type="integer" value="" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -33,6 +33,13 @@
                         "settingName": "itemgrid.alwaysShowTitles",
                         "type": "bool",
                         "default": "false"
+                    },
+                    {
+                        "title": "Item Reset",
+                        "description": "Use the refresh button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)",
+                        "settingName": "itemgrid.reset",
+                        "type": "bool",
+                        "default": "true"
                     }
                 ]
             }


### PR DESCRIPTION
Added a user setting to set how the refresh button works in the grid screen. 
If "Item Reset" is disabled - The grid will "Jump" to 1st item in folder
If "Item Reset" is enabled - The grid will "Animate" to 1st item in folder

**Changes**
1. added User Interface -> Media Grid -> "Item Reset" 
2. allows user to set the jump or animate to the first item in the folder using the refresh button on the remote

This is in reference to #637 

