### PR TITLE
Remove temporary code to migrate MPEG2 setting

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -13,13 +13,6 @@ sub Main (args as dynamic) as void
     WriteAsciiFile("tmp:/scene.temp", "")
     MoveFile("tmp:/scene.temp", "tmp:/scene")
 
-    ' Temporary code to migrate MPEG2 setting from device setting to user setting
-    ' Added for 1.4.13 release and should probably be removed for 1.4.15
-    if get_setting("playback.mpeg2") <> invalid and registry_read("playback.mpeg2", get_setting("active_user")) = invalid
-        set_user_setting("playback.mpeg2", get_setting("playback.mpeg2"))
-    end if
-    ' End Temporary code
-
     m.port = CreateObject("roMessagePort")
     m.screen.setMessagePort(m.port)
     m.scene = m.screen.CreateScene("JFScene")


### PR DESCRIPTION
Remove temporary code which was added when User Settings were introduced to migrate the system MPEG2 setting to the new User Settings.  

This setting migration was for user convenience (nothing breaks if the setting returns to default) so should be no risk to remove now.