### PR TITLE
Stop load channel task on back press

### DIFF
--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -288,6 +288,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         gridGrp.setFocus(true)
         return true
     else if key = "back"
+        m.LoadChannelsTask.control = "stop"
         m.global.sceneManager.callFunc("popScene")
         return true
     end if


### PR DESCRIPTION
**Changes**
Stops the LiveTV load channel task when user presses back button. Prevents deadlock if user leaves and returns to schedule before channels load.