### PR TITLE
Fix to crash

### DIFF
--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -106,11 +106,14 @@ end sub
 
 sub onProgramFocused()
     m.top.watchChannel = invalid
+
+    ' Make sure we have channels (i.e. filter set to favorite yet there are none)
     if m.scheduleGrid.content.getChildCount() <= 0
         channel = invalid
     else
         channel = m.scheduleGrid.content.GetChild(m.scheduleGrid.programFocusedDetails.focusChannelIndex)
     end if
+
     m.detailsPane.channel = channel
     m.top.focusedChannel = channel
 

--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -80,6 +80,11 @@ end sub
 ' When LoadScheduleTask completes (initial or more data) and we have a schedule to display
 sub onScheduleLoaded()
 
+    ' make sure we actually have a schedule (i.e. filter by favorites, but no channels have been favorited)
+    if m.scheduleGrid.content.GetChildCount() <= 0
+        return
+    end if
+
     for each item in m.LoadScheduleTask.schedule
 
         channel = m.scheduleGrid.content.GetChild(m.channelIndex[item.ChannelId])
@@ -101,12 +106,16 @@ end sub
 
 sub onProgramFocused()
     m.top.watchChannel = invalid
-    channel = m.scheduleGrid.content.GetChild(m.scheduleGrid.programFocusedDetails.focusChannelIndex)
+    if m.scheduleGrid.content.getChildCount() <= 0
+        channel = invalid
+    else
+        channel = m.scheduleGrid.content.GetChild(m.scheduleGrid.programFocusedDetails.focusChannelIndex)
+    end if
     m.detailsPane.channel = channel
     m.top.focusedChannel = channel
 
     ' Exit if Channels not yet loaded
-    if channel.getChildCount() = 0
+    if channel = invalid or channel.getChildCount() = 0
         m.detailsPane.programDetails = invalid
         return
     end if


### PR DESCRIPTION
Found a crash in master (still happens in unstable).  If a user filters the Live TV guide by Favorites, but has no favorites defined, the app crashes.  And they can never get back in to the TV guide without a re-install.

**Changes**
Fixes crash

