### PR TITLE
remove server circumvention

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -130,5 +130,18 @@
                 ]
             }
         ]
+    },
+	{
+        "title": "Advanced",
+        "description": "Settings you probably do not need, and should probably not touch.",
+        "children": [
+            {
+                "title": "Substitute loopback in shortcuts",
+                "description": "If a shortcut contains a loopback host, replace the host expression with the server url. Stream directly from a server that is local to jellyfin by configuring locations in your reverse proxy.",
+                "settingName": "advanced.subLoopbacks",
+                "type": "bool",
+                "default": "false"
+            }
+        ]
     }
 ]

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -210,8 +210,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     ' 'TODO: allow user selection of subtitle track before playback initiated, for now set to no subtitles
 
     video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
-    fully_external = false
-
 
     ' For h264 video, Roku spec states that it supports and Encoding level 4.1 and 4.2.
     ' The device can decode content with a Higher Encoding level but may play it back with certain
@@ -274,9 +272,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     ' is enabled/will be enabled, indexed on the provided list of subtitles
     video.SelectedSubtitle = setupSubtitle(video, video.Subtitles, subtitle_idx)
 
-    if not fully_external
-        video.content = authorize_request(video.content)
-    end if
+    video.content = authorize_request(video.content)
 
 end sub
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -226,8 +226,9 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
         end if
     end if
 
-	subtitute_localhost = false
+	
     if video.directPlaySupported
+		subtitute_localhost = false
         protocol = LCase(playbackInfo.MediaSources[0].Protocol)
         ' This branch allows serving videos from a server local to jf, without jf standing between said server and the rp
         if protocol <> "file"
@@ -237,6 +238,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
             localhost = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
             ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
             if localhost.isMatch(uri[2])
+                substitute_localhost = true
                 video.content.url = buildURL(uri[4]) ' direct all requests to jellyfin server's host:port
             end if
         end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -237,7 +237,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
             localhost = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
             ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
             if localhost.isMatch(uri[2])
-                substitute_localhost = true ' don't request our own loopback
                 video.content.url = buildURL(uri[4]) ' direct all requests to jellyfin server's host:port
             end if
         end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -228,12 +228,12 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
 
 	
     if video.directPlaySupported
-		subtitute_localhost = false
-        protocol = LCase(playbackInfo.MediaSources[0].Protocol)
+	substitute_localhost = false
+        protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
         ' This branch allows serving videos from a server local to jf, without jf standing between said server and the rp
         if protocol <> "file"
             uriRegex = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
-            uri = uriRegex.Match(playbackInfo.MediaSources[0].Path)
+            uri = uriRegex.Match(m.playbackInfo.MediaSources[0].Path)
             ' proto $1, host $2, port $3, the-rest $4
             localhost = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
             ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
@@ -256,15 +256,15 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
             video.isTranscoded = false
         end if
     else
-        if playbackInfo.MediaSources[0].TranscodingUrl = invalid
+        if m.playbackInfo.MediaSources[0].TranscodingUrl = invalid
             ' If server does not provide a transcode URL, display a message to the user
             m.global.sceneManager.callFunc("userMessage", tr("Error Getting Playback Information"), tr("An error was encountered while playing this item.  Server did not provide required transcoding data."))
             video.content = invalid
             return
         end if
         ' Get transcoding reason
-        video.transcodeReasons = getTranscodeReasons(playbackInfo.MediaSources[0].TranscodingUrl)
-        video.content.url = buildURL(playbackInfo.MediaSources[0].TranscodingUrl)
+        video.transcodeReasons = getTranscodeReasons(m.playbackInfo.MediaSources[0].TranscodingUrl)
+        video.content.url = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)
         video.isTranscoded = true
     end if
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -226,11 +226,11 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
         end if
     end if
 
+	subtitute_localhost = false
     if video.directPlaySupported
         protocol = LCase(playbackInfo.MediaSources[0].Protocol)
         ' This branch allows serving videos from a server local to jf, without jf standing between said server and the rp
         if protocol <> "file"
-            subtitute_localhost = false
             uriRegex = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
             uri = uriRegex.Match(playbackInfo.MediaSources[0].Path)
             ' proto $1, host $2, port $3, the-rest $4
@@ -241,7 +241,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
                 video.content.url = buildURL(uri[4]) ' direct all requests to jellyfin server's host:port
             end if
         end if
-        if (protocol = "file" or substitute_localhost = false)
+        if protocol = "file" or substitute_localhost = false
             params.append({
                 "Static": "true",
                 "Container": video.container,

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -227,23 +227,21 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if video.directPlaySupported
-        protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
+        protocol = LCase(playbackInfo.MediaSources[0].Protocol)
+        ' This branch allows serving videos from a server local to jf, without jf standing between said server and the rp
         if protocol <> "file"
+            subtitute_localhost = false
             uriRegex = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
-            uri = uriRegex.Match(m.playbackInfo.MediaSources[0].Path)
+            uri = uriRegex.Match(playbackInfo.MediaSources[0].Path)
             ' proto $1, host $2, port $3, the-rest $4
             localhost = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
             ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
             if localhost.isMatch(uri[2])
-                ' if the domain of the URI is local to the server,
-                ' create a new URI by appending the received path to the server URL
-                ' later we will substitute the users provided URL for this case
-                video.content.url = buildURL(uri[4])
-            else
-                fully_external = true
-                video.content.url = m.playbackInfo.MediaSources[0].Path
+                substitute_localhost = true ' don't request our own loopback
+                video.content.url = buildURL(uri[4]) ' direct all requests to jellyfin server's host:port
             end if
-        else:
+        end if
+        if (protocol = "file" or substitute_localhost = false)
             params.append({
                 "Static": "true",
                 "Container": video.container,
@@ -254,19 +252,18 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
                 params.MediaSourceId = mediaSourceId
             end if
             video.content.url = buildURL(Substitute("Videos/{0}/stream", video.id), params)
-
+            video.isTranscoded = false
         end if
-        video.isTranscoded = false
     else
-        if m.playbackInfo.MediaSources[0].TranscodingUrl = invalid
+        if playbackInfo.MediaSources[0].TranscodingUrl = invalid
             ' If server does not provide a transcode URL, display a message to the user
             m.global.sceneManager.callFunc("userMessage", tr("Error Getting Playback Information"), tr("An error was encountered while playing this item.  Server did not provide required transcoding data."))
             video.content = invalid
             return
         end if
         ' Get transcoding reason
-        video.transcodeReasons = getTranscodeReasons(m.playbackInfo.MediaSources[0].TranscodingUrl)
-        video.content.url = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)
+        video.transcodeReasons = getTranscodeReasons(playbackInfo.MediaSources[0].TranscodingUrl)
+        video.content.url = buildURL(playbackInfo.MediaSources[0].TranscodingUrl)
         video.isTranscoded = true
     end if
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -226,23 +226,22 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
         end if
     end if
 
-	
     if video.directPlaySupported
-	substitute_localhost = false
+        substituting_loopbacks = false
         protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
         ' This branch allows serving videos from a server local to jf, without jf standing between said server and the rp
-        if protocol <> "file"
+        if protocol <> "file" and get_user_setting("advanced.subLoopbacks") = "true"
             uriRegex = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
             uri = uriRegex.Match(m.playbackInfo.MediaSources[0].Path)
             ' proto $1, host $2, port $3, the-rest $4
             localhost = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
             ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
             if localhost.isMatch(uri[2])
-                substitute_localhost = true
+                substituting_loopbacks = true
                 video.content.url = buildURL(uri[4]) ' direct all requests to jellyfin server's host:port
             end if
         end if
-        if protocol = "file" or substitute_localhost = false
+        if protocol = "file" or get_user_setting("advanced.subLoopbacks") = "false" or substituting_loopbacks = false
             params.append({
                 "Static": "true",
                 "Container": video.container,


### PR DESCRIPTION
We no longer bypass jf server when requesting external strms because the core team insisted.
In my opinion these changes ruin the playback of external resources when jf server is on an rpi4, but i don't disagree with the team's logic on why the previous functionality was bad.
we no longer use the mediasource's Path unless that path contains localhost, and in that case we replace the entire schema:localhost:port expression with that of the currently connected jf server.
This is important because otherwise ALL content served this way (from a jf-local server) looks like garbage on the rpi4, instead of only external content.
It is fine and correct to do it this way because we are still limiting our communications to the jf port, and advanced users can still use locations to configure whatever server business they want in their reverse proxy.
The use of "localhost" strm uri's is important when serving this way to allow jellyfin to scan off those local servers, but it must step out of the way when serving them to produce good results on low power hardware.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
