### PR TITLE
Check Clock node is found before trying to hide

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -10,7 +10,7 @@ sub init()
 
     if get_user_setting("ui.design.hideclock") = "true"
         clockNode = findNodeBySubtype(m.top, "clock")
-        clockNode[0].parent.removeChild(clockNode[0].node)
+        if clockNode[0] <> invalid then clockNode[0].parent.removeChild(clockNode[0].node)
     end if
 end sub
 


### PR DESCRIPTION
When clock is hidden via settings, attempting to play an TV Episode from the Season Screen resulted in a crash trying to access first member of array which was empty

**Changes**
- Ensure clock node if found before attempting to hide

**Issues**
refs #697
