### PR TITLE
Handle short runtime for TV Episodes

### DIFF
--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -30,8 +30,14 @@ sub itemContentChanged()
 
     m.poster.uri = imageUrl
 
-    if type(itemData.RunTimeTicks) = "LongInteger"
-        m.top.findNode("runtime").text = stri(getRuntime()).trim() + " mins"
+    if type(itemData.RunTimeTicks) = "roInt" or type(itemData.RunTimeTicks) = "LongInteger"
+        runTime = getRuntime()
+        if runTime < 2
+            m.top.findNode("runtime").text = "1 min"
+        else
+            m.top.findNode("runtime").text = stri(runTime).trim() + " mins"
+        end if
+
         if get_user_setting("ui.design.hideclock") <> "true"
             m.top.findNode("endtime").text = tr("Ends at %1").Replace("%1", getEndTime())
         end if


### PR DESCRIPTION
**Changes**
We don't show runtimes for videos that are under ~3 minutes or so. This change adds runtime display support for videos down to 1 minute.