### PR TITLE
Update github workflow - auto create releases

### DIFF
--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -1,0 +1,42 @@
+name: master-release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test-build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: "14.12.0"
+      - run: npm ci
+      - run: npm run validate
+      - run: npm run check-formatting
+      - name: "Find and save major_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "MAJOR="$2; }' manifest >> $GITHUB_ENV
+      - name: "Find and save minor_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "MINOR="$2; }' manifest >> $GITHUB_ENV
+      - name: "Find and save build_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "BUILD="$2; }' manifest >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - uses: vimtor/action-zip@v1
+        with:
+          recursive: false
+          files: components/ images/ locale/ settings/ source/ manifest
+          dest: jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}
+          draft: true
+          prerelease: false
+          title: v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}
+          files: ${{ github.workspace }}/jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+          path: ${{ github.workspace }}/jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+          if-no-files-found: error

--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -1,0 +1,41 @@
+name: unstable-release
+on:
+  push:
+    branches:
+      - unstable
+
+jobs:
+  test-build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: "14.12.0"
+      - run: npm ci
+      - run: npm run validate
+      - run: npm run check-formatting
+      - name: "Find and save major_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "MAJOR="$2; }' manifest >> $GITHUB_ENV
+      - name: "Find and save minor_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "MINOR="$2; }' manifest >> $GITHUB_ENV
+      - name: "Find and save build_version from manifest"
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "BUILD="$2; }' manifest >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - uses: vimtor/action-zip@v1
+        with:
+          recursive: false
+          files: components/ images/ locale/ settings/ source/ manifest
+          dest: jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}
+          prerelease: true
+          title: v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}
+          files: ${{ github.workspace }}/jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+          path: ${{ github.workspace }}/jellyfin_v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.BUILD }}.zip
+          if-no-files-found: error

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,8 @@
-name: build
+name: validate
 on: [push, pull_request]
 
 jobs:
-  ci:
+  run:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
**I blew up my fork. This is a remake of #702** 

This updates our github workflow to automatically create a new release whenever there is a new push to master or the unstable branch. It also:

- Creates and attaches a zip file of the app build (this can be sideloded or given to roku for a release)
- Uses the manifest file to find the apps version number and uses that to name the tag and release as well as the zip file.
- Shows the commits that have been merged since last release
- Creates draft releases when merging with master - so we can edit as needed. 

**Changes**
Rename `build.yml` to `validate.yml`
Create `master-release.yml`
Create `unstable-release.yml`


