### PR TITLE
Add user setting: blur posters of unwatched episodes

### DIFF
--- a/components/ListPoster.brs
+++ b/components/ListPoster.brs
@@ -56,7 +56,18 @@ sub itemContentChanged() as void
     end if
     m.staticTitle.text = m.title.text
 
-    m.poster.uri = itemData.posterUrl
+    imageUrl = itemData.posterURL
+
+    if get_user_setting("ui.tvshows.blurunwatched") = "true"
+
+        if itemData.json.lookup("Type") = "Episode"
+            if not itemData.json.userdata.played
+                imageUrl = imageUrl + "&blur=15"
+            end if
+        end if
+    end if
+
+    m.poster.uri = imageUrl
 
     updateSize()
 end sub

--- a/components/ListPoster.xml
+++ b/components/ListPoster.xml
@@ -23,5 +23,5 @@
   </interface>
 
   <script type="text/brightscript" uri="ListPoster.brs" />
-
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -3,6 +3,7 @@ sub init()
     m.title.text = tr("Loading...")
     m.options = m.top.findNode("tvListOptions")
     m.overview = m.top.findNode("overview")
+    m.poster = m.top.findNode("poster")
     m.deviceInfo = CreateObject("roDeviceInfo")
 end sub
 
@@ -15,8 +16,19 @@ sub itemContentChanged()
         indexNumber = ""
     end if
     m.title.text = indexNumber + item.title
-    m.top.findNode("poster").uri = item.posterURL
     m.overview.text = item.overview
+
+    imageUrl = item.posterURL
+
+    if get_user_setting("ui.tvshows.blurunwatched") = "true"
+        if itemData.lookup("Type") = "Episode"
+            if not itemData.userdata.played
+                imageUrl = imageUrl + "&blur=15"
+            end if
+        end if
+    end if
+
+    m.poster.uri = imageUrl
 
     if type(itemData.RunTimeTicks) = "LongInteger"
         m.top.findNode("runtime").text = stri(getRuntime()).trim() + " mins"

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -33,4 +33,5 @@
   </interface>
   <script type="text/brightscript" uri="TVListDetails.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -574,14 +574,34 @@
         <translation>There was an error authenticating via Quick Connect.</translation>
     </message>
     <message>
-    <source>Return to Top</source>
-    <translation>Return to Top</translation>
-    <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
-</message>
-<message>
-    <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
-    <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
-    <extracomment>Description for option in Setting Screen</extracomment>
-</message>
+        <source>Return to Top</source>
+        <translation>Return to Top</translation>
+        <extracomment>UI -> Media Grid -> Item Title in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</source>
+        <translation>Use the replay button to slowly animate to the first item in the folder. (If disabled, The folder will reset to the first item immediately)</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+
+    <message>
+        <source>TV Shows</source>
+        <translation>TV Shows</translation>
+    </message>
+    <message>
+        <source>Options for TV Shows.</source>
+        <translation>Options for TV Shows.</translation>
+        <extracomment>Description for TV Shows user settings.</extracomment>
+    </message>
+    <message>
+        <source>Blur Unwatched Episodes</source>
+        <translation>Blur Unwatched Episodes</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>If enabled, images for unwatched episodes will be blurred.</source>
+        <translation>If enabled, images for unwatched episodes will be blurred.</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
 </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,6 +17,19 @@
         "description": "Settings relating to how the how the applications looks",
         "children": [
             {
+                "title": "TV Shows",
+                "description": "Options for TV Shows.",
+                "children": [
+                    {
+                        "title": "Blur Unwatched Episodes",
+                        "description": "If enabled, images for unwatched episodes will be blurred.",
+                        "settingName": "ui.tvshows.blurunwatched",
+                        "type": "bool",
+                        "default": "false"
+                    }
+                ]
+            },
+            {
                 "title": "Media Grid",
                 "description": "Media Grid Options",
                 "children": [


### PR DESCRIPTION
**Changes**
Adds a user setting that when enabled will blur unwatched tv episodes on season detail page and in search results.

https://www.reddit.com/r/jellyfin/comments/ky6mrf/hiding_ep_thumbnails_cause_of_spoilers/
https://www.reddit.com/r/jellyfin/comments/sn5qtw/is_there_a_way_to_blur_our_unwatched_episode/