### PR TITLE
Fix for reported bug where hours shown as 24

### DIFF
--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -43,7 +43,7 @@ end function
 
 ' Format time as 12 or 24 hour format based on system clock setting
 function formatTime(time) as string
-    hours = time.getHours()
+    hours = time.getHours() mod 24 ' Specifically for reported bug where hours occasionally shown as '24' #609
     minHourDigits = 1
     di = CreateObject("roDeviceInfo")
     if di.GetClockFormat() = "12h"


### PR DESCRIPTION
Fix for reported but where time shown as 24:00 when the clock ticks over midnight.  This should never happen according to the Roku Documentation, but fix should ensure that.

**Changes**
 - Perform `mod 24` on result of `GetHours()`

**Issues**
fixes #609
