### PR TITLE
Update MovieDetails.brs

### DIFF
--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -52,7 +52,7 @@ sub itemContentChanged()
     setFieldText("overview", itemData.overview)
 
     if itemData.communityRating <> invalid
-        setFieldText("communityRating", itemData.communityRating)
+        setFieldText("communityRating", int(itemData.communityRating * 10) / 10)
         m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
     else
         ' hide the star icon

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -53,7 +53,6 @@ sub itemContentChanged()
 
     if itemData.communityRating <> invalid
         setFieldText("communityRating", int(itemData.communityRating * 10) / 10)
-        m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
     else
         ' hide the star icon
         m.top.findNode("communityRatingGroup").visible = false

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -53,6 +53,7 @@ sub itemContentChanged()
 
     if itemData.communityRating <> invalid
         setFieldText("communityRating", itemData.communityRating)
+        m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
     else
         ' hide the star icon
         m.top.findNode("communityRatingGroup").visible = false


### PR DESCRIPTION
Rating on Movies are showing as 3 decimal points instead of 1.
I used the same format to do the calculation to 1 decimal point as in the TV shows

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
I used the same format to do the calculation to 1 decimal point as in the TV shows

**Issues**
Rating on Movies are showing as 3 decimal points instead of 1.
