### PR TITLE
roUrlTransfer objects cannot be created from within render threads. 

### DIFF
--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -1,8 +1,6 @@
 ' Functions for making requests to the API
 function buildParams(params = {} as object) as string
     ' Take an object of parameters and construct the URL query
-    ' remove req create object as this cannot be called within a render thread and occasionally produces a crash - use EncodeURI Component instead
-    ' req = createObject("roUrlTransfer") ' Just so we can use it for escape
 
     param_array = []
     for each field in params.items()
@@ -29,7 +27,6 @@ function buildParams(params = {} as object) as string
         else if field <> invalid
             print "Unhandled param type: " + type(field.value)
             item = field.key + "=" + field.value.EncodeUriComponent()
-            'item = field.key + "=" + field.value
         end if
 
         if item <> "" then param_array.push(item)

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -1,14 +1,14 @@
 ' Functions for making requests to the API
 function buildParams(params = {} as object) as string
     ' Take an object of parameters and construct the URL query
-    req = createObject("roUrlTransfer") ' Just so we can use it for escape
+    ' remove req create object as this cannot be called within a render thread and occasionally produces a crash - use EncodeURI Component instead
+    ' req = createObject("roUrlTransfer") ' Just so we can use it for escape
 
     param_array = []
     for each field in params.items()
         item = ""
         if type(field.value) = "String" or type(field.value) = "roString"
-            item = field.key + "=" + req.escape(field.value.trim())
-            'item = field.key + "=" + field.value.trim()
+            item = field.key + "=" + field.value.trim().EncodeUriComponent()
         else if type(field.value) = "roInteger" or type(field.value) = "roInt"
             item = field.key + "=" + stri(field.value).trim()
             'item = field.key + "=" + str(field.value).trim()
@@ -28,7 +28,7 @@ function buildParams(params = {} as object) as string
             item = field.key + "=null"
         else if field <> invalid
             print "Unhandled param type: " + type(field.value)
-            item = field.key + "=" + req.escape(field.value)
+            item = field.key + "=" + field.value.EncodeUriComponent()
             'item = field.key + "=" + field.value
         end if
 


### PR DESCRIPTION
roUrlTransfer objects cannot be created from within render threads.  Creating this object just to escape parameters causes an occasional crash to homescreen (as the object is null when attempting to call escape).  This code change no longer creates this object and instead uses the EncodeURIComponet function to escape the parameters.
