### PR TITLE
Add stale PR auto-close workflow.

### DIFF
--- a/.github/workflows/auto-close-stale-pr.yml
+++ b/.github/workflows/auto-close-stale-pr.yml
@@ -1,0 +1,20 @@
+name: "Close stale Pull Requests"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-message: "This pull request has been inactive for 21 days and will be automatically closed in 7 days if there is no further activity."
+          close-pr-message: "This pull request has been closed because it has been inactive for 28 days. You may submit a new pull request if desired."
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Changes**
Creates new workflow to auto close stale pull requests.

It issues a close warning after 21 days of inactivity and closes after 28 days of inactivity.