### PR TITLE
Avoid crash if missing Premiere Date

### DIFF
--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -75,7 +75,7 @@ sub onLikeThisLoaded()
             item.labelText = item.json.Name
             if item.json.ProductionYear <> invalid
                 item.subTitle = stri(item.json.ProductionYear)
-            else
+            else if item.json.PremiereDate <> invalid
                 premierYear = CreateObject("roDateTime")
                 premierYear.FromISO8601String(item.json.PremiereDate)
                 item.subTitle = stri(premierYear.GetYear())


### PR DESCRIPTION
Not all TV shows that I have access to have a Premiere Date.  If I select such a show, the app crashes.
