### PR TITLE
Fix TV Episode focus issues

### DIFF
--- a/components/tvshows/TVEpisodes.brs
+++ b/components/tvshows/TVEpisodes.brs
@@ -54,6 +54,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if press and key = "play" or proceed = true
+        m.top.lastFocus = focusedChild
         itemToPlay = focusedChild.content.getChild(focusedChild.rowItemFocused[0]).getChild(0)
         if itemToPlay <> invalid and itemToPlay.id <> ""
             m.top.quickPlayNode = itemToPlay

--- a/components/tvshows/TVEpisodes.brs
+++ b/components/tvshows/TVEpisodes.brs
@@ -57,6 +57,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         m.top.lastFocus = focusedChild
         itemToPlay = focusedChild.content.getChild(focusedChild.rowItemFocused[0]).getChild(0)
         if itemToPlay <> invalid and itemToPlay.id <> ""
+            itemToPlay.type = "Episode"
             m.top.quickPlayNode = itemToPlay
         end if
         handled = true

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -95,6 +95,13 @@ sub Main (args as dynamic) as void
                 if video <> invalid and video.errorMsg <> "introaborted"
                     sceneManager.callFunc("pushScene", video)
                 end if
+
+                group = sceneManager.callFunc("getActiveScene")
+                if LCase(group.subtype()) = "tvepisodes"
+                    if isValid(group.lastFocus)
+                        group.lastFocus.setFocus(true)
+                    end if
+                end if
             end if
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -102,6 +102,8 @@ sub Main (args as dynamic) as void
                         group.lastFocus.setFocus(true)
                     end if
                 end if
+
+                reportingNode.quickPlayNode.type = ""
             end if
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -83,6 +83,7 @@ sub Main (args as dynamic) as void
                 group.setFocus(true)
             end if
         else if isNodeEvent(msg, "quickPlayNode")
+            group = sceneManager.callFunc("getActiveScene")
             reportingNode = msg.getRoSGNode()
             itemNode = reportingNode.quickPlayNode
             if itemNode = invalid or itemNode.id = "" then return
@@ -96,7 +97,6 @@ sub Main (args as dynamic) as void
                     sceneManager.callFunc("pushScene", video)
                 end if
 
-                group = sceneManager.callFunc("getActiveScene")
                 if LCase(group.subtype()) = "tvepisodes"
                     if isValid(group.lastFocus)
                         group.lastFocus.setFocus(true)

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -91,6 +91,12 @@ function get_dialog_result(dialog, port)
 end function
 
 function lastFocusedChild(obj as object) as object
+    if LCase(obj.focusedChild.focusedChild.subType()) = "tvepisodes"
+        if isValid(obj?.focusedChild?.focusedChild?.lastFocus)
+            return obj.focusedChild.focusedChild.lastFocus
+        end if
+    end if
+
     child = obj
     for i = 0 to obj.getChildCount()
         if obj.focusedChild <> invalid


### PR DESCRIPTION
Fixes 2 scenarios that result in lost focus on TV episode list view

1. Pressing back on resume dialog on episode list
2. Choosing resume and pressing back from video playback