### PR TITLE
Convert MPEG4 direct play to user setting

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -707,6 +707,7 @@
             <source>Next episode</source>
             <translation>Next episode</translation>
         </message>
+        <message>
             <source>Play Trailer</source>
             <translation>Play Trailer</translation>
         </message>
@@ -819,6 +820,16 @@
             <source>Unable to find any albums or songs belonging to this artist</source>
             <translation>Unable to find any albums or songs belonging to this artist</translation>
             <extracomment>Popup message when we find no audio data for an artist</extracomment>
+        </message>
+        <message>
+            <source>MPEG-4 Support</source>
+            <translation>MPEG-4 Support</translation>
+            <extracomment>Settings Menu - Title for option</extracomment>
+        </message>
+        <message>
+            <source>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</source>
+            <translation>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
         </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -11,6 +11,13 @@
                 "default": "false"
             },
             {
+                "title": "MPEG-4 Support",
+                "description": "Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.",
+                "settingName": "playback.mpeg4",
+                "type": "bool",
+                "default": "true"
+            },
+            {
                 "title": "Attempt Direct Play (Profile Lvl)",
                 "description": "Attempt Direct Play for H.264 media with unsupported profile levels (> 4.2) before falling back to transcoding if it fails.",
                 "settingName": "playback.tryDirect.h264ProfileLevel",

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -177,7 +177,7 @@ end function
 
 function GetDirectPlayProfiles() as object
 
-    mp4Video = "h264,mpeg4"
+    mp4Video = "h264"
     mp4Audio = "mp3,pcm,lpcm,wav"
     mkvVideo = "h264,vp8"
     mkvAudio = "mp3,pcm,lpcm,wav"
@@ -200,6 +200,10 @@ function GetDirectPlayProfiles() as object
     if playMpeg2 and di.CanDecodeVideo({ Codec: "mpeg2" }).Result = true
         mp4Video = mp4Video + ",mpeg2video"
         mkvVideo = mkvVideo + ",mpeg2video"
+    end if
+
+    if get_user_setting("playback.mpeg4") = "true"
+        mp4Video = mp4Video + ",mpeg4"
     end if
 
     ' Check for supported Audio


### PR DESCRIPTION
**Changes**
Makes MPEG-4 direct play a user setting that can be toggled.

**Issues**
Resolves issue where DIVX encoded files can't be played since they report as MPEG-4, but Roku can't play them directly. So it results in JF attempting to play unplayable files.
