### PR TITLE
Code cleanup - Setup option values by collection type

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -130,6 +130,127 @@ sub loadInitialItems()
 
 end sub
 
+' Set Movies view, sort, and filter options
+sub setMoviesOptions(options)
+    options.views = [
+        { "Title": tr("Movies"), "Name": "movies" },
+    ]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" },
+        { "Title": tr("IMDB_RATING"), "Name": "CommunityRating" },
+        { "Title": tr("CRITIC_RATING"), "Name": "CriticRating" },
+        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
+        { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
+        { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
+        { "Title": tr("PLAY_COUNT"), "Name": "PlayCount" },
+        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
+        { "Title": tr("RUNTIME"), "Name": "Runtime" }
+    ]
+    options.filter = [
+        { "Title": tr("All"), "Name": "All" },
+        { "Title": tr("Favorites"), "Name": "Favorites" }
+    ]
+end sub
+
+' Set Boxset view, sort, and filter options
+sub setBoxsetsOptions(options)
+    options.views = [{ "Title": tr("Shows"), "Name": "shows" }]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" },
+        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
+        { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
+        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
+    ]
+    options.filter = [
+        { "Title": tr("All"), "Name": "All" },
+        { "Title": tr("Favorites"), "Name": "Favorites" }
+    ]
+end sub
+
+' Set TV Show view, sort, and filter options
+sub setTvShowsOptions(options)
+    options.views = [{ "Title": tr("Shows"), "Name": "shows" }]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" },
+        { "Title": tr("IMDB_RATING"), "Name": "CommunityRating" },
+        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
+        { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
+        { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
+        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
+    ]
+    options.filter = [
+        { "Title": tr("All"), "Name": "All" },
+        { "Title": tr("Favorites"), "Name": "Favorites" }
+    ]
+end sub
+
+' Set Live TV view, sort, and filter options
+sub setLiveTvOptions(options)
+    options.views = [
+        { "Title": tr("Channels"), "Name": "livetv" },
+        { "Title": tr("TV Guide"), "Name": "tvGuide" }
+    ]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" }
+    ]
+    options.filter = [
+        { "Title": tr("All"), "Name": "All" },
+        { "Title": tr("Favorites"), "Name": "Favorites" }
+    ]
+    options.favorite = [
+        { "Title": tr("Favorite"), "Name": "Favorite" }
+    ]
+end sub
+
+' Set Music view, sort, and filter options
+sub setMusicOptions(options)
+    options.views = [{ "Title": tr("Music"), "Name": "music" }]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" },
+        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
+        { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
+        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
+    ]
+    options.filter = [
+        { "Title": tr("All"), "Name": "All" },
+        { "Title": tr("Favorites"), "Name": "Favorites" }
+    ]
+end sub
+
+' Set Photo Album view, sort, and filter options
+sub setPhotoAlbumOptions(options)
+    ' TODO/FIXME: Show shuffle options once implemented
+    ' options.views = [
+    '     { "Title": tr("Don't Shuffle"), "Name": "singlephoto"}
+    '     { "Title": tr("Shuffle"), "Name": "shufflephoto"}
+    ' ]
+    options.views = []
+    options.sort = []
+end sub
+
+' Set Default view, sort, and filter options
+sub setDefaultOptions(options)
+    options.views = [
+        { "Title": tr("Default"), "Name": "default" }
+    ]
+    options.sort = [
+        { "Title": tr("TITLE"), "Name": "SortName" }
+    ]
+end sub
+
+' Return parent collection type
+function getCollectionType() as string
+    return m.top.parentItem.collectionType
+end function
+
+' Search string array for search value. Return if it's found
+function inStringArray(array, searchValue) as boolean
+    for each item in array
+        if lcase(item) = lcase(searchValue) then return true
+    end for
+    return false
+end function
+
 ' Data to display when options button selected
 sub SetUpOptions()
 
@@ -137,104 +258,23 @@ sub SetUpOptions()
     options.filter = []
     options.favorite = []
 
-    'Movies
-    if m.top.parentItem.collectionType = "movies"
-        options.views = [
-            { "Title": tr("Movies"), "Name": "movies" },
-        ]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" },
-            { "Title": tr("IMDB_RATING"), "Name": "CommunityRating" },
-            { "Title": tr("CRITIC_RATING"), "Name": "CriticRating" },
-            { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
-            { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
-            { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
-            { "Title": tr("PLAY_COUNT"), "Name": "PlayCount" },
-            { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
-            { "Title": tr("RUNTIME"), "Name": "Runtime" }
-        ]
-        options.filter = [
-            { "Title": tr("All"), "Name": "All" },
-            { "Title": tr("Favorites"), "Name": "Favorites" }
-        ]
-        'Boxsets
-    else if m.top.parentItem.collectionType = "boxsets"
-        options.views = [{ "Title": tr("Shows"), "Name": "shows" }]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" },
-            { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
-            { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
-            { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
-        ]
-        options.filter = [
-            { "Title": tr("All"), "Name": "All" },
-            { "Title": tr("Favorites"), "Name": "Favorites" }
-        ]
-        'TV Shows
-    else if m.top.parentItem.collectionType = "tvshows"
-        options.views = [{ "Title": tr("Shows"), "Name": "shows" }]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" },
-            { "Title": tr("IMDB_RATING"), "Name": "CommunityRating" },
-            { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
-            { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
-            { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
-            { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
-        ]
-        options.filter = [
-            { "Title": tr("All"), "Name": "All" },
-            { "Title": tr("Favorites"), "Name": "Favorites" }
-        ]
-        'Live TV
-    else if m.top.parentItem.collectionType = "livetv"
-        options.views = [
-            { "Title": tr("Channels"), "Name": "livetv" },
-            { "Title": tr("TV Guide"), "Name": "tvGuide" }
-        ]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" }
-        ]
-        options.filter = [
-            { "Title": tr("All"), "Name": "All" },
-            { "Title": tr("Favorites"), "Name": "Favorites" }
-        ]
-        options.favorite = [
-            { "Title": tr("Favorite"), "Name": "Favorite" }
-        ]
-    else if m.top.parentItem.collectionType = "photoalbum" or m.top.parentItem.collectionType = "photo" or m.top.parentItem.collectionType = "homevideos"
-        ' For some reason, my photo library shows up as "homevideos", maybe because it has some mp4 mixed in with the jpgs?
-
-        ' TODO/FIXME: Show shuffle options once implemented
-        ' options.views = [
-        '     { "Title": tr("Don't Shuffle"), "Name": "singlephoto"}
-        '     { "Title": tr("Shuffle"), "Name": "shufflephoto"}
-        ' ]
-        options.views = []
-        options.sort = []
-        options.filter = []
-        'Music
-    else if m.top.parentItem.collectionType = "music"
-        options.views = [{ "Title": tr("Music"), "Name": "music" }]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" },
-            { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
-            { "Title": tr("DATE_PLAYED"), "Name": "DatePlayed" },
-            { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
-        ]
-        options.filter = [
-            { "Title": tr("All"), "Name": "All" },
-            { "Title": tr("Favorites"), "Name": "Favorites" }
-        ]
+    if getCollectionType() = "movies"
+        setMoviesOptions(options)
+    else if getCollectionType() = "boxsets"
+        setBoxsetsOptions(options)
+    else if getCollectionType() = "tvshows"
+        setTvShowsOptions(options)
+    else if getCollectionType() = "livetv"
+        setLiveTvOptions(options)
+    else if inStringArray(["photoalbum", "photo", "homevideos"], getCollectionType())
+        setPhotoAlbumOptions(options)
+    else if getCollectionType() = "music"
+        setMusicOptions(options)
     else
-        options.views = [
-            { "Title": tr("Default"), "Name": "default" }
-        ]
-        options.sort = [
-            { "Title": tr("TITLE"), "Name": "SortName" }
-        ]
-        options.filter = []
+        setDefaultOptions(options)
     end if
 
+    ' Set selected view option
     for each o in options.views
         if o.Name = m.view
             o.Selected = true
@@ -243,6 +283,7 @@ sub SetUpOptions()
         end if
     end for
 
+    ' Set selected sort option
     for each o in options.sort
         if o.Name = m.sortField
             o.Selected = true
@@ -251,6 +292,7 @@ sub SetUpOptions()
         end if
     end for
 
+    ' Set selected filter option
     for each o in options.filter
         if o.Name = m.filter
             o.Selected = true
@@ -258,14 +300,7 @@ sub SetUpOptions()
         end if
     end for
 
-    ' for each o in options.favorite
-    '     if o.Name = m.favorite
-    '         m.options.favorite = o.Name
-    '     end if
-    ' end for
-
     m.options.options = options
-
 end sub
 
 


### PR DESCRIPTION
**Changes**
Doing some code cleanup inside itemgrid.brs. There's still a lot that can be cleaned, but I want to take it in small chunks.

For this one, I focused on SetUpOptions(). I reduced large functions/conditions to make the easier to read, moved duplicated code to functions, added function comments, and removed commented out code (If it's coming back, we can pull it from GitHub history.)