### PR TITLE
Fix invalid en_US translations file

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -292,12 +292,12 @@
         <message>
             <source>Special Features</source>
             <translation>Special Features</translation>
-       </message>
+        </message>
         <message>
             <source>Additional Parts</source>
             <translation>Additional Parts</translation>
             <extracomment>Additional parts of a video</extracomment>
-        </message>        
+        </message>
         <message>
             <source>Movies</source>
             <translation>Movies</translation>
@@ -746,6 +746,7 @@
             <translation>Attempt Direct Play for HEVC media with unsupported profile levels before falling back to trancoding if it fails.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+        <message>
             <source>Settings relating to playback and supported codec and media types.</source>
             <translation>Settings relating to playback and supported codec and media types.</translation>
         </message>
@@ -876,11 +877,11 @@
         <message>
             <source>Slideshow Paused</source>
             <translation>Slideshow Paused</translation>
-        </message>                
+        </message>
         <message>
             <source>Slideshow Resumed</source>
             <translation>Slideshow Resumed</translation>
-        </message>     
+        </message>
         <message>
             <source>Random Off</source>
             <translation>Random Off</translation>
@@ -889,7 +890,7 @@
             <source>Random On</source>
             <translation>Random On</translation>
         </message>
-        <message>        
+        <message>
             <source>MPEG-4 Support</source>
             <translation>MPEG-4 Support</translation>
             <extracomment>Settings Menu - Title for option</extracomment>


### PR DESCRIPTION
**Changes**
Fixes en_US translations file by adding missing <message> tag.

You can test this my looking at the sort options for movies

**Current Unstable**
![image](https://user-images.githubusercontent.com/3330318/206827065-210a8c02-7579-4760-94e3-fd5041c90caf.png)

**After Fix**
![image](https://user-images.githubusercontent.com/3330318/206827081-8d203e3b-9d63-4db0-b93a-7ddc3febba68.png)
