### PR TITLE
Check if overview is empty

### DIFF
--- a/components/music/MusicAlbumDetails.brs
+++ b/components/music/MusicAlbumDetails.brs
@@ -70,8 +70,8 @@ end sub
 ' Populate on screen text variables
 sub setOnScreenTextValues(json)
     if isValid(json)
-        if isValid(json.overview)
-            ' Have have overview text
+        if isValid(json.overview) and json.overview <> ""
+            ' We have overview text
             setFieldTextValue("overview", json.overview)
         else
             ' We don't have overview text


### PR DESCRIPTION
**Changes**
For album overview, we check if overview is invalid. If so we show more songs. This change also checks if the overview is an empty string to show more songs.