### PR TITLE
Fix out of sync home page

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -41,9 +41,9 @@ sub onState(msg)
             ReportPlayback("start")
             m.playReported = true
         else
-            m.playbackTimer.control = "start"
             ReportPlayback()
         end if
+        m.playbackTimer.control = "start"
     else if m.top.state = "paused"
         m.playbackTimer.control = "stop"
         ReportPlayback()

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -107,6 +107,11 @@ sub onLibrariesLoaded()
 end sub
 
 sub updateHomeRows()
+    if m.global.playstateTask.state = "run"
+        m.global.playstateTask.observeField("state", "updateHomeRows")
+    else
+        m.global.playstateTask.unobserveField("state")
+    end if
     m.LoadContinueTask.observeField("content", "updateContinueItems")
     m.LoadContinueTask.control = "RUN"
 end sub


### PR DESCRIPTION
**Changes**
- Starts the playback timer when a video starts, instead of just when it resumes.
- Adds some state that tracks when video progress is being updated, so we can refresh the home page again once it's done, if it isn't done yet.

**Testing**
In master, start a video. Without pausing it or resuming it or seeking, exit it. It's likely that the home page will be out of sync, with the video still being in "Next Up". On this branch, you should see it showing correctly every time.