### PR TITLE
Add vscode workplace setting - translation files are XML

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.ts": "xml"
+    }
+}


### PR DESCRIPTION
Creates a VSCode workplace settings file. This file overrides personal user settings in VSCode.

### Changes
Create `.vscode/settings.json`
Add setting to always associate `.ts` files as XML

### Context
Every time I opened one of the translation files, VSCode would assume it was typescript and spit out hundreds of errors. This PR makes it so that any file with a `.ts` file extension is treated as XML - no more errors and no more changing the format manually.


