### PR TITLE
Create Movie Grid View and new default setting

### DIFF
--- a/components/ItemGrid/GridItemSmall.brs
+++ b/components/ItemGrid/GridItemSmall.brs
@@ -1,13 +1,17 @@
 sub init()
     m.itemPoster = m.top.findNode("itemPoster")
     m.posterText = m.top.findNode("posterText")
+    m.title = m.top.findNode("title")
     m.posterText.font.size = 30
+    m.title.font.size = 25
     m.backdrop = m.top.findNode("backdrop")
 
     m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
 
     'Parent is MarkupGrid and it's parent is the ItemGrid
     m.topParent = m.top.GetParent().GetParent()
+
+    m.title.visible = false
 
     'Get the imageDisplayMode for these grid items
     if m.topParent.imageDisplayMode <> invalid
@@ -19,17 +23,31 @@ end sub
 sub itemContentChanged()
     m.backdrop.blendColor = "#101010"
 
+    if isValid(m.topParent.showItemTitles)
+        m.title.visible = m.topParent.showItemTitles
+    end if
+
     itemData = m.top.itemContent
 
     if not isValid(itemData) then return
 
     m.itemPoster.uri = itemData.PosterUrl
     m.posterText.text = itemData.title
+    m.title.text = itemData.title
 
     'If Poster not loaded, ensure "blue box" is shown until loaded
     if m.itemPoster.loadStatus <> "ready"
         m.backdrop.visible = true
         m.posterText.visible = true
+    end if
+end sub
+
+sub focusChanged()
+
+    if m.top.itemHasFocus = true
+        m.title.repeatCount = -1
+    else
+        m.title.repeatCount = 0
     end if
 end sub
 

--- a/components/ItemGrid/GridItemSmall.xml
+++ b/components/ItemGrid/GridItemSmall.xml
@@ -3,6 +3,7 @@
   <children>
     <Poster id="backdrop" translation="[0,15]" width="230" height="320" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
     <Poster id="itemPoster" translation="[0,15]" width="230" height="320" loadDisplayMode="scaleToZoom" />
+    <ScrollingLabel translation="[0,340]" id="title" horizAlign="center" font="font:SmallSystemFont" repeatCount="0" maxWidth="230" />
     <Poster id="itemIcon" width="50" height="50" translation="[230,10]" />
     <Label id="posterText" width="230" height="320" translation="[5,5]" horizAlign="center" vertAlign="center" ellipsizeOnBoundary="true" wrap="true" />
   </children>

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -786,7 +786,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         else
             m.itemGrid.jumpToItem = 0
         end if
-
+        return true
     else if key = "replay" and m.genreList.isinFocusChain()
         if m.resetGrid = true
             m.genreList.animateToItem = 0

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -124,9 +124,18 @@ sub loadInitialItems()
     end if
 
     m.sortField = get_user_setting("display." + m.top.parentItem.Id + ".sortField")
-    sortAscendingStr = get_user_setting("display." + m.top.parentItem.Id + ".sortAscending")
     m.filter = get_user_setting("display." + m.top.parentItem.Id + ".filter")
     m.view = get_user_setting("display." + m.top.parentItem.Id + ".landing")
+    sortAscendingStr = get_user_setting("display." + m.top.parentItem.Id + ".sortAscending")
+
+    ' If user has not set a preferred view for this folder
+    if not isValid(m.view)
+        ' Check if user has set a preferred view for the parent folder
+        if isValid(m.top.parentItem.parentfolder)
+            print "Not View Set, Use Default"
+            m.view = get_user_setting("display." + m.top.parentItem.parentfolder + ".view")
+        end if
+    end if
 
     if not isValid(m.sortField) then m.sortField = "SortName"
     if not isValid(m.filter) then m.filter = "All"
@@ -171,15 +180,26 @@ sub loadInitialItems()
     m.loadItemsTask.studioIds = ""
     m.loadItemsTask.view = "Movies"
     m.itemGrid.translation = "[96, 650]"
+    m.itemGrid.itemSize = "[230, 310]"
+    m.itemGrid.rowHeights = "[310]"
     m.itemGrid.numRows = "2"
     m.selectedMovieOverview.visible = true
     m.infoGroup.visible = true
+    m.top.showItemTitles = false
 
     if m.options.view = "Studios" or m.view = "Studios"
         m.itemGrid.translation = "[96, 60]"
         m.itemGrid.numRows = "3"
         m.loadItemsTask.view = "Networks"
         m.top.imageDisplayMode = "scaleToFit"
+        m.selectedMovieOverview.visible = false
+        m.infoGroup.visible = false
+    else if LCase(m.options.view) = "moviesgrid" or LCase(m.view) = "moviesgrid"
+        m.itemGrid.translation = "[96, 60]"
+        m.itemGrid.itemSize = "[230, 350]"
+        m.itemGrid.rowHeights = "[350]"
+        m.top.showItemTitles = true
+        m.itemGrid.numRows = "3"
         m.selectedMovieOverview.visible = false
         m.infoGroup.visible = false
     else if m.options.view = "Genres" or m.view = "Genres"
@@ -201,14 +221,16 @@ end sub
 sub setMoviesOptions(options)
 
     options.views = [
-        { "Title": tr("Movies"), "Name": "Movies" },
+        { "Title": tr("Movies (Presentation)"), "Name": "Movies" },
+        { "Title": tr("Movies (Grid)"), "Name": "MoviesGrid" },
         { "Title": tr("Studios"), "Name": "Studios" },
         { "Title": tr("Genres"), "Name": "Genres" }
     ]
 
     if m.top.parentItem.json.type = "Genre"
         options.views = [
-            { "Title": tr("Movies"), "Name": "Movies" }
+            { "Title": tr("Movies (Presentation)"), "Name": "Movies" },
+            { "Title": tr("Movies (Grid)"), "Name": "MoviesGrid" },
         ]
     end if
 
@@ -430,7 +452,13 @@ sub onItemFocused()
     m.communityRatingGroup.visible = false
     m.criticRatingGroup.visible = false
 
-    if m.options.view = "Studios" or m.view = "Studios"
+    if not isValid(m.selectedFavoriteItem)
+        return
+    end if
+
+    if LCase(m.options.view) = "studios" or LCase(m.view) = "studios"
+        return
+    else if LCase(m.options.view) = "moviesgrid" or LCase(m.view) = "moviesgrid"
         return
     end if
 

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -128,13 +128,9 @@ sub loadInitialItems()
     m.view = get_user_setting("display." + m.top.parentItem.Id + ".landing")
     sortAscendingStr = get_user_setting("display." + m.top.parentItem.Id + ".sortAscending")
 
-    ' If user has not set a preferred view for this folder
+    ' If user has not set a preferred view for this folder, check if they've set a default view
     if not isValid(m.view)
-        ' Check if user has set a preferred view for the parent folder
-        if isValid(m.top.parentItem.parentfolder)
-            print "Not View Set, Use Default"
-            m.view = get_user_setting("display." + m.top.parentItem.parentfolder + ".view")
-        end if
+        m.view = get_user_setting("itemgrid.movieDefaultView")
     end if
 
     if not isValid(m.sortField) then m.sortField = "SortName"
@@ -196,12 +192,12 @@ sub loadInitialItems()
         m.infoGroup.visible = false
     else if LCase(m.options.view) = "moviesgrid" or LCase(m.view) = "moviesgrid"
         m.itemGrid.translation = "[96, 60]"
-        m.itemGrid.itemSize = "[230, 350]"
-        m.itemGrid.rowHeights = "[350]"
-        m.top.showItemTitles = true
         m.itemGrid.numRows = "3"
         m.selectedMovieOverview.visible = false
         m.infoGroup.visible = false
+        m.itemGrid.itemSize = "[230, 350]"
+        m.itemGrid.rowHeights = "[350]"
+        m.top.showItemTitles = true
     else if m.options.view = "Genres" or m.view = "Genres"
         m.loadItemsTask.StudioIds = m.top.parentItem.Id
         m.loadItemsTask.view = "Genres"

--- a/components/ItemGrid/MovieLibraryView.xml
+++ b/components/ItemGrid/MovieLibraryView.xml
@@ -54,6 +54,7 @@
     <field id="imageDisplayMode" type="string" value="scaleToZoom" />
     <field id="AlphaSelected" type="string" alias="AlphaMenu.itemAlphaSelected" alwaysNotify="true" onChange="onItemAlphaSelected" />
     <field id="alphaActive" type="boolean" value="false" />
+    <field id="showItemTitles" type="boolean" value="false" />
     <field id="jumpToItem" type="integer" value="" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -31,6 +31,7 @@
       </RadioButtonList>
     </LayoutGroup>
 
+    <RadioButtonList id="radioSetting" translation="[900, 450]" inheritParentTransform="false" vertFocusAnimationStyle="floatingFocus" />
     <intkeyboard_integerKeyboard translation="[900, 520]" id="integerSetting" maxLength="3" domain="numeric" visible="false" />
 
   </children>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -303,6 +303,16 @@
             <translation>Movies</translation>
         </message>
         <message>
+            <source>Movies (Presentation)</source>
+            <translation>Movies (Presentation)</translation>
+            <extracomment>Movie library view option</extracomment>
+        </message>
+        <message>
+            <source>Movies (Grid)</source>
+            <translation>Movies (Grid)</translation>
+            <extracomment>Movie library view option</extracomment>
+        </message>
+        <message>
             <source>TV Shows</source>
             <translation>TV Shows</translation>
         </message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -147,6 +147,23 @@
                         "settingName": "itemgrid.reset",
                         "type": "bool",
                         "default": "true"
+                    },
+                    {
+                        "title": "Movie Library Default View",
+                        "description": "Default view for Movie Libraries.",
+                        "settingName": "itemgrid.movieDefaultView",
+                        "type": "radio",
+                        "default": "movies",
+                        "options": [
+                            {
+                                "title": "Movies (Presentation)",
+                                "id": "Movies"
+                            },
+                            {
+                                "title": "Movies (Grid)",
+                                "id": "MoviesGrid"
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
**Changes**

1. Creates a new Movie Library view called Grid
2. Create a new User Setting type called Radio
3. Creates a new User Setting that sets a default view to use in the Movie Library if the user has not already selected a view. This is needed so if the user wants to use grid for everything, they don't have to manually set it on every library or sub folder.

**Issues**
Fixes #899