### PR TITLE
Smooth "nextEpisode" transition

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -427,10 +427,10 @@ sub autoPlayNextEpisode(videoID as string, showID as string)
         data = getJson(resp)
 
         if data <> invalid and data.Items.Count() = 2
-            ' remove finished video node
-            m.global.sceneManager.callFunc("popScene")
             ' setup new video node
             nextVideo = CreateVideoPlayerGroup(data.Items[1].Id, invalid, 1, false, false)
+            ' remove last video scene
+            m.global.sceneManager.callFunc("clearPreviousScene")
             if nextVideo <> invalid
                 m.global.sceneManager.callFunc("pushScene", nextVideo)
             else


### PR DESCRIPTION
Fixed the issues where when the next episode shows the user the episode list before it plays the next episode.

**Changes**
removed popScene and added clearPreviousScene

**Issues**
When an episode finishes and the next one starts the user is shown the episodes list before the next episode plays. This will allow the user to only see the next episode. 
