### PR TITLE
Fix Crash When Invalid Deep Link Arguments Are Passed

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -48,7 +48,7 @@ sub Main (args as dynamic) as void
     m.device.EnableAppFocusEvent(false)
 
     ' Check if we were sent content to play with the startup command (Deep Link)
-    if isValid(args.mediaType) and isValid(args.contentId) and not args.contentId = ""
+    if isValidAndNotEmpty(args.mediaType) and isValidAndNotEmpty(args.contentId)
         video = CreateVideoPlayerGroup(args.contentId)
 
         if isValid(video) and video.errorMsg <> "introaborted"

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -48,10 +48,10 @@ sub Main (args as dynamic) as void
     m.device.EnableAppFocusEvent(false)
 
     ' Check if we were sent content to play with the startup command (Deep Link)
-    if (args.mediaType <> invalid) and (args.contentId <> invalid) and not (args.contentId = "")
+    if isValid(args.mediaType) and isValid(args.contentId) and not args.contentId = ""
         video = CreateVideoPlayerGroup(args.contentId)
 
-        if video <> invalid and video.errorMsg <> "introaborted"
+        if isValid(video) and video.errorMsg <> "introaborted"
             sceneManager.callFunc("pushScene", video)
         else
             dialog = createObject("roSGNode", "Dialog")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -48,7 +48,7 @@ sub Main (args as dynamic) as void
     m.device.EnableAppFocusEvent(false)
 
     ' Check if we were sent content to play with the startup command (Deep Link)
-    if (args.mediaType <> invalid) and (args.contentId <> invalid)
+    if (args.mediaType <> invalid) and (args.contentId <> invalid) and not (args.contentId = "")
         video = CreateVideoPlayerGroup(args.contentId)
 
         if video <> invalid and video.errorMsg <> "introaborted"

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -22,8 +22,8 @@ end function
 sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -1, playbackPosition = -1, forceTranscoding = false, showIntro = true, allowResumeDialog = true)
     video.content = createObject("RoSGNode", "ContentNode")
     meta = ItemMetaData(video.id)
-    m.videotype = meta.type
     if meta = invalid
+        m.videotype = meta.type
         video.content = invalid
         return
     end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -23,10 +23,10 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     video.content = createObject("RoSGNode", "ContentNode")
     meta = ItemMetaData(video.id)
     if meta = invalid
-        m.videotype = meta.type
         video.content = invalid
         return
     end if
+    m.videotype = meta.type
 
     ' Special handling for "Programs" or "Vidoes" launched from "On Now" or elsewhere on the home screen...
     ' basically anything that is a Live Channel.

--- a/source/utils/Subtitles.brs
+++ b/source/utils/Subtitles.brs
@@ -21,7 +21,7 @@ end function
 ' returns the server-side track index for the appriate subtitle
 function defaultSubtitleTrackFromVid(video_id) as integer
     meta = ItemMetaData(video_id)
-    if meta.json.mediaSources <> invalid
+    if meta?.json?.mediaSources <> invalid
         subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
         default_text_subs = defaultSubtitleTrack(subtitles["all"], true) ' Find correct subtitle track (forced text)
         if default_text_subs <> -1

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -194,9 +194,9 @@ end function
 function isValidAndNotEmpty(input) as boolean
     if not isValid(input) then return false
     ' Use roAssociativeArray instead of list so we get access to the doesExist() method
-    countableTypes = { "Array": 1, "List": 1, "roArray": 1, "roAssociativeArray": 1, "roList": 1 }
-    inputType = type(input)
-    if type(input) = "String" or type(input) = "roString"
+    countableTypes = { "array": 1, "list": 1, "roarray": 1, "roassociativearray": 1, "rolist": 1 }
+    inputType = LCase(type(input))
+    if inputType = "string" or inputType = "rostring"
         trimmedInput = input.trim()
         return trimmedInput <> ""
     else if countableTypes.doesExist(inputType)

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -189,6 +189,24 @@ function isValid(input) as boolean
     return input <> invalid
 end function
 
+' Returns whether or not passed value is valid and not empty
+' Accepts a string, or any countable type (arrays and lists)
+function isValidAndNotEmpty(input) as boolean
+    if not isValid(input) then return false
+    ' Use roAssociativeArray instead of list so we get access to the doesExist() method
+    countableTypes = { "Array": 1, "List": 1, "roArray": 1, "roAssociativeArray": 1, "roList": 1 }
+    inputType = type(input)
+    if type(input) = "String" or type(input) = "roString"
+        trimmedInput = input.trim()
+        return trimmedInput <> ""
+    else if countableTypes.doesExist(inputType)
+        return input.count() > 0
+    else
+        print "Called isValidAndNotEmpty() with invalid type: ", inputType
+        return false
+    end if
+end function
+
 ' Rounds number to nearest integer
 function roundNumber(f as float) as integer
     ' BrightScript only has a "floor" round


### PR DESCRIPTION
For some reason, launching the channel via a RASP automation script sets this value to an empty string in stead of null, which was causing the channel to crash.

**Changes**
Fixes crash when `args.contentId` is set to an empty string.

Also replaces instances of `<> invalid` with `isValid()` within this function.