### PR TITLE
Set Maximum Bitrates values based on Roku Guidelines

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -170,6 +170,13 @@ function getDeviceProfile() as object
                         "Property": "VideoLevel",
                         "Value": "41",
                         "IsRequired": false
+                    },
+                    ' Roku only supports h264 up to 10Mpbs
+                    {
+                        "Condition": "LessThanEqual",
+                        "Property": "VideoBitrate",
+                        "Value": "10000000",
+                        IsRequired: true
                     }
                 ]
             }
@@ -203,6 +210,13 @@ function getDeviceProfile() as object
                     "Property": "VideoRangeType",
                     "Value": av1VideoRangeTypes,
                     "IsRequired": false
+                },
+                ' Roku only supports AVI up to 40Mpbs
+                {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
                 }
             ]
         })
@@ -229,6 +243,13 @@ function getDeviceProfile() as object
                     "Property": "VideoLevel",
                     "Value": (120 * 5.1).ToStr(),
                     "IsRequired": false
+                },
+                ' Roku only supports h265 up to 40Mpbs
+                {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
                 }
             ]
         })
@@ -243,6 +264,13 @@ function getDeviceProfile() as object
                     "Property": "VideoRangeType",
                     "Value": vp9VideoRangeTypes,
                     "IsRequired": false
+                },
+                ' Roku only supports VP9 up to 40Mpbs
+                {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
                 }
             ]
         })


### PR DESCRIPTION
**Changes**
Set max bitrate for each codec profile according to Roku [Supported video codecs
](https://developer.roku.com/en-gb/docs/specs/media/streaming-specifications.md#supported-video-codecs)

**Issues**
Fixes #722
Possibly fixes #401, #449, #496
Likely fixes the issues observed in #541. We could also set these limits from a user setting if desired.