### PR TITLE
Live TV from home screen (other than On Now)

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -176,7 +176,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     if meta.live then mediaSourceId = "" ' Don't send mediaSourceId for Live media
 
     playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
-    print "Debug playbackinfo: " playbackInfo
     video.videoId = video.id
     video.mediaSourceId = mediaSourceId
     video.audioIndex = audio_stream_idx

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -28,12 +28,21 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
         return
     end if
 
-    ' Special handling for "Programs" launched from "On Now"
-    if meta.json.type = "Program"
-        meta.title = meta.json.EpisodeTitle
+    ' Special handling for "Programs" or "Vidoes" launched from "On Now" or elsewhere on the home screen...
+    ' basically anything that is a Live Channel.
+    if meta.json.ChannelId <> invalid
+        if meta.json.EpisodeTitle <> invalid
+            meta.title = meta.json.EpisodeTitle
+        else if meta.json.Name <> invalid
+            meta.title = meta.json.Name
+        end if
         meta.showID = meta.json.id
         meta.live = true
-        video.id = meta.json.ChannelId
+        if meta.json.type = "Program"
+            video.id = meta.json.ChannelId
+        else
+            video.id = meta.json.id
+        end if
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
@@ -167,7 +176,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     if meta.live then mediaSourceId = "" ' Don't send mediaSourceId for Live media
 
     playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
-
+    print "Debug playbackinfo: " playbackInfo
     video.videoId = video.id
     video.mediaSourceId = mediaSourceId
     video.audioIndex = audio_stream_idx
@@ -215,7 +224,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     ' artifacts. If the user preference is set, and the only reason the server says we need to
     ' transcode is that the Envoding Level is not supported, then try to direct play but silently
     ' fall back to the transcode if that fails.
-    if get_user_setting("playback.tryDirect.h264ProfileLevel") = "true" and playbackInfo.MediaSources[0].TranscodingUrl <> invalid and forceTranscoding = false and playbackInfo.MediaSources[0].MediaStreams[0].codec = "h264"
+    if meta.live = false and get_user_setting("playback.tryDirect.h264ProfileLevel") = "true" and playbackInfo.MediaSources[0].TranscodingUrl <> invalid and forceTranscoding = false and playbackInfo.MediaSources[0].MediaStreams[0].codec = "h264"
         transcodingReasons = getTranscodeReasons(playbackInfo.MediaSources[0].TranscodingUrl)
         if transcodingReasons.Count() = 1 and transcodingReasons[0] = "VideoLevelNotSupported"
             video.directPlaySupported = true


### PR DESCRIPTION
I happen to have access to a server that has a Live TV setup that is not shown under Live TV, but as its own "Collection" folder.  I don't know if this is common, but since I have now seen it, I'm sure someone else will come across it.

**Changes**
Make the the "Program" check smarter, to look for anything with a "Channel ID" instead.  This allows Live TV to be played whether the show is selected from "On Now" or from a "Folder"
