### PR TITLE
Add Music Video Support

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -88,7 +88,7 @@ sub loadItems()
 
         for each item in data.Items
             tmp = invalid
-            if item.Type = "Movie"
+            if item.Type = "Movie" or item.Type = "MusicVideo"
                 tmp = CreateObject("roSGNode", "MovieData")
             else if item.Type = "Series"
                 tmp = CreateObject("roSGNode", "SeriesData")

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -83,7 +83,7 @@ function ItemMetaData(id as string)
             imgParams.Append(param)
         end if
     end if
-    if data.type = "Movie"
+    if data.type = "Movie" or data.type = "MusicVideo"
         tmp = CreateObject("roSGNode", "MovieData")
         tmp.image = PosterImage(data.id, imgParams)
         tmp.json = data


### PR DESCRIPTION
Add Music Video Support via a grid view. Fixes #787

**Changes**
Add "MusicVideo" as a data type and an Item type. 


**Issues**
This just to support and to be able to play music videos. If there is interest to be able to sort, view by artist or album or anything else that will need to be discussed and added. 
