### PR TITLE
Crash when trying to read subtitle track for live tv.

### DIFF
--- a/source/utils/Subtitles.brs
+++ b/source/utils/Subtitles.brs
@@ -22,7 +22,6 @@ end function
 function defaultSubtitleTrackFromVid(video_id) as integer
     meta = ItemMetaData(video_id)
     if meta.json.mediaSources <> invalid
-        if meta = invalid then return invalid
         subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
         default_text_subs = defaultSubtitleTrack(subtitles["all"], true) ' Find correct subtitle track (forced text)
         if default_text_subs <> -1

--- a/source/utils/Subtitles.brs
+++ b/source/utils/Subtitles.brs
@@ -21,14 +21,19 @@ end function
 ' returns the server-side track index for the appriate subtitle
 function defaultSubtitleTrackFromVid(video_id) as integer
     meta = ItemMetaData(video_id)
-    if meta = invalid then return invalid
-    subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
-    default_text_subs = defaultSubtitleTrack(subtitles["all"], true) ' Find correct subtitle track (forced text)
-    if default_text_subs <> -1
-        return default_text_subs
-    else
-        return defaultSubtitleTrack(subtitles["all"]) ' if no appropriate text subs exist, allow non-text
+    if meta.json.mediaSources <> invalid
+        if meta = invalid then return invalid
+        subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
+        default_text_subs = defaultSubtitleTrack(subtitles["all"], true) ' Find correct subtitle track (forced text)
+        if default_text_subs <> -1
+            return default_text_subs
+        else
+            return defaultSubtitleTrack(subtitles["all"]) ' if no appropriate text subs exist, allow non-text
+        end if
     end if
+
+    ' No valid mediaSources (i.e. LiveTV)
+    return -1
 end function
 
 


### PR DESCRIPTION
Fix crash when trying to play LiveTV from the Home Screen via "On Now"

**Changes**
Skips trying to load subtitle tracks if there are no mediaSources (i.e. LiveTV).
