### PR TITLE
Create Music Grid View

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -99,9 +99,10 @@ sub loadItems()
     else if m.top.ItemType = "MusicArtist"
         url = "Artists"
         params.append({
-            UserId: get_setting("active_user")
+            UserId: get_setting("active_user"),
+            Fields: "Genres"
         })
-        params.IncludeItemTypes = ""
+        params.IncludeItemTypes = "MusicAlbum,Audio"
     else if m.top.ItemType = "MusicAlbum"
         url = Substitute("Users/{0}/Items/", get_setting("active_user"))
         params.append({ ImageTypeLimit: 1 })

--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -6,6 +6,9 @@ sub setupNodes()
     m.newBackdrop = m.top.findNode("backdropTransition")
     m.emptyText = m.top.findNode("emptyText")
     m.selectedArtistName = m.top.findNode("selectedArtistName")
+    m.selectedArtistSongCount = m.top.findNode("selectedArtistSongCount")
+    m.selectedArtistAlbumCount = m.top.findNode("selectedArtistAlbumCount")
+    m.selectedArtistGenres = m.top.findNode("selectedArtistGenres")
     m.artistLogo = m.top.findNode("artistLogo")
     m.swapAnimation = m.top.findNode("backroundSwapAnimation")
     m.spinner = m.top.findNode("spinner")
@@ -124,7 +127,7 @@ sub loadInitialItems()
 
     if not isValid(m.sortField) then m.sortField = "SortName"
     if not isValid(m.filter) then m.filter = "All"
-    if not isValid(m.view) then m.view = "Artists"
+    if not isValid(m.view) then m.view = "ArtistsPresentation"
 
     if sortAscendingStr = invalid or LCase(sortAscendingStr) = "true"
         m.sortAscending = true
@@ -138,7 +141,9 @@ sub loadInitialItems()
         m.loadItemsTask.recursive = true
         m.loadItemsTask.genreIds = m.top.parentItem.id
         m.loadItemsTask.itemId = m.top.parentItem.parentFolder
-    else if LCase(m.view) = "artists" or LCase(m.options.view) = "artists"
+    else if LCase(m.view) = "artistspresentation" or LCase(m.options.view) = "artistspresentation"
+        m.loadItemsTask.genreIds = ""
+    else if LCase(m.view) = "artistsgrid" or LCase(m.options.view) = "artistsgrid"
         m.loadItemsTask.genreIds = ""
     else
         m.loadItemsTask.itemId = m.top.parentItem.Id
@@ -168,6 +173,9 @@ sub loadInitialItems()
         m.itemGrid.numRows = "4"
         m.loadItemsTask.itemType = "MusicAlbum"
         m.top.imageDisplayMode = "scaleToFit"
+    else if LCase(m.options.view) = "artistsgrid" or LCase(m.view) = "artistsgrid"
+        m.itemGrid.translation = "[96, 60]"
+        m.itemGrid.numRows = "4"
     else if LCase(m.options.view) = "genres" or LCase(m.view) = "genres"
         m.loadItemsTask.itemType = ""
         m.loadItemsTask.recursive = true
@@ -193,7 +201,8 @@ end sub
 sub setMusicOptions(options)
 
     options.views = [
-        { "Title": tr("Artists"), "Name": "Artists" },
+        { "Title": tr("Artists (Presentation)"), "Name": "ArtistsPresentation" },
+        { "Title": tr("Artists (Grid)"), "Name": "ArtistsGrid" },
         { "Title": tr("Albums"), "Name": "Albums" },
         { "Title": tr("Genres"), "Name": "Genres" }
     ]
@@ -362,6 +371,33 @@ sub SetName(artistName as string)
 end sub
 
 '
+'Set Selected Artist Song Count
+sub SetSongCount(totalCount)
+    appendText = " Songs"
+    if totalCount = 1
+        appendText = " Song"
+    end if
+
+    m.selectedArtistSongCount.text = totalCount.tostr() + appendText
+end sub
+'
+'Set Selected Artist Album Count
+sub SetAlbumCount(totalCount)
+    appendText = " Albums"
+    if totalCount = 1
+        appendText = " Album"
+    end if
+
+    m.selectedArtistAlbumCount.text = totalCount.tostr() + appendText
+end sub
+
+'
+'Set Selected Artist Genres
+sub SetGenres(artistGenres)
+    m.selectedArtistGenres.text = artistGenres.join(", ")
+end sub
+
+'
 'Set Background Image
 sub SetBackground(backgroundUri as string)
     if backgroundUri = ""
@@ -391,6 +427,9 @@ sub onItemFocused()
 
     m.artistLogo.visible = false
     m.selectedArtistName.visible = false
+    m.selectedArtistGenres.visible = false
+    m.selectedArtistSongCount.visible = false
+    m.selectedArtistAlbumCount.visible = false
 
     ' Load more data if focus is within last 5 rows, and there are more items to load
     if focusedRow >= m.loadedRows - 5 and m.loadeditems < m.loadItemsTask.totalRecordCount
@@ -403,7 +442,41 @@ sub onItemFocused()
         return
     end if
 
+    if LCase(m.options.view) = "artistsgrid" or LCase(m.view) = "artistsgrid"
+        return
+    end if
+
+    if not m.selectedArtistGenres.visible
+        m.selectedArtistGenres.visible = true
+    end if
+
+    if not m.selectedArtistSongCount.visible
+        m.selectedArtistSongCount.visible = true
+    end if
+
+    if not m.selectedArtistAlbumCount.visible
+        m.selectedArtistAlbumCount.visible = true
+    end if
+
     itemData = m.selectedFavoriteItem.json
+
+    if isValid(itemData.SongCount)
+        SetSongCount(itemData.SongCount)
+    else
+        SetSongCount("")
+    end if
+
+    if isValid(itemData.AlbumCount)
+        SetAlbumCount(itemData.AlbumCount)
+    else
+        SetAlbumCount("")
+    end if
+
+    if isValid(itemData.Genres)
+        SetGenres(itemData.Genres)
+    else
+        SetGenres([])
+    end if
 
     if isValid(itemData.Name)
         SetName(itemData.Name)

--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -373,9 +373,9 @@ end sub
 '
 'Set Selected Artist Song Count
 sub SetSongCount(totalCount)
-    appendText = " Songs"
+    appendText = " " + tr("Songs")
     if totalCount = 1
-        appendText = " Song"
+        appendText = " " + tr("Song")
     end if
 
     m.selectedArtistSongCount.text = totalCount.tostr() + appendText
@@ -383,9 +383,9 @@ end sub
 '
 'Set Selected Artist Album Count
 sub SetAlbumCount(totalCount)
-    appendText = " Albums"
+    appendText = " " + tr("Albums")
     if totalCount = 1
-        appendText = " Album"
+        appendText = " " + tr("Album")
     end if
 
     m.selectedArtistAlbumCount.text = totalCount.tostr() + appendText

--- a/components/ItemGrid/MusicLibraryView.xml
+++ b/components/ItemGrid/MusicLibraryView.xml
@@ -13,6 +13,9 @@
 
     <Label id="selectedArtistName" visible="false" translation="[120, 40]" wrap="true" font="font:LargeBoldSystemFont" width="850" height="196" horizAlign="left" vertAlign="center" />
     <Poster id="artistLogo" visible="false" translation="[120, 40]" loadDisplayMode="scaleToFit" width="384" height="196" />
+    <Label id="selectedArtistSongCount" translation="[120, 270]" wrap="true" font="font:SmallestSystemFont" width="850" height="30" horizAlign="left" />
+    <Label id="selectedArtistAlbumCount" translation="[120, 310]" wrap="true" font="font:SmallestSystemFont" width="850" height="30" horizAlign="left" />
+    <Label id="selectedArtistGenres" translation="[120, 350]" wrap="true" font="font:SmallestSystemFont" width="850" height="30" horizAlign="left" />
 
     <MarkupGrid id="itemGrid" itemComponentName="MusicArtistGridItem" numColumns="6" numRows="2" vertFocusAnimationStyle="fixed" itemSize="[280, 280]" itemSpacing="[20, 20]" />
     <MarkupGrid id="genrelist" itemComponentName="MusicArtistGridItem" numColumns="6" numRows="4" vertFocusAnimationStyle="fixed" translation="[96, 60]" itemSize="[280, 280]" itemSpacing="[20, 20]" opacity="0" />

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -494,7 +494,7 @@
             <translation>Playback</translation>
             <extracomment>Title for Playback section in user setting screen.</extracomment>
         </message>
-        
+
         <message>
             <source>Codec Support</source>
             <translation>Codec Support</translation>
@@ -515,7 +515,7 @@
             <translation>Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
-         <message>
+        <message>
             <source>MPEG-4</source>
             <translation>MPEG-4</translation>
             <extracomment>Name of codec used in settings menu</extracomment>
@@ -972,6 +972,30 @@
         <message>
             <source>Resumable</source>
             <translation>Resumable</translation>
+        </message>
+        <message>
+            <source>Artists (Presentation)</source>
+            <translation>Artists (Presentation)</translation>
+        </message>
+        <message>
+            <source>Artists (Grid)</source>
+            <translation>Artists (Grid)</translation>
+        </message>
+        <message>
+            <source>Song</source>
+            <translation>Song</translation>
+        </message>
+        <message>
+            <source>Songs</source>
+            <translation>Songs</translation>
+        </message>
+        <message>
+            <source>Album</source>
+            <translation>Album</translation>
+        </message>
+        <message>
+            <source>Albums</source>
+            <translation>Albums</translation>
         </message>
     </context>
 </TS>


### PR DESCRIPTION
**Changes**
Creates grid view for Music Artists, allowing users to select from 4 different views. Also updates the Presentation view a bit.

Grid View
![image](https://user-images.githubusercontent.com/3330318/210122953-88d3e4a2-d4df-4b31-8895-e78581e5c119.png)

Updated Presentation View
![image](https://user-images.githubusercontent.com/3330318/210122997-094f07f3-ae11-4362-8727-15bc90e8f607.png)
