### PR TITLE
Disable Community Rating for Episodes of TV shows

### DIFF
--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -52,11 +52,15 @@ sub itemContentChanged()
         end if
     end if
 
-    if isValid(itemData.communityRating)
-        m.top.findNode("star").visible = true
-        m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
+    if get_user_setting("ui.tvshows.disableCommunityRating") = "false"
+        if isValid(itemData.communityRating)
+            m.top.findNode("star").visible = true
+            m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
+        else
+            m.top.findNode("star").visible = false
+        end if
     else
-        m.top.findNode("star").visible = false
+        m.top.findNode("rating").visible = false
     end if
 
     videoIdx = invalid

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -60,8 +60,8 @@ sub itemContentChanged()
             m.top.findNode("star").visible = false
         end if
     else
-       m.rating.visible = false
-       m.infoBar.itemSpacings = [20, -25, 20, 20] 
+        m.rating.visible = false
+        m.infoBar.itemSpacings = [20, -25, 20, 20]
     end if
 
     videoIdx = invalid

--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -60,7 +60,8 @@ sub itemContentChanged()
             m.top.findNode("star").visible = false
         end if
     else
-        m.top.findNode("rating").visible = false
+       m.rating.visible = false
+       m.infoBar.itemSpacings = [20, -25, 20, 20] 
     end if
 
     videoIdx = invalid

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -973,5 +973,13 @@
             <source>Resumable</source>
             <translation>Resumable</translation>
         </message>
+        <message>
+            <source>Disable Community Rating for Episodes</source>
+            <translation>Disable Community Rating for Episodes</translation>
+        </message>
+        <message>
+            <source>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</source>
+            <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -127,6 +127,13 @@
                         "settingName": "ui.tvshows.goStraightToEpisodeListing",
                         "type": "bool",
                         "default": "false"
+                    },
+                    {
+                        "title":"Disable Community Rating for Episodes",
+                        "description": "If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.",
+                        "settingName": "ui.tvshows.disableCommunityRating",
+                        "type":"bool",
+                        "default":"false"
                     }
                 ]
             },


### PR DESCRIPTION
**Changes**
Outlined in more detail in the enhancement request https://github.com/jellyfin/jellyfin-roku/issues/936
Adds setting to disable community rating for episodes of TV shows.

Also, the if statement could maybe be brought out so that it's not nested.
```Brightscript
if get_user_setting("ui.tvshows.disableCommunityRating") = "false"
    if isValid(itemData.communityRating)
        m.top.findNode("star").visible = true
        m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
    else
        m.top.findNode("star").visible = false
    end if
else
    m.top.findNode("rating").visible = false
end if
```

```Brightscript
if get_user_setting("ui.tvshows.disableCommunityRating") = "false" and isValid(itemData.communityRating)
    m.top.findNode("star").visible = true
    m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)
else:
    m.top.findNode("star").visible = false
end if
```
**Issues**
ex. Fixes #936 

**To Do**
A small spacing is left over after the setting is turned on. 