### PR TITLE
Add setting: Use splashscreen as screensaver bg

### DIFF
--- a/components/screensaver/Screensaver.brs
+++ b/components/screensaver/Screensaver.brs
@@ -8,4 +8,9 @@ sub init()
 
     m.BounceAnimation = m.top.findNode("BounceAnimation")
     m.BounceAnimation.control = "start" 'Start BounceAnimation
+
+    if get_user_setting("ui.screensaver.splashBackground") = "true"
+        m.backdrop = m.top.findNode("backdrop")
+        m.backdrop.uri = buildURL("/Branding/Splashscreen?format=jpg&foregroundLayer=0.15&fillWidth=1280&width=1280&fillHeight=720&height=720&tag=splash")
+    end if
 end sub

--- a/components/screensaver/Screensaver.xml
+++ b/components/screensaver/Screensaver.xml
@@ -4,6 +4,7 @@
 <script type="text/brightscript" uri = "Screensaver.brs"/>
 
 <children>
+	<Poster id="backdrop" loadDisplayMode="scaleToZoom" width="1920" height="1200" />
 
 <!-- Makes 2 Posters on top of each other -->
 	<Poster
@@ -140,4 +141,6 @@
 	</SequentialAnimation>
 	
 </children>
+  <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -574,14 +574,33 @@
         <translation>There was an error authenticating via Quick Connect.</translation>
     </message>
     <message>
-    <source>Return to Top</source>
-    <translation>Return to Top</translation>
-    <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
-</message>
-<message>
-    <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
-    <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
-    <extracomment>Description for option in Setting Screen</extracomment>
-</message>
+        <source>Return to Top</source>
+        <translation>Return to Top</translation>
+        <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
+        <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+    <message>
+        <source>Screensaver</source>
+        <translation>Screensaver</translation>
+    </message>
+    <message>
+        <source>Options for Jellyfin's screensaver.</source>
+        <translation>Options for Jellyfin's screensaver.</translation>
+        <extracomment>Description for Screensaver user settings.</extracomment>
+    </message>
+    <message>
+        <source>Use Splashscreen as Screensaver Background</source>
+        <translation>Use Splashscreen as Screensaver Background</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>Use generated splashscreen image as Jellyfin's screensaver background.</source>
+        <translation>Use generated splashscreen image as Jellyfin's screensaver background.</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
 </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,6 +17,19 @@
         "description": "Settings relating to how the how the applications looks",
         "children": [
             {
+                "title": "Screensaver",
+                "description": "Options for Jellyfin's screensaver.",
+                "children": [
+                    {
+                        "title": "Use Splashscreen as Screensaver Background",
+                        "description": "Use generated splashscreen image as Jellyfin's screensaver background.",
+                        "settingName": "ui.screensaver.splashBackground",
+                        "type": "bool",
+                        "default": "false"
+                    }
+                ]
+            },
+            {
                 "title": "Media Grid",
                 "description": "Media Grid Options",
                 "children": [


### PR DESCRIPTION
**Changes**
Adds a setting allowing the user to use their generated splashscreen as the background for the default screensaver.

This does not change the background for the custom music NowPlaying screensaver.
