### PR TITLE
Fix distorted TV episode posters. Add client-side progress bar and played indicator.

### DIFF
--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -11,6 +11,8 @@ sub init()
     m.progressBackground = m.top.findNode("progressBackground")
     m.progressBar = m.top.findnode("progressBar")
     m.playedIndicator = m.top.findNode("playedIndicator")
+    m.checkmark = m.top.findNode("checkmark")
+    m.checkmark.font.size = 35
 end sub
 
 sub itemContentChanged()

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -64,7 +64,6 @@ sub itemContentChanged()
 
     ' Add checkmark in corner (if applicable)
     if isValid(itemData?.UserData?.Played) and itemData.UserData.Played = true
-        m.playedIndicator.uri = m.global.constants.icons.check_white
         m.playedIndicator.visible = true
     end if
 

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -8,6 +8,9 @@ sub init()
 
     m.rating = m.top.findnode("rating")
     m.infoBar = m.top.findnode("infoBar")
+    m.progressBackground = m.top.findNode("progressBackground")
+    m.progressBar = m.top.findnode("progressBar")
+    m.playedIndicator = m.top.findNode("playedIndicator")
 end sub
 
 sub itemContentChanged()
@@ -57,6 +60,21 @@ sub itemContentChanged()
         m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
     else
         m.top.findNode("star").visible = false
+    end if
+
+    ' Add checkmark in corner (if applicable)
+    if isValid(itemData?.UserData?.Played) and itemData.UserData.Played = true
+        m.playedIndicator.uri = m.global.constants.icons.check_white
+        m.playedIndicator.visible = true
+    end if
+
+    ' Add progress bar on bottom (if applicable)
+    if isValid(itemData?.UserData?.PlayedPercentage) and itemData?.UserData?.PlayedPercentage > 0
+        m.progressBackground.width = m.poster.width
+        m.progressBackground.visible = true
+        progressWidthInPixels = int(m.progressBackground.width / itemData.UserData.PlayedPercentage)
+        m.progressBar.width = progressWidthInPixels
+        m.progressBar.visible = true
     end if
 
     videoIdx = invalid

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -72,7 +72,7 @@ sub itemContentChanged()
     if isValid(itemData?.UserData?.PlayedPercentage) and itemData?.UserData?.PlayedPercentage > 0
         m.progressBackground.width = m.poster.width
         m.progressBackground.visible = true
-        progressWidthInPixels = int(m.progressBackground.width / itemData.UserData.PlayedPercentage)
+        progressWidthInPixels = int(m.progressBackground.width * itemData.UserData.PlayedPercentage / 100)
         m.progressBar.width = progressWidthInPixels
         m.progressBar.visible = true
     end if

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -2,8 +2,13 @@
 <component name="TVListDetails" extends="Group">
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
-      <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
-        <Poster id="poster" width="350" height="300" loadDisplayMode="scaleToZoom"/>
+      <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">        
+        <Group id="posterAndProgress">
+          <Poster id="poster" width="350" height="299" loadDisplayMode="scaleToZoom"/>
+          <Poster id="playedIndicator" width="40" height="40" visible="false" translation="[290, 20]"/>
+          <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="15" translation="[0,285]"/>
+          <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="15" translation="[0,285]" visible="false"/>
+        </Group>
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -5,10 +5,11 @@
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">        
         <Poster id="poster" width="350" height="300" loadDisplayMode="scaleToZoom">
           <Rectangle id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" translation="[290, 0]">
-            <Label id="checkmark" width="60" height="46" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" text="✓"/>
+            <Label id="checkmark" width="60" height="44" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" text="✓"/>
           </Rectangle>
-          <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="14" translation="[0,287]"/>
-          <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="14" translation="[0,287]" visible="false"/>
+          <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="16" translation="[0,286]">
+            <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="16" visible="false"/>
+          </Rectangle>
         </Poster>
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -3,7 +3,7 @@
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
-        <Poster id="poster" width="350" height="300" />
+        <Poster id="poster" width="350" height="300" loadDisplayMode="scaleToZoom"/>
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -5,7 +5,7 @@
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">        
         <Poster id="poster" width="350" height="300" loadDisplayMode="scaleToZoom">
           <Rectangle id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" translation="[290, 0]">
-            <Label id="checkmark" width="60" height="44" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" text="✓"/>
+            <Label id="checkmark" width="60" height="42" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="bottom" text="✓"/>
           </Rectangle>
           <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="16" translation="[0,286]">
             <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="16" visible="false"/>

--- a/components/tvshows/TVListDetails.xml
+++ b/components/tvshows/TVListDetails.xml
@@ -3,12 +3,13 @@
   <children>
     <LayoutGroup id="toplevel" layoutDirection="vert" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">        
-        <Group id="posterAndProgress">
-          <Poster id="poster" width="350" height="299" loadDisplayMode="scaleToZoom"/>
-          <Poster id="playedIndicator" width="40" height="40" visible="false" translation="[290, 20]"/>
-          <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="15" translation="[0,285]"/>
-          <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="15" translation="[0,285]" visible="false"/>
-        </Group>
+        <Poster id="poster" width="350" height="300" loadDisplayMode="scaleToZoom">
+          <Rectangle id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" translation="[290, 0]">
+            <Label id="checkmark" width="60" height="46" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" text="✓"/>
+          </Rectangle>
+          <Rectangle id="progressBackground" visible="false" color="0x00000098" width="350" height="14" translation="[0,287]"/>
+          <Rectangle id="progressBar" color="#00a4dcFF" width="0" height="14" translation="[0,287]" visible="false"/>
+        </Poster>
         <LayoutGroup id="text" layoutDirection="vert" itemSpacings="[15]">
           <!-- Using poster of 1 length to get spacing. Not successful with adding translation to title -->
           <Poster id="null" height="1" />

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -389,13 +389,8 @@ function TVEpisodes(show_id as string, season_id as string)
     data = getJson(resp)
     results = []
     for each item in data.Items
-        imgParams = { "AddPlayedIndicator": item.UserData.Played, "maxWidth": 400, "maxheight": 250 }
-        if item.UserData.PlayedPercentage <> invalid
-            param = { "PercentPlayed": item.UserData.PlayedPercentage }
-            imgParams.Append(param)
-        end if
         tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.image = PosterImage(item.id, imgParams)
+        tmp.image = PosterImage(item.id)
         if tmp.image <> invalid
             tmp.image.posterDisplayMode = "scaleToZoom"
         end if

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -389,8 +389,9 @@ function TVEpisodes(show_id as string, season_id as string)
     data = getJson(resp)
     results = []
     for each item in data.Items
+        imgParams = { "maxWidth": 400, "maxheight": 250 }
         tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.image = PosterImage(item.id)
+        tmp.image = PosterImage(item.id, imgParams)
         if tmp.image <> invalid
             tmp.image.posterDisplayMode = "scaleToZoom"
         end if


### PR DESCRIPTION
**Changes**
✔ Sets `loadDisplayMode="scaleToZoom"` on TV episode posters to avoid squashing the image. 
✔ Removes `AddPlayedIndicator` and `PercentPlayed` parameters when retrieving episode images.
✔ Renders client-side progress bar (inspired by the `HomeItem` component)
✔ Renders client-side "played" indicator (inspired by @1hitsong's pr #882) 

Before and after:
![image](https://user-images.githubusercontent.com/91706106/209450359-7cf6f8c3-f3dd-499b-8aff-ee0f3d2d56d0.png)

![image](https://user-images.githubusercontent.com/91706106/209881320-bcb2b55c-c913-4aea-a0a3-af0d56b416b4.png)

**Issues**
Fixes #603 

Should also improve performance and free up texture memory, since we don't need to call/store a separate image with playback info overlay.