### PR TITLE
betterize subtitle profiles

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -175,6 +175,22 @@ function getDeviceProfile() as object
             {
                 "Format": "ssa",
                 "Method": "Embed"
+            },
+            {
+                "Format": "smi",
+                "Method": "Encode"
+            },
+            {
+                "Format": "dvdsub",
+                "Method": "Encode"
+            },
+            {
+                "Format": "pgs",
+                "Method": "Encode"
+            },
+            {
+                "Format": "pgssub",
+                "Method": "Encode"
             }
         ]
     }

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -161,6 +161,14 @@ function getDeviceProfile() as object
                 "Method": "Embed"
             },
             {
+                "Format": "srt",
+                "Method": "External"
+            },
+            {
+                "Format": "srt",
+                "Method": "Embed"
+            },
+            {
                 "Format": "ass",
                 "Method": "External"
             },

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -141,16 +141,40 @@ function getDeviceProfile() as object
                 "Method": "External"
             },
             {
-                "Format": "srt",
-                "Method": "External"
+                "Format": "vtt",
+                "Method": "Embed"
             },
             {
                 "Format": "ttml",
                 "Method": "External"
             },
             {
+                "Format": "ttml",
+                "Method": "Embed"
+            },
+            {
                 "Format": "sub",
                 "Method": "External"
+            },
+            {
+                "Format": "sub",
+                "Method": "Embed"
+            },
+            {
+                "Format": "ass",
+                "Method": "External"
+            },
+            {
+                "Format": "ass",
+                "Method": "Embed"
+            },
+            {
+                "Format": "ssa",
+                "Method": "External"
+            },
+            {
+                "Format": "ssa",
+                "Method": "Embed"
             }
         ]
     }


### PR DESCRIPTION
most profiles i have looked at list multiple available methods for each format, so I have replicated that.  The addition of ass and ssa profiles in particular prevents malfunctions with those types where they appear to require transcoding but in fact do not.

**Changes**
add ass and ssa subtitle profiles to prevent failures with those types
extend all textual profiles to include "embed" instead of only "external"

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
