### PR TITLE
Add user setting: Go straight to episode listing (if only 1 season available)

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -658,13 +658,13 @@
             <extracomment>Option Title in user setting screen</extracomment>
         </message>
         <message>
-            <source>Go straight to episode listing (if only 1 season)</source>
-            <translation>Go straight to episode listing (if only 1 season)</translation>
+            <source>Skip Details for Single Seasons</source>
+            <translation>Skip Details for Single Seasons</translation>
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>
-            <source>If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.</source>
-            <translation>If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.</translation>
+            <source>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..</source>
+            <translation>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -658,6 +658,16 @@
             <extracomment>Option Title in user setting screen</extracomment>
         </message>
         <message>
+            <source>Go straight to episode listing (if series has only one season)</source>
+            <translation>Go straight to episode listing (if series has only one season)</translation>
+            <extracomment>Settings Menu - Title for option</extracomment>
+        </message>
+        <message>
+            <source>If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.</source>
+            <translation>If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
+        <message>
             <source>If enabled, images of unwatched episodes will be blurred.</source>
             <translation>If enabled, images of unwatched episodes will be blurred.</translation>
         </message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -658,13 +658,13 @@
             <extracomment>Option Title in user setting screen</extracomment>
         </message>
         <message>
-            <source>Go straight to episode listing (if series has only one season)</source>
-            <translation>Go straight to episode listing (if series has only one season)</translation>
+            <source>Go straight to episode listing (if only 1 season)</source>
+            <translation>Go straight to episode listing (if only 1 season)</translation>
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>
-            <source>If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.</source>
-            <translation>If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.</translation>
+            <source>If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.</source>
+            <translation>If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -663,8 +663,8 @@
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>
-            <source>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..</source>
-            <translation>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..</translation>
+            <source>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.</source>
+            <translation>If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -89,8 +89,8 @@
                         "default": "false"
                     },
                     {
-                        "title": "Go straight to episode listing (if series has only one season)",
-                        "description": "If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.",
+                        "title": "Go straight to episode listing (if only 1 season)",
+                        "description": "If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.",
                         "settingName": "ui.tvshows.goStraightToEpisodeListing",
                         "type": "bool",
                         "default": "true"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -87,6 +87,13 @@
                         "settingName": "ui.tvshows.blurunwatched",
                         "type": "bool",
                         "default": "false"
+                    },
+                    {
+                        "title": "Go straight to episode listing (if series has only one season)",
+                        "description": "If enabled, selecting a TV series with only one season will go directly to the episode listing for that episode, rather than the season listing.",
+                        "settingName": "ui.tvshows.goStraightToEpisodeListing",
+                        "type": "bool",
+                        "default": "true"
                     }
                 ]
             },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -97,7 +97,7 @@
                     },
                     {
                         "title": "Skip Details for Single Seasons",
-                        "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..",
+                        "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.",
                         "settingName": "ui.tvshows.goStraightToEpisodeListing",
                         "type": "bool",
                         "default": "false"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -89,11 +89,11 @@
                         "default": "false"
                     },
                     {
-                        "title": "Go straight to episode listing (if only 1 season)",
-                        "description": "If enabled, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.",
+                        "title": "Skip Details for Single Seasons",
+                        "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list..",
                         "settingName": "ui.tvshows.goStraightToEpisodeListing",
                         "type": "bool",
-                        "default": "true"
+                        "default": "false"
                     }
                 ]
             },

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -362,7 +362,6 @@ function CreateSeriesDetailsGroup(series)
     seasonData = TVSeasons(series.id)
     ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
     if get_user_setting("ui.tvshows.goStraightToEpisodeListing") = "true" and seasonData.Items.Count() = 1
-        print "Returning single season"
         return CreateSeasonDetailsGroupByID(series.id, seasonData.Items[0].id)
     end if
     group = CreateObject("roSGNode", "TVShowDetails")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -358,12 +358,19 @@ function CreateMovieDetailsGroup(movie)
 end function
 
 function CreateSeriesDetailsGroup(series)
+    ' Get season data early in the function so we can check number of seasons.
+    seasonData = TVSeasons(series.id)
+    ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
+    if get_user_setting("ui.tvshows.goStraightToEpisodeListing") = "true" and seasonData.Items.Count() = 1
+        print "Returning single season"
+        return CreateSeasonDetailsGroupByID(series.id, seasonData.Items[0].id)
+    end if
     group = CreateObject("roSGNode", "TVShowDetails")
     group.optionsAvailable = false
     m.global.sceneManager.callFunc("pushScene", group)
 
     group.itemContent = ItemMetaData(series.id)
-    group.seasonData = TVSeasons(series.id)
+    group.seasonData = seasonData ' Re-use variable from beginning of function
 
     group.observeField("seasonSelected", m.port)
 


### PR DESCRIPTION
**Changes**
Adds a new user setting that, when enabled, goes straight to episode listing when selecting TV series with only one season.

If enabled,, selecting a TV series with only one season will go straight to the episode listing for that season, rather than the season listing.

**Issues**
Discussed in #662

**Tests**
Tested multiple series with various numbers of seasons/episodes on Roku 4200X:
✔ Single-season series go straight to episode listing
✔ While in episode listing, the back button correctly returns to TV series listing, rather than the (bypassed) season listing
✔ Multi-season series are not affected, and always go to season listing
✔ Reverts to old behavior when setting is disabled