### PR TITLE
Fix option menu focus if opened while library still loading

### DIFF
--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -340,6 +340,10 @@ sub ItemDataLoaded(msg)
 
         m.loading = false
         m.spinner.visible = false
+        ' Return focus to options menu if it was opened while library was loading
+        if m.options.visible
+            m.options.setFocus(true)
+        end if
         return
     end if
 
@@ -364,6 +368,10 @@ sub ItemDataLoaded(msg)
     end if
 
     m.spinner.visible = false
+    ' Return focus to options menu if it was opened while library was loading
+    if m.options.visible
+        m.options.setFocus(true)
+    end if
 end sub
 
 '


### PR DESCRIPTION
**Changes**
Return focus to options menu if it was was opened before library items finished loading.

**Issues**
Fixes #892