### PR TITLE
Add "Skip Intro" Button to use with the Intro-Skipper Jellyfin plugin

### DIFF
--- a/components/GetIntroInfoTask.brs
+++ b/components/GetIntroInfoTask.brs
@@ -1,0 +1,14 @@
+sub init()
+    m.top.functionName = "getIntroInfoTask"
+end sub
+
+sub getIntroInfoTask()
+    api_retval = api_API().introskipper.get(m.top.videoID)
+    if api_retval = invalid or type(api_retval) <> "roAssociativeArray" or api_retval.Valid <> true
+        m.introData = invalid
+        m.top.introData = invalid
+    else
+        m.introData = api_retval
+        m.top.introData = api_retval
+    end if
+end sub

--- a/components/GetIntroInfoTask.xml
+++ b/components/GetIntroInfoTask.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<component name="GetIntroInfoTask" extends="Task">
+    <interface>
+        <field id="videoID" type="string" />
+        <field id="introData" type="assocarray" />
+    </interface>
+    <script type="text/brightscript" uri="GetIntroInfoTask.brs" />
+    <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+    <script type="text/brightscript" uri="pkg:/source/roku_modules/api/api.brs" />
+</component>

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -23,6 +23,9 @@
     <field id="mediaSourceId" type="string" />
     <field id="audioIndex" type="integer" />
     <field id="runTime" type="integer" />
+    <field id="introPromptStartTime" type="integer" />
+    <field id="introPromptEndTime" type="integer" />
+    <field id="introSkipTime" type="integer" />
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
@@ -32,7 +35,9 @@
   <children>
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
+    <!--note that nextEpisode and skipIntro have the same translation, but since they are shown at opposite ends of an episode, they should not conflict-->
     <JFButton id="nextEpisode" opacity="0" textColor="#f0f0f0" focusedTextColor="#202020" focusFootprintBitmapUri="pkg:/images/option-menu-bg.9.png" focusBitmapUri="pkg:/images/white.9.png" translation="[1500, 900]" />
+    <JFButton id="skipIntro" opacity="0" textColor="#f0f0f0" focusedTextColor="#202020" focusFootprintBitmapUri="pkg:/images/option-menu-bg.9.png" focusBitmapUri="pkg:/images/white.9.png" translation="[1500, 900]" />
 
     <!--animation for the play next episode button-->
     <Animation id="showNextEpisodeButton" duration="1.0" repeat="false" easeFunction="inQuad">
@@ -40,6 +45,14 @@
     </Animation>
     <Animation id="hideNextEpisodeButton" duration=".2" repeat="false" easeFunction="inQuad">
       <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[.9, 0]" fieldToInterp="nextEpisode.opacity" />
+    </Animation>
+
+    <!--animation for the skip introduction button-->
+    <Animation id="showSkipIntroButton" duration="1.0" repeat="false" easeFunction="inQuad">
+      <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[0.0, .9]" fieldToInterp="skipIntro.opacity" />
+    </Animation>
+    <Animation id="hideSkipIntroButton" duration=".2" repeat="false" easeFunction="inQuad">
+      <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[.9, 0]" fieldToInterp="skipIntro.opacity" />
     </Animation>
   </children>
 </component>


### PR DESCRIPTION
Add a "Skip Intro" button to use with the [Intro-Skipper](https://github.com/ConfusedPolarBear/intro-skipper) Jellyfin plugin.

**Changes**
Add a "Skip Intro" button to the player interface when an intro has been detected with the [Intro-Skipper](https://github.com/ConfusedPolarBear/intro-skipper) plugin.  When the user clicks the button, the playback position is moved to the end of the detected introduction.  The button is shown and hidden at the times suggested by Intro-Skipper. If the Intro Skipper plugin is not installed or disabled, the button will not be shown.  The button will only be shown once during the first time through the intro section.

**Other Notes**
I had to rework the way the Next Episode button observers worked since it assumed exclusive use of the `Video.position` field observer.  This setup should allow other consumers of the `Video.position` callback now.

**Credit**
Thanks to @candry7731 for the Next Episode button code, which I heavily leveraged for this one.