### PR TITLE
Add user setting: Hide Clock

### DIFF
--- a/components/JFOverhang.brs
+++ b/components/JFOverhang.brs
@@ -3,8 +3,10 @@ sub init()
     ' hide seperators till they're needed
     leftSeperator = m.top.findNode("overlayLeftSeperator")
     leftSeperator.visible = "false"
-    rightSeperator = m.top.findNode("overlayRightSeperator")
-    rightSeperator.visible = "false"
+    m.rightSeperator = m.top.findNode("overlayRightSeperator")
+
+    m.hideClock = get_user_setting("ui.design.hideclock") = "true"
+
     ' set font sizes
     optionText = m.top.findNode("overlayOptionsText")
     optionText.font.size = 20
@@ -12,20 +14,30 @@ sub init()
     optionStar.font.size = 58
     overlayMeridian = m.top.findNode("overlayMeridian")
     overlayMeridian.font.size = 20
-    ' get system preference clock format (12/24hr)
-    di = CreateObject("roDeviceInfo")
-    m.clockFormat = di.GetClockFormat()
-    ' grab current time
-    currentTime = CreateObject("roDateTime")
-    currentTime.ToLocalTime()
-    m.currentHours = currentTime.GetHours()
-    m.currentMinutes = currentTime.GetMinutes()
-    ' start timer
-    m.currentTimeTimer = m.top.findNode("currentTimeTimer")
-    m.currentTimeTimer.control = "start"
-    m.currentTimeTimer.ObserveField("fire", "updateTime")
 
-    updateTimeDisplay()
+    m.overlayRightGroup = m.top.findNode("overlayRightGroup")
+    m.overlayTimeGroup = m.top.findNode("overlayTimeGroup")
+
+    if not m.hideClock
+        ' get system preference clock format (12/24hr)
+        di = CreateObject("roDeviceInfo")
+        m.clockFormat = di.GetClockFormat()
+
+        ' grab current time
+        currentTime = CreateObject("roDateTime")
+        currentTime.ToLocalTime()
+        m.currentHours = currentTime.GetHours()
+        m.currentMinutes = currentTime.GetMinutes()
+
+        ' start timer
+        m.currentTimeTimer = m.top.findNode("currentTimeTimer")
+        m.currentTimeTimer.control = "start"
+        m.currentTimeTimer.ObserveField("fire", "updateTime")
+
+        updateTimeDisplay()
+    end if
+
+    setClockVisibility()
 end sub
 
 sub updateTitle()
@@ -37,16 +49,33 @@ sub updateTitle()
     end if
     title = m.top.findNode("overlayTitle")
     title.text = m.top.title
-    resetTime()
+
+    if not m.hideClock
+        resetTime()
+    end if
+end sub
+
+sub setClockVisibility()
+    if m.hideClock
+        m.overlayRightGroup.removeChild(m.overlayTimeGroup)
+    end if
+end sub
+
+sub setRightSeperatorVisibility()
+    if m.hideClock
+        m.top.removeChild(m.rightSeperator)
+        return
+    end if
+
+    if m.top.currentUser <> ""
+        m.rightSeperator.visible = "true"
+    else
+        m.rightSeperator.visible = "false"
+    end if
 end sub
 
 sub updateUser()
-    rightSeperator = m.top.findNode("overlayRightSeperator")
-    if m.top.currentUser <> ""
-        rightSeperator.visible = "true"
-    else
-        rightSeperator.visible = "false"
-    end if
+    setRightSeperatorVisibility()
     user = m.top.findNode("overlayCurrentUser")
     user.text = m.top.currentUser
 end sub

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -19,7 +19,8 @@
         id="overlayRightSeperator"
         color="#666666"
         width="2"
-        height="64"/>
+        height="64"
+        visible="false"/>
       <LayoutGroup id="overlayTimeGroup" layoutDirection="horiz" horizAlignment="right" itemSpacings="0" >
         <Label id="overlayHours" font="font:MediumSystemFont" vertAlign="center" height="64" />
         <Label font="font:MediumSystemFont" text=":" vertAlign="center" height="64" />
@@ -45,4 +46,5 @@
     <function name="resetTime" />
   </interface>
   <script type="text/brightscript" uri="JFOverhang.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -8,6 +8,10 @@ sub init()
     m.top.transcodeReasons = []
     m.bufferCheckTimer.duration = 10
 
+    if get_user_setting("ui.design.hideclock") = "true"
+        clockNode = findNodeBySubtype(m.top, "clock")
+        clockNode[0].parent.removeChild(clockNode[0].node)
+    end if
 end sub
 
 '

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -24,6 +24,8 @@
 
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <children>
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -68,7 +68,9 @@ sub itemContentChanged()
 
     if type(itemData.RunTimeTicks) = "LongInteger"
         setFieldText("runtime", stri(getRuntime()) + " mins")
-        setFieldText("ends-at", tr("Ends at %1").Replace("%1", getEndTime()))
+        if get_user_setting("ui.design.hideclock") <> "true"
+            setFieldText("ends-at", tr("Ends at %1").Replace("%1", getEndTime()))
+        end if
     end if
 
     if itemData.genres.count() > 0

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -32,7 +32,9 @@ sub itemContentChanged()
 
     if type(itemData.RunTimeTicks) = "LongInteger"
         m.top.findNode("runtime").text = stri(getRuntime()).trim() + " mins"
-        m.top.findNode("endtime").text = tr("Ends at %1").Replace("%1", getEndTime())
+        if get_user_setting("ui.design.hideclock") <> "true"
+            m.top.findNode("endtime").text = tr("Ends at %1").Replace("%1", getEndTime())
+        end if
     end if
 
     if itemData.communityRating <> invalid

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -678,5 +678,15 @@
         <translation>Cinema mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.</translation>
         <extracomment>Settings Menu - Description for option</extracomment>
     </message>
+    <message>
+        <source>Hide Clock</source>
+        <translation>Hide Clock</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>Hides all clocks in Jellyfin. Jellyfin will need to be closed and reopened for change to take effect.</source>
+        <translation>Hides all clocks in Jellyfin. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
 </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -74,6 +74,13 @@
                 "description": "Options that alter the design of Jellyfin.",
                 "children": [
                     {
+                        "title": "Hide Clock",
+                        "description": "Hides all clocks in Jellyfin. Jellyfin will need to be closed and reopened for change to take effect.",
+                        "settingName": "ui.design.hideclock",
+                        "type": "bool",
+                        "default": "false"
+                    },
+                    {
                         "title": "Use Splashscreen as Home Background",
                         "description": "Use generated splashscreen image as Jellyfin home background. Jellyfin will need to be closed and reopened for change to take effect.",
                         "settingName": "ui.home.splashBackground",

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -238,3 +238,22 @@ function versionChecker(versionToCheck as string, minVersionAccepted as string)
 
     return leftHand >= rightHand
 end function
+
+function findNodeBySubtype(node, subtype)
+    foundNodes = []
+
+    for each child in node.getChildren(-1, 0)
+        if lcase(child.subtype()) = "group"
+            return findNodeBySubtype(child, subtype)
+        end if
+
+        if lcase(child.subtype()) = lcase(subtype)
+            foundNodes.push({
+                node: child,
+                parent: node
+            })
+        end if
+    end for
+
+    return foundNodes
+end function


### PR DESCRIPTION
**Changes**
Adds a new user setting to hide the clocks in the application. If enabled, this setting hides the following clocks:
1. Clock in top right of header overlay
2. Clock in top right of video playback overlay
3. "Ends at" text on movie detail page
4. "Ends at" text on TV episode list page

**Issues**
Fixes #273
