### PR TITLE
Add basic av1 support to device profile

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -201,6 +201,11 @@ function GetDirectPlayProfiles() as object
         mkvVideo = mkvVideo + ",vp9"
     end if
 
+    if di.CanDecodeVideo({ Codec: "av1" }).Result = true
+        mp4Video = mp4Video + ",av1"
+        mkvVideo = mkvVideo + ",av1"
+    end if
+
     if playMpeg2 and di.CanDecodeVideo({ Codec: "mpeg2" }).Result = true
         mp4Video = mp4Video + ",mpeg2video"
         mkvVideo = mkvVideo + ",mpeg2video"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -36,6 +36,10 @@ function getDeviceProfile() as object
         tsVideoCodecs = tsVideoCodecs + ",h265,hevc"
     end if
 
+    if di.CanDecodeVideo({ Codec: "av1" }).result
+        tsVideoCodecs = tsVideoCodecs + ",av1"
+    end if
+
     if di.CanDecodeAudio({ Codec: "ac3" }).result
         tsAudioCodecs = "aac,ac3"
     else


### PR DESCRIPTION
Add av1 to device profile so Roku devices which support av1 can direct play content.

More comprehensive detection and support is part of PR #686  by @whiteowl3, but this is a quick fix to address some user requests.

**Changes**
 - Add av1 support to device profile