### PR TITLE
Fix Collection Folder Error

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -259,7 +259,7 @@ end sub
 
 ' Return parent collection type
 function getCollectionType() as string
-    return m.top.parentItem.collectionType
+    return m.top.parentItem.Type
 end function
 
 ' Search string array for search value. Return if it's found


### PR DESCRIPTION
When selecting a collection inside the collections folder Roku would throw an error and not show the items inside a collection folder


**Changes**
Changed the variable m.top.parentItem.CollectionType to m.top.parentItem.Type
