### PR TITLE
Allow for unlimited bitrate

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1035,7 +1035,7 @@
         </message>
         <message>
             <source>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.</source>
-            <translation>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.</translation>
+            <translation>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.</translation>
         </message>
         <message>
             <source>Libraries</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1026,8 +1026,16 @@
             <translation>Limit Bitrate</translation>
         </message>
         <message>
-            <source>Enable or disable limiting video bitrates based on Roku's specifications.</source>
-            <translation>Enable or disable limiting video bitrates based on Roku's specifications.</translation>
+            <source>Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).</source>
+            <translation>Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).</translation>
+        </message>
+        <message>
+            <source>Playback Bitrate Limit</source>
+            <translation>Playback Bitrate Limit</translation>
+        </message>
+        <message>
+            <source>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.</source>
+            <translation>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.</translation>
         </message>
         <message>
             <source>Libraries</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1034,7 +1034,7 @@
             <translation>Playback Bitrate Limit</translation>
         </message>
         <message>
-            <source>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.</source>
+            <source>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.</source>
             <translation>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.</translation>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1049,5 +1049,13 @@
             <source>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</source>
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
+        <message>
+            <source>Turn off bitrate limiting</source>
+            <translation>Turn off bitrate limiting</translation>
+        </message>
+        <message>
+            <source>This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.</source>
+            <translation>This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.</translation>
+        </message>        
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1026,7 +1026,7 @@
             <translation>Limit Bitrate</translation>
         </message>
         <message>
-            <source>Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).</source>
+            <source>If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.</source>
             <translation>Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).</translation>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1027,7 +1027,7 @@
         </message>
         <message>
             <source>If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.</source>
-            <translation>Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).</translation>
+            <translation>If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.</translation>
         </message>
         <message>
             <source>Playback Bitrate Limit</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1022,8 +1022,16 @@
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
         <message>
-            <source>Limit Bitrate</source>
-            <translation>Limit Bitrate</translation>
+            <source>Playback Bitrate Limits</source>
+            <translation>Playback Bitrate Limits</translation>
+        </message>
+        <message>
+            <source>Set limits for how high playback bitrates are allowed to be.</source>
+            <translation>Set limits for how high playback bitrates are allowed to be.</translation>
+        </message>
+        <message>
+            <source>Limits Enabled</source>
+            <translation>Limits Enabled</translation>
         </message>
         <message>
             <source>If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.</source>
@@ -1034,8 +1042,8 @@
             <translation>Playback Bitrate Limit</translation>
         </message>
         <message>
-            <source>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.</source>
-            <translation>Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.</translation>
+            <source>Max bitrate (Mbps) allowed if limits are enabled. Set to 0 to use Roku's specifications.</source>
+            <translation>Max bitrate (Mbps) allowed if limits are enabled. Set to 0 to use Roku's specifications.</translation>
         </message>
         <message>
             <source>Libraries</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1050,12 +1050,12 @@
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
         <message>
-            <source>Turn off bitrate limiting</source>
-            <translation>Turn off bitrate limiting</translation>
+            <source>Bitrate Limiting</source>
+            <translation>Bitrate Limiting</translation>
         </message>
         <message>
-            <source>This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.</source>
-            <translation>This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.</translation>
+            <source>Enable or disable limiting video bitrates based on Roku's specifications.</source>
+            <translation>Enable or disable limiting video bitrates based on Roku's specifications.</translation>
         </message>        
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1022,13 +1022,13 @@
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
         <message>
-            <source>Bitrate Limiting</source>
-            <translation>Bitrate Limiting</translation>
+            <source>Limit Bitrate</source>
+            <translation>Limit Bitrate</translation>
         </message>
         <message>
             <source>Enable or disable limiting video bitrates based on Roku's specifications.</source>
             <translation>Enable or disable limiting video bitrates based on Roku's specifications.</translation>
-        </message>        
+        </message>
         <message>
             <source>Libraries</source>
             <translation>Libraries</translation>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -4,6 +4,13 @@
         "description": "Settings relating to playback and supported codec and media types.",
         "children": [
             {
+                "title": "Cinema Mode",
+                "description": "Cinema Mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.",
+                "settingName": "playback.cinemamode",
+                "type": "bool",
+                "default": "false"
+            },
+            {
                 "title": "Codec Support",
                 "description": "Enable or disable Direct Play support for certain codecs",
                 "children": [
@@ -29,13 +36,6 @@
                         "default": "true"
                     }
                 ]
-            },
-            {
-                "title": "Cinema Mode",
-                "description": "Cinema Mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.",
-                "settingName": "playback.cinemamode",
-                "type": "bool",
-                "default": "false"
             },
             {
                 "title": "Playback Bitrate Limits",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -63,6 +63,13 @@
                 "settingName": "playback.subs.onlytext",
                 "type": "bool",
                 "default": "false"
+            },
+            {
+                "title": "Turn off bitrate limiting",
+                "description": "This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.",
+                "settingName": "playback.bitrate.unlimited",
+                "type": "bool",
+                "default": "false"
             }
         ]
     },
@@ -129,11 +136,11 @@
                         "default": "false"
                     },
                     {
-                        "title":"Disable Community Rating for Episodes",
+                        "title": "Disable Community Rating for Episodes",
                         "description": "If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.",
                         "settingName": "ui.tvshows.disableCommunityRating",
-                        "type":"bool",
-                        "default":"false"
+                        "type": "bool",
+                        "default": "false"
                     }
                 ]
             },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -69,7 +69,7 @@
                 "description": "Enable or disable limiting video bitrates based on Roku's specifications.",
                 "settingName": "playback.bitrate.unlimited",
                 "type": "bool",
-                "default": "false"
+                "default": "true"
             }
         ]
     },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -65,18 +65,24 @@
                 "default": "false"
             },
             {
-                "title": "Limit Bitrate",
-                "description": "If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.",
-                "settingName": "playback.bitrate.maxlimited",
-                "type": "bool",
-                "default": "true"
-            },
-            {
-                "title": "Playback Bitrate Limit",
-                "description": "Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.",
-                "settingName": "playback.bitrate.limit",
-                "type": "integer",
-                "default": "0"
+                "title": "Playback Bitrate Limits",
+                "description": "Set limits for how high playback bitrates are allowed to be.",
+                "children": [
+                    {
+                        "title": "Limits Enabled",
+                        "description": "If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.",
+                        "settingName": "playback.bitrate.maxlimited",
+                        "type": "bool",
+                        "default": "true"
+                    },
+                    {
+                        "title": "Playback Bitrate Limit",
+                        "description": "Max bitrate (Mbps) allowed if limits are enabled. Set to 0 to use Roku's specifications.",
+                        "settingName": "playback.bitrate.limit",
+                        "type": "integer",
+                        "default": "0"
+                    }
+                ]
             }
         ]
     },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -65,7 +65,7 @@
                 "default": "false"
             },
             {
-                "title": "Turn off bitrate limiting",
+                "title": "Bitrate Limiting",
                 "description": "This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.",
                 "settingName": "playback.bitrate.unlimited",
                 "type": "bool",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -66,14 +66,14 @@
             },
             {
                 "title": "Limit Bitrate",
-                "description": "Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).",
+                "description": "If enabled, playback bitrates will be limited based on the 'Playback Bitrate Limit' setting.",
                 "settingName": "playback.bitrate.maxlimited",
                 "type": "bool",
                 "default": "true"
             },
             {
                 "title": "Playback Bitrate Limit",
-                "description": "Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.",
+                "description": "Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. Set to 0 to use Roku's specifications.",
                 "settingName": "playback.bitrate.limit",
                 "type": "integer",
                 "default": "0"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -65,7 +65,7 @@
                 "default": "false"
             },
             {
-                "title": "Bitrate Limiting",
+                "title": "Limit Bitrate",
                 "description": "Enable or disable limiting video bitrates based on Roku's specifications.",
                 "settingName": "playback.bitrate.maxlimited",
                 "type": "bool",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -31,36 +31,9 @@
                 ]
             },
             {
-                "title": "Profile Level Support",
-                "description": "Attempt Direct Play of potentially unsupported profile levels",
-                "children": [
-                    {
-                        "title": "H.264",
-                        "description": "Attempt Direct Play for H.264 media with unsupported profile levels before falling back to transcoding if it fails.",
-                        "settingName": "playback.tryDirect.h264ProfileLevel",
-                        "type": "bool",
-                        "default": "true"
-                    },
-                    {
-                        "title": "HEVC",
-                        "description": "Attempt Direct Play for HEVC media with unsupported profile levels before falling back to trancoding if it fails.",
-                        "settingName": "playback.tryDirect.hevcProfileLevel",
-                        "type": "bool",
-                        "default": "true"
-                    }
-                ]
-            },
-            {
                 "title": "Cinema Mode",
                 "description": "Cinema Mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.",
                 "settingName": "playback.cinemamode",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Text Subtitles Only",
-                "description": "Only display text subtitles to minimize transcoding.",
-                "settingName": "playback.subs.onlytext",
                 "type": "bool",
                 "default": "false"
             },
@@ -83,6 +56,33 @@
                         "default": "0"
                     }
                 ]
+            },
+            {
+                "title": "Profile Level Support",
+                "description": "Attempt Direct Play of potentially unsupported profile levels",
+                "children": [
+                    {
+                        "title": "H.264",
+                        "description": "Attempt Direct Play for H.264 media with unsupported profile levels before falling back to transcoding if it fails.",
+                        "settingName": "playback.tryDirect.h264ProfileLevel",
+                        "type": "bool",
+                        "default": "true"
+                    },
+                    {
+                        "title": "HEVC",
+                        "description": "Attempt Direct Play for HEVC media with unsupported profile levels before falling back to trancoding if it fails.",
+                        "settingName": "playback.tryDirect.hevcProfileLevel",
+                        "type": "bool",
+                        "default": "true"
+                    }
+                ]
+            },
+            {
+                "title": "Text Subtitles Only",
+                "description": "Only display text subtitles to minimize transcoding.",
+                "settingName": "playback.subs.onlytext",
+                "type": "bool",
+                "default": "false"
             }
         ]
     },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -66,10 +66,17 @@
             },
             {
                 "title": "Limit Bitrate",
-                "description": "Enable or disable limiting video bitrates based on Roku's specifications.",
+                "description": "Enable or disable limiting video bitrates (based on the 'Playback Bitrate Limit' setting *or* Roku's specifications).",
                 "settingName": "playback.bitrate.maxlimited",
                 "type": "bool",
                 "default": "true"
+            },
+            {
+                "title": "Playback Bitrate Limit",
+                "description": "Max bitrate (MBPS) to use if 'Limit Bitrate' is enabled. If set to 0 limits will be per Roku's specifications.",
+                "settingName": "playback.bitrate.limit",
+                "type": "integer",
+                "default": "0"
             }
         ]
     },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -67,7 +67,7 @@
             {
                 "title": "Bitrate Limiting",
                 "description": "Enable or disable limiting video bitrates based on Roku's specifications.",
-                "settingName": "playback.bitrate.unlimited",
+                "settingName": "playback.bitrate.maxlimited",
                 "type": "bool",
                 "default": "true"
             }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -66,7 +66,7 @@
             },
             {
                 "title": "Bitrate Limiting",
-                "description": "This will ignore Roku's official max bitrate specifications and attempt to stream without enforcing a max bitrate.",
+                "description": "Enable or disable limiting video bitrates based on Roku's specifications.",
                 "settingName": "playback.bitrate.unlimited",
                 "type": "bool",
                 "default": "false"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -252,6 +252,13 @@ function getDeviceProfile() as object
         })
     end if
 
+    print "DEBUG: "
+    for each item in deviceProfile.CodecProfiles
+        print item
+        for each condition in item.Conditions
+            print condition
+        end for
+    end for
     return deviceProfile
 end function
 
@@ -360,44 +367,54 @@ function GetDirectPlayProfiles() as object
 end function
 
 function GetBitRateLimit(codec as string)
-
     if get_user_setting("playback.bitrate.maxlimited") = "true"
-        ' Some repeated values (e.g. same "40mbps" for several codecs)
-        ' but this makes it easy to update in the future if the bitrates start to deviate.
-        if codec = "H264"
-            ' Roku only supports h264 up to 10Mpbs
+        userSetLimit = get_user_setting("playback.bitrate.limit").ToInt()
+        userSetLimit *= 1000000
+
+        if userSetLimit > 0
             return {
                 "Condition": "LessThanEqual",
                 "Property": "VideoBitrate",
-                "Value": "10000000",
+                "Value": userSetLimit.ToStr(),
                 IsRequired: true
             }
-        else if codec = "AV1"
-            ' Roku only supports AV1 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
-        else if codec = "H265"
-            ' Roku only supports h265 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
-        else if codec = "VP9"
-            ' Roku only supports VP9 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
+        else
+            ' Some repeated values (e.g. same "40mbps" for several codecs)
+            ' but this makes it easy to update in the future if the bitrates start to deviate.
+            if codec = "H264"
+                ' Roku only supports h264 up to 10Mpbs
+                return {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "10000000",
+                    IsRequired: true
+                }
+            else if codec = "AV1"
+                ' Roku only supports AV1 up to 40Mpbs
+                return {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
+                }
+            else if codec = "H265"
+                ' Roku only supports h265 up to 40Mpbs
+                return {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
+                }
+            else if codec = "VP9"
+                ' Roku only supports VP9 up to 40Mpbs
+                return {
+                    "Condition": "LessThanEqual",
+                    "Property": "VideoBitrate",
+                    "Value": "40000000",
+                    IsRequired: true
+                }
+            end if
         end if
     end if
-
     return {}
 end function

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -361,45 +361,42 @@ end function
 
 function GetBitRateLimit(codec as string)
 
-    ' If the user has requested to not cap their bitrate (regardless of if that works or not)...
-    if get_user_setting("playback.bitrate.unlimited") = "true"
-        return {}
-    end if
-
-    ' Some repeated values (e.g. same "40mbps" for several codecs)
-    ' but this makes it easy to update in the future if the bitrates start to deviate.
-    if codec = "H264"
-        ' Roku only supports h264 up to 10Mpbs
-        return {
-            "Condition": "LessThanEqual",
-            "Property": "VideoBitrate",
-            "Value": "10000000",
-            IsRequired: true
-        }
-    else if codec = "AV1"
-        ' Roku only supports AV1 up to 40Mpbs
-        return {
-            "Condition": "LessThanEqual",
-            "Property": "VideoBitrate",
-            "Value": "40000000",
-            IsRequired: true
-        }
-    else if codec = "H265"
-        ' Roku only supports h265 up to 40Mpbs
-        return {
-            "Condition": "LessThanEqual",
-            "Property": "VideoBitrate",
-            "Value": "40000000",
-            IsRequired: true
-        }
-    else if codec = "VP9"
-        ' Roku only supports VP9 up to 40Mpbs
-        return {
-            "Condition": "LessThanEqual",
-            "Property": "VideoBitrate",
-            "Value": "40000000",
-            IsRequired: true
-        }
+    if get_user_setting("playback.bitrate.maxlimited") = "true"
+        ' Some repeated values (e.g. same "40mbps" for several codecs)
+        ' but this makes it easy to update in the future if the bitrates start to deviate.
+        if codec = "H264"
+            ' Roku only supports h264 up to 10Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "10000000",
+                IsRequired: true
+            }
+        else if codec = "AV1"
+            ' Roku only supports AV1 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        else if codec = "H265"
+            ' Roku only supports h265 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        else if codec = "VP9"
+            ' Roku only supports VP9 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        end if
     end if
 
     return {}

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -361,44 +361,45 @@ end function
 
 function GetBitRateLimit(codec as string)
 
-    ' Some repeated values (e.g. same "40mbps" for several codecs)
-    ' but this makes it easy to update in the future if the bitrates start to deviate.
+    ' If the user has requested to not cap their bitrate (regardless of if that works or not)...
     if get_user_setting("playback.bitrate.unlimited") = "true"
         return {}
-    else
-        if codec = "H264"
-            ' Roku only supports h264 up to 10Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "10000000",
-                IsRequired: true
-            }
-        else if codec = "AV1"
-            ' Roku only supports AV1 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
-        else if codec = "H265"
-            ' Roku only supports h265 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
-        else if codec = "VP9"
-            ' Roku only supports VP9 up to 40Mpbs
-            return {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitrate",
-                "Value": "40000000",
-                IsRequired: true
-            }
-        end if
+    end if
+
+    ' Some repeated values (e.g. same "40mbps" for several codecs)
+    ' but this makes it easy to update in the future if the bitrates start to deviate.
+    if codec = "H264"
+        ' Roku only supports h264 up to 10Mpbs
+        return {
+            "Condition": "LessThanEqual",
+            "Property": "VideoBitrate",
+            "Value": "10000000",
+            IsRequired: true
+        }
+    else if codec = "AV1"
+        ' Roku only supports AV1 up to 40Mpbs
+        return {
+            "Condition": "LessThanEqual",
+            "Property": "VideoBitrate",
+            "Value": "40000000",
+            IsRequired: true
+        }
+    else if codec = "H265"
+        ' Roku only supports h265 up to 40Mpbs
+        return {
+            "Condition": "LessThanEqual",
+            "Property": "VideoBitrate",
+            "Value": "40000000",
+            IsRequired: true
+        }
+    else if codec = "VP9"
+        ' Roku only supports VP9 up to 40Mpbs
+        return {
+            "Condition": "LessThanEqual",
+            "Property": "VideoBitrate",
+            "Value": "40000000",
+            IsRequired: true
+        }
     end if
 
     return {}

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -171,13 +171,7 @@ function getDeviceProfile() as object
                         "Value": "41",
                         "IsRequired": false
                     },
-                    ' Roku only supports h264 up to 10Mpbs
-                    {
-                        "Condition": "LessThanEqual",
-                        "Property": "VideoBitrate",
-                        "Value": "10000000",
-                        IsRequired: true
-                    }
+                    GetBitRateLimit("H264")
                 ]
             }
         ],
@@ -211,13 +205,7 @@ function getDeviceProfile() as object
                     "Value": av1VideoRangeTypes,
                     "IsRequired": false
                 },
-                ' Roku only supports AVI up to 40Mpbs
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitrate",
-                    "Value": "40000000",
-                    IsRequired: true
-                }
+                GetBitRateLimit("AV1")
             ]
         })
     end if
@@ -244,13 +232,7 @@ function getDeviceProfile() as object
                     "Value": (120 * 5.1).ToStr(),
                     "IsRequired": false
                 },
-                ' Roku only supports h265 up to 40Mpbs
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitrate",
-                    "Value": "40000000",
-                    IsRequired: true
-                }
+                GetBitRateLimit("H265")
             ]
         })
     end if
@@ -265,13 +247,7 @@ function getDeviceProfile() as object
                     "Value": vp9VideoRangeTypes,
                     "IsRequired": false
                 },
-                ' Roku only supports VP9 up to 40Mpbs
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitrate",
-                    "Value": "40000000",
-                    IsRequired: true
-                }
+                GetBitRateLimit("VP9")
             ]
         })
     end if
@@ -381,4 +357,49 @@ function GetDirectPlayProfiles() as object
         }
     ]
 
+end function
+
+function GetBitRateLimit(codec as string)
+
+    ' Some repeated values (e.g. same "40mbps" for several codecs)
+    ' but this makes it easy to update in the future if the bitrates start to deviate.
+    if get_user_setting("playback.bitrate.unlimited") = "true"
+        return {}
+    else
+        if codec = "H264"
+            ' Roku only supports h264 up to 10Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "10000000",
+                IsRequired: true
+            }
+        else if codec = "AV1"
+            ' Roku only supports AV1 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        else if codec = "H265"
+            ' Roku only supports h265 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        else if codec = "VP9"
+            ' Roku only supports VP9 up to 40Mpbs
+            return {
+                "Condition": "LessThanEqual",
+                "Property": "VideoBitrate",
+                "Value": "40000000",
+                IsRequired: true
+            }
+        end if
+    end if
+
+    return {}
 end function

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -252,13 +252,6 @@ function getDeviceProfile() as object
         })
     end if
 
-    print "DEBUG: "
-    for each item in deviceProfile.CodecProfiles
-        print item
-        for each condition in item.Conditions
-            print condition
-        end for
-    end for
     return deviceProfile
 end function
 


### PR DESCRIPTION
Just giving the people what they want.  Some users swear that without capping their bitrate, their devices can direct stream videos that have a higher bitrate than what Roku says is allowed.

**Changes**
~~New setting that will not send the max bitrate to the Jellyfin server.  With the default being OFF.~~
* New setting to enable / disable bitrate limiting.  With the default being ON.
* New setting to enter a max bit rate when limiting is enabled.  If set to 0, the specs in Roku's docs will be used.

**Issues**
Users that don't understand this setting my turn it on and have issues with playback.

**Fixes**
Fixes #1015 