### PR TITLE
Add setting to hide taglines on movie detail pages

### DIFF
--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -12,6 +12,9 @@ sub init()
     overview = m.top.findNode("overview")
     overview.width = 1920 - 96 - 300 - 96 - 30
 
+    m.details = m.top.findNode("details")
+    m.tagline = m.top.findNode("tagline")
+
     m.buttonGrp = m.top.findNode("buttons")
     m.buttonGrp.setFocus(true)
     m.top.lastFocus = m.buttonGrp
@@ -90,9 +93,13 @@ sub itemContentChanged()
     if itemData.mediaStreams[0] <> invalid
         setFieldText("video_codec", tr("Video") + ": " + itemData.mediaStreams[0].displayTitle)
     end if
-    ' TODO - cmon now. these are buttons, not words
-    if itemData.taglines.count() > 0
-        setFieldText("tagline", itemData.taglines[0])
+
+    if get_user_setting("ui.details.hidetagline") = "false"
+        if itemData.taglines.count() > 0
+            setFieldText("tagline", itemData.taglines[0])
+        end if
+    else
+        m.details.removeChild(m.tagline)
     end if
 
     setFavoriteColor()

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -5,7 +5,7 @@
       <Poster id="moviePoster"
         translation="[250,150]"
         width="300" height="450" />
-      <LayoutGroup layoutDirection="vert" translation="[455, 150]" itemSpacings="[25]">
+      <LayoutGroup layoutDirection="vert" translation="[455, 150]" itemSpacings="[25]" id="details">
         <LayoutGroup layoutDirection="horiz" itemSpacings="[100]" id="infoGroup">
           <Label id="releaseYear" />
           <Label id="runtime" />
@@ -50,5 +50,6 @@
     <field id="selectedVideoStreamId" type="string" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="MovieDetails.brs" />
 </component>

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -4,7 +4,7 @@
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[-10]" >
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[15]" >
         <Poster id="tvshowPoster" width="300" height="450" />
-        <LayoutGroup layoutDirection="vert" itemSpacings="[15]" id="details">
+        <LayoutGroup layoutDirection="vert" itemSpacings="[15]">
           <LayoutGroup layoutDirection="horiz" itemSpacings="[150]">
             <Label id="releaseYear" />
             <Label id="officialRating" />

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -4,7 +4,7 @@
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[-10]" >
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[15]" >
         <Poster id="tvshowPoster" width="300" height="450" />
-        <LayoutGroup layoutDirection="vert" itemSpacings="[15]">
+        <LayoutGroup layoutDirection="vert" itemSpacings="[15]" id="details">
           <LayoutGroup layoutDirection="horiz" itemSpacings="[150]">
             <Label id="releaseYear" />
             <Label id="officialRating" />

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -574,14 +574,33 @@
         <translation>There was an error authenticating via Quick Connect.</translation>
     </message>
     <message>
-    <source>Return to Top</source>
-    <translation>Return to Top</translation>
-    <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
-</message>
-<message>
-    <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
-    <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
-    <extracomment>Description for option in Setting Screen</extracomment>
-</message>
+        <source>Return to Top</source>
+        <translation>Return to Top</translation>
+        <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
+        <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+    <message>
+        <source>Detail Page</source>
+        <translation>Detail Page</translation>
+    </message>
+    <message>
+        <source>Options for details pages.</source>
+        <translation>Options for details pages.</translation>
+        <extracomment>Description for Detail Page user settings.</extracomment>
+    </message>
+    <message>
+        <source>Hide Taglines</source>
+        <translation>Hide Taglines</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>Hides tagline text on details pages.</source>
+        <translation>Hides tagline text on details pages.</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
 </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,6 +17,19 @@
         "description": "Settings relating to how the how the applications looks",
         "children": [
             {
+                "title": "Detail Page",
+                "description": "Options for details pages.",
+                "children": [
+                    {
+                        "title": "Hide Taglines",
+                        "description": "Hides tagline text on details pages.",
+                        "settingName": "ui.details.hidetagline",
+                        "type": "bool",
+                        "default": "false"
+                    }
+                ]
+            },
+            {
                 "title": "Media Grid",
                 "description": "Media Grid Options",
                 "children": [


### PR DESCRIPTION
**Changes**
Creates new user setting that allows for toggling visible/hidden of the movie tagline text content. Setting comes from a request posted on reddit.

https://www.reddit.com/r/jellyfin/comments/vezhz6/disable_taglines/