### PR TITLE
prepare to deprecate ImageUrl()

### DIFF
--- a/components/ItemGrid/MovieLibraryView.xml
+++ b/components/ItemGrid/MovieLibraryView.xml
@@ -60,6 +60,7 @@
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
   <script type="text/brightscript" uri="MovieLibraryView.brs" />
 </component>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -39,7 +39,9 @@
     <extrasSlider id="personVideos" />
   </children>
   <script type="text/brightscript" uri="PersonDetails.brs" />
+
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/SearchBox.xml
+++ b/components/SearchBox.xml
@@ -12,5 +12,6 @@
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
 </component>

--- a/components/data/ChannelData.xml
+++ b/components/data/ChannelData.xml
@@ -5,6 +5,7 @@
   </interface>
   <script type="text/brightscript" uri="ChannelData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/CollectionData.xml
+++ b/components/data/CollectionData.xml
@@ -7,6 +7,7 @@
   </interface>
   <script type="text/brightscript" uri="CollectionData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/FolderData.xml
+++ b/components/data/FolderData.xml
@@ -2,6 +2,7 @@
 <component name="FolderData" extends="JFContentItem">
   <script type="text/brightscript" uri="FolderData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -17,5 +17,6 @@
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="HomeData.brs" />
 </component>

--- a/components/data/MovieData.xml
+++ b/components/data/MovieData.xml
@@ -10,6 +10,7 @@
   </interface>
   <script type="text/brightscript" uri="MovieData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/components/data/MusicAlbumSongListData.xml
+++ b/components/data/MusicAlbumSongListData.xml
@@ -2,6 +2,7 @@
 <component name="MusicAlbumSongListData" extends="JFContentItem">
   <script type="text/brightscript" uri="MusicAlbumSongListData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/MusicArtistData.xml
+++ b/components/data/MusicArtistData.xml
@@ -2,6 +2,7 @@
 <component name="MusicArtistData" extends="JFContentItem">
   <script type="text/brightscript" uri="MusicArtistData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/PersonData.xml
+++ b/components/data/PersonData.xml
@@ -7,6 +7,7 @@
 </interface>
 <script type="text/brightscript" uri="PersonData.brs" />
 <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+<script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
 <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
 <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/PhotoData.xml
+++ b/components/data/PhotoData.xml
@@ -6,6 +6,7 @@
   </interface>
   <script type="text/brightscript" uri="PhotoData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/ScheduleProgramData.xml
+++ b/components/data/ScheduleProgramData.xml
@@ -17,6 +17,7 @@
   </interface>
   <script type="text/brightscript" uri="ScheduleProgramData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/SeriesData.xml
+++ b/components/data/SeriesData.xml
@@ -8,6 +8,7 @@
   </interface>
   <script type="text/brightscript" uri="SeriesData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/TVEpisode.xml
+++ b/components/data/TVEpisode.xml
@@ -2,6 +2,7 @@
 <component name="TVEpisode" extends="JFContentItem">
   <script type="text/brightscript" uri="TVEpisode.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/data/VideoData.xml
+++ b/components/data/VideoData.xml
@@ -2,6 +2,7 @@
 <component name="VideoData" extends="JFContentItem">
   <script type="text/brightscript" uri="VideoData.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -22,6 +22,7 @@
   </interface>
   <script type="text/brightscript" uri="HomeItem.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/music/NowPlaying.xml
+++ b/components/music/NowPlaying.xml
@@ -127,6 +127,7 @@
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
   <script type="text/brightscript" uri="NowPlaying.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/components/photos/LoadPhotoTask.xml
+++ b/components/photos/LoadPhotoTask.xml
@@ -7,6 +7,7 @@
   </interface>
   <script type="text/brightscript" uri="LoadPhotoTask.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
 </component>

--- a/components/search/SearchResults.xml
+++ b/components/search/SearchResults.xml
@@ -24,5 +24,6 @@
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
 </component>

--- a/components/search/SearchRow.xml
+++ b/components/search/SearchRow.xml
@@ -11,5 +11,6 @@
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
 </component>

--- a/components/search/SearchTask.xml
+++ b/components/search/SearchTask.xml
@@ -10,5 +10,6 @@
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/deviceCapabilities.brs" />
 </component>

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -13,6 +13,7 @@
   </interface>
   <script type="text/brightscript" uri="TVEpisodes.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
+  <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
 </component>

--- a/source/api/Image.brs
+++ b/source/api/Image.brs
@@ -54,6 +54,23 @@ function ImageURL(id, version = "Primary", params = {})
     return buildURL(url, params)
 end function
 
+function ImageURL_API(id, version = "Primary", params = {})
+    ' set defaults
+    if params.maxHeight = invalid
+        param = { "maxHeight": "384" }
+        params.append(param)
+    end if
+    if params.maxWidth = invalid
+        param = { "maxWidth": "196" }
+        params.append(param)
+    end if
+    if params.quality = invalid
+        param = { "quality": "90" }
+        params.append(param)
+    end if
+    return api_API().items.getimageurl(id, version, 0, params)
+end function
+
 function UserImageURL(id, params = {})
     ' set defaults
     if params.maxHeight = invalid


### PR DESCRIPTION
changes no logic whatsoever.
this pr creates ImageUrl_API() which is identical to ImageUrl() except it uses the API instead of replace() and buildurl(), and puts the api in the context of all the brs files that might use Image.brs
once this is merged we can begin migrating piece by piece.
