### PR TITLE
Toggle video playback when OK button is pressed

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -222,7 +222,12 @@ end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
 
-    if key = "OK" and m.nextEpisodeButton.hasfocus() and not m.top.trickPlayBar.visible
+    ' don't do anything if trick play bar is visible
+    if m.top.trickPlayBar.visible
+        return false
+    end if
+
+    if key = "OK" and m.nextEpisodeButton.hasfocus()
         m.top.state = "finished"
         hideNextEpisodeButton()
         return true
@@ -243,6 +248,16 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "up"
         m.top.selectPlaybackInfoPressed = true
         return true
+    else if key = "OK"
+        print("OK pressed")
+        ' OK will play/pause depending on current state
+        if m.top.state = "paused"
+            m.top.control = "resume"
+            return true
+        else if m.top.state = "playing"
+            m.top.control = "pause"
+            return true
+        end if
     end if
 
     return false

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -243,14 +243,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "up"
         m.top.selectPlaybackInfoPressed = true
         return true
+    else if key = "OK"
         ' OK will play/pause depending on current state
-    else if key = "OK" and not m.top.trickPlayBar.visible
+        ' return false to allow selection during seeking
         if m.top.state = "paused"
             m.top.control = "resume"
-            return true
+            return false
         else if m.top.state = "playing"
             m.top.control = "pause"
-            return true
+            return false
         end if
     end if
 

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -222,12 +222,7 @@ end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
 
-    ' don't do anything if trick play bar is visible
-    if m.top.trickPlayBar.visible
-        return false
-    end if
-
-    if key = "OK" and m.nextEpisodeButton.hasfocus()
+    if key = "OK" and m.nextEpisodeButton.hasfocus() and not m.top.trickPlayBar.visible
         m.top.state = "finished"
         hideNextEpisodeButton()
         return true
@@ -248,9 +243,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "up"
         m.top.selectPlaybackInfoPressed = true
         return true
-    else if key = "OK"
-        print("OK pressed")
         ' OK will play/pause depending on current state
+    else if key = "OK" and not m.top.trickPlayBar.visible
         if m.top.state = "paused"
             m.top.control = "resume"
             return true


### PR DESCRIPTION
**Changes**
- implement play/pause action on ok button press
- prevent handling any buttons while trick play bar is visible (otherwise, ok button would play/pause video in the background instead of making a selection during seeking)

**Issues**
Fixes #883