### PR TITLE
Fix Crashing or Freezing When Starting an Episode of a Series

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -46,7 +46,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
-        video.runTime = (meta.json.RunTimeTicks / 10000000.0)
         video.content.contenttype = "episode"
     end if
 


### PR DESCRIPTION
**Changes**
This PR removes a line causes the Roku client to crash or freeze when the user picks an episode. On the latest git version of the code it freezes and on the stable release on the Roku marketplace, it crashes out or sometimes plays the media, but zoomed in significantly which makes it unwatchable.