### PR TITLE
Fix Crash When Options Button Pressed, but Options Are Not Available

### DIFF
--- a/components/JFScene.brs
+++ b/components/JFScene.brs
@@ -11,7 +11,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else if key = "options"
         group = m.global.sceneManager.callFunc("getActiveScene")
-        if group <> invalid and group.optionsAvailable <> invalid and group.optionsAvailable
+        if isValid(group) and isValid(group.optionsAvailable) and group.optionsAvailable
             group.lastFocus = group.focusedChild
             panel = group.findNode("options")
             panel.visible = true

--- a/components/JFScene.brs
+++ b/components/JFScene.brs
@@ -11,7 +11,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else if key = "options"
         group = m.global.sceneManager.callFunc("getActiveScene")
-        if group <> invalid and group.optionsAvailable
+        if group <> invalid and group.optionsAvailable <> invalid and group.optionsAvailable
             group.lastFocus = group.focusedChild
             panel = group.findNode("options")
             panel.visible = true

--- a/components/JFScene.xml
+++ b/components/JFScene.xml
@@ -8,4 +8,5 @@
     <field id="exit" type="boolean" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="JFScene.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>


### PR DESCRIPTION
Pressing the ~back~ options button during initial video buffering may trigger this code with a group not containing `optionsAvailable` property, leading to a crash. In my case, the entire Roku device crashed and reset.

**Changes**
Checks if `group.optionsAvailable` is valid before we observe it.

Converts another `<> invalid` check to `isValid()`
