### PR TITLE
Support next up time limit

### DIFF
--- a/components/home/LoadItemsTask.brs
+++ b/components/home/LoadItemsTask.brs
@@ -54,6 +54,22 @@ sub loadItems()
         params["ImageTypeLimit"] = 1
         params["UserId"] = get_setting("active_user")
 
+        maxDaysInNextUp = get_user_setting("ui.details.maxdaysnextup", "365")
+        if isValid(maxDaysInNextUp)
+            maxDaysInNextUp = Val(maxDaysInNextUp)
+            if maxDaysInNextUp > 0
+                dateToday = CreateObject("roDateTime")
+                dateCutoff = CreateObject("roDateTime")
+
+                dateCutoff.FromSeconds(dateToday.AsSeconds() - (maxDaysInNextUp * 86400))
+
+                params["NextUpDateCutoff"] = dateCutoff.ToISOString()
+                params["EnableRewatching"] = false
+                params["DisableFirstEpisode"] = false
+                params["limit"] = 24
+            end if
+        end if
+
         resp = APIRequest(url, params)
         data = getJson(resp)
         for each item in data.Items

--- a/components/home/LoadItemsTask.xml
+++ b/components/home/LoadItemsTask.xml
@@ -12,6 +12,7 @@
   <script type="text/brightscript" uri="pkg:/source/api/Items.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
 </component>

--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -12,6 +12,9 @@ sub init()
     m.path = m.top.findNode("path")
 
     m.boolSetting = m.top.findNode("boolSetting")
+    m.integerSetting = m.top.findNode("integerSetting")
+    m.integerSetting.observeField("submit", "onKeyGridSubmit")
+    m.integerSetting.observeField("escape", "onKeyGridEscape")
 
     m.settingsMenu.setFocus(true)
     m.settingsMenu.observeField("itemFocused", "settingFocused")
@@ -24,6 +27,17 @@ sub init()
     LoadMenu({ children: m.configTree })
 end sub
 
+sub onKeyGridSubmit()
+    selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
+    set_user_setting(selectedSetting.settingName, m.integerSetting.text)
+    m.settingsMenu.setFocus(true)
+end sub
+
+sub onKeyGridEscape()
+    if m.integerSetting.escape = "left" or m.integerSetting.escape = "back"
+        m.settingsMenu.setFocus(true)
+    end if
+end sub
 
 sub LoadMenu(configSection)
 
@@ -58,8 +72,6 @@ sub LoadMenu(configSection)
     end for
 end sub
 
-
-
 sub settingFocused()
 
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
@@ -68,6 +80,7 @@ sub settingFocused()
 
     ' Hide Settings
     m.boolSetting.visible = false
+    m.integerSetting.visible = false
 
     if selectedSetting.type = invalid
         return
@@ -80,6 +93,12 @@ sub settingFocused()
         else
             m.boolSetting.checkedItem = 0
         end if
+    else if selectedSetting.type = "integer"
+        integerValue = get_user_setting(selectedSetting.settingName, selectedSetting.default)
+        if isValid(integerValue)
+            m.integerSetting.text = integerValue
+        end if
+        m.integerSetting.visible = true
     else
         print "Unknown setting type " + selectedSetting.type
     end if
@@ -91,10 +110,12 @@ sub settingSelected()
 
     selectedItem = m.userLocation.peek().children[m.settingsMenu.itemFocused]
 
-
     if selectedItem.type <> invalid ' Show setting
         if selectedItem.type = "bool"
             m.boolSetting.setFocus(true)
+        end if
+        if selectedItem.type = "integer"
+            m.integerSetting.setFocus(true)
         end if
     else if selectedItem.children <> invalid and selectedItem.children.Count() > 0 ' Show sub menu
         LoadMenu(selectedItem)

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -2,50 +2,39 @@
 <component name="Settings" extends="JFGroup">
   <children>
 
-         <Label id="path" translation = "[95,175]" font="font:SmallestBoldSystemFont" />
+    <Label id="path" translation = "[95,175]" font="font:SmallestBoldSystemFont" />
 
-        <LabelList
+    <LabelList
             translation = "[120,250]"
             id = "settingsMenu"
             itemSize = "[440,48]"
             vertFocusAnimationStyle = "floatingFocus"
             focusBitmapBlendColor = "#006fab"
             focusedColor = "#ffffff"
-            itemSpacing = "[0,5]"
-            />
+            itemSpacing = "[0,5]" />
 
-            <Poster
-               translation = "[710,250]"
-               id="testRectangle"
-               width="880"
-               height="700"
-               uri="pkg:/images/white.9.png"
-               blendColor = "#3f3f3f"
-             />
+    <Poster
+               translation = "[710,250]" id="testRectangle" width="880" height="700" uri="pkg:/images/white.9.png"
+               blendColor = "#3f3f3f" />
 
-             <LayoutGroup
-               translation = "[1150,275]"
-               id="settingDetail"
-               vertAlignment="top"
-               horizAlignment="center"
-               itemSpacings="[50]"
-             >
+    <LayoutGroup translation = "[1150,275]" id="settingDetail" vertAlignment="top" horizAlignment="center" itemSpacings="[50]">
 
-                <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" maxWidth="750" />
+      <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" maxWidth="750" />
 
-                <Label id="settingDesc" width="750" wrap = "true" />
+      <Label id="settingDesc" width="750" wrap = "true" />
 
-                <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus">
-                  <ContentNode role="content">
-                    <ContentNode title="Disabled" />
-                    <ContentNode title="Enabled" />
-                  </ContentNode>
-                </RadioButtonList>
+      <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus">
+        <ContentNode role="content">
+          <ContentNode title="Disabled" />
+          <ContentNode title="Enabled" />
+        </ContentNode>
+      </RadioButtonList>
+    </LayoutGroup>
 
-             </LayoutGroup>
-
+    <intkeyboard_integerKeyboard translation="[900, 520]" id="integerSetting" maxLength="3" domain="numeric" visible="false" />
 
   </children>
   <script type="text/brightscript" uri="settings.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -692,5 +692,24 @@
             <source>Play Trailer</source>
             <translation>Play Trailer</translation>
         </message>
+        <message>
+            <source>Home Page</source>
+            <translation>Home Page</translation>
+        </message>
+        <message>
+            <source>Options for Home Page.</source>
+            <translation>Options for Home Page.</translation>
+            <extracomment>Description for Home Page user settings.</extracomment>
+        </message>
+        <message>
+            <source>Max Days Next Up</source>
+            <translation>Max Days Next Up</translation>
+            <extracomment>Option Title in user setting screen</extracomment>
+        </message>
+        <message>
+            <source>Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.</source>
+            <translation>Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
     </context>
 </TS>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "api": "npm:jellyfin-api-bs-client@^1.0.5",
         "bgv": "npm:button-group-vert@^1.0.1",
         "brighterscript-formatter": "^1.6.8",
-        "sob": "npm:slide-out-button@^1.0.1"
+        "sob": "npm:slide-out-button@^1.0.1",
+        "intKeyboard": "npm:integer-keyboard@^1.0.12"
       },
       "devDependencies": {
         "@rokucommunity/bslint": "0.7.5",
@@ -3766,6 +3767,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/intKeyboard": {
+      "name": "integer-keyboard",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/integer-keyboard/-/integer-keyboard-1.0.12.tgz",
+      "integrity": "sha512-DSLyd/PvtEBfc4grICTxSLu94Yo/Vm6rNerRZRbbzRrP0HQ9pYaquoY2RD9x6gAmica43gsFimScNpuRYVe54w=="
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -9534,6 +9541,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "intKeyboard": {
+      "version": "npm:integer-keyboard@1.0.12",
+      "resolved": "https://registry.npmjs.org/integer-keyboard/-/integer-keyboard-1.0.12.tgz",
+      "integrity": "sha512-DSLyd/PvtEBfc4grICTxSLu94Yo/Vm6rNerRZRbbzRrP0HQ9pYaquoY2RD9x6gAmica43gsFimScNpuRYVe54w=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "api": "npm:jellyfin-api-bs-client@^1.0.5",
     "bgv": "npm:button-group-vert@^1.0.1",
     "brighterscript-formatter": "^1.6.8",
-    "sob": "npm:slide-out-button@^1.0.1"
+    "sob": "npm:slide-out-button@^1.0.1",
+    "intKeyboard": "npm:integer-keyboard@^1.0.12"
   }
 }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -31,6 +31,19 @@
         "description": "Settings relating to how the application looks.",
         "children": [
             {
+                "title": "Home Page",
+                "description": "Options for Home page.",
+                "children": [
+                    {
+                        "title": "Max Days Next Up",
+                        "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
+                        "settingName": "ui.details.maxdaysnextup",
+                        "type": "integer",
+                        "default": "365"
+                    }
+                ]
+            },
+            {
                 "title": "Details Page",
                 "description": "Options for Details pages.",
                 "children": [
@@ -42,8 +55,8 @@
                         "default": "false"
                     }
                 ]
-            },     
-            {    
+            },
+            {
                 "title": "TV Shows",
                 "description": "Options for TV Shows.",
                 "children": [
@@ -55,8 +68,8 @@
                         "default": "false"
                     }
                 ]
-            },     
-            {              
+            },
+            {
                 "title": "Screensaver",
                 "description": "Options for Jellyfin's screensaver.",
                 "children": [
@@ -68,7 +81,7 @@
                         "default": "false"
                     }
                 ]
-            },     
+            },
             {
                 "title": "Design Elements",
                 "description": "Options that alter the design of Jellyfin.",


### PR DESCRIPTION
**Changes**
Create new user setting called Max Days Next Up. This value is used to set the maximum amount of days a show should stay in the Next Up list on the homepage without watching it.

This value exists on the Web UI, but was missing in Roku.