### PR TITLE
introduce layouts, reorganize options modal

### DIFF
--- a/components/Buttons/JFButtons.brs
+++ b/components/Buttons/JFButtons.brs
@@ -105,12 +105,20 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
     if key = "left"
-        if m.selectedFocusedIndex > 0 then m.selectedFocusedIndex = m.selectedFocusedIndex - 1
+        if m.selectedFocusedIndex > 0
+            m.selectedFocusedIndex = m.selectedFocusedIndex - 1
+        else
+            return true
+        end if
         highlightSelected(m.selectedFocusedIndex)
         m.top.focusedIndex = m.selectedFocusedIndex
         return true
     else if key = "right"
-        if m.selectedFocusedIndex < m.buttonCount - 1 then m.selectedFocusedIndex = m.selectedFocusedIndex + 1
+        if m.selectedFocusedIndex < m.buttonCount - 1
+            m.selectedFocusedIndex = m.selectedFocusedIndex + 1
+        else
+            return true
+        end if
         highlightSelected(m.selectedFocusedIndex)
         m.top.focusedIndex = m.selectedFocusedIndex
         return true

--- a/components/ItemGrid/ItemGridOptions.brs
+++ b/components/ItemGrid/ItemGridOptions.brs
@@ -1,11 +1,10 @@
 sub init()
 
     m.buttons = m.top.findNode("buttons")
-    m.buttons.buttons = [tr("View"), tr("Sort"), tr("Filter")]
+    m.buttons.buttons = [tr("View"), tr("Layout"), tr("Sort"), tr("Filter")]
     m.buttons.selectedIndex = 1
     m.buttons.setFocus(true)
 
-    m.favoriteMenu = m.top.findNode("favoriteMenu")
     m.selectedFavoriteItem = m.top.findNode("selectedFavoriteItem")
 
     m.selectedSortIndex = 0
@@ -13,10 +12,12 @@ sub init()
 
     m.menus = []
     m.menus.push(m.top.findNode("viewMenu"))
+    m.menus.push(m.top.findNode("layoutMenu"))
     m.menus.push(m.top.findNode("sortMenu"))
     m.menus.push(m.top.findNode("filterMenu"))
 
     m.viewNames = []
+    m.layoutNames = []
     m.sortNames = []
     m.filterNames = []
 
@@ -26,7 +27,6 @@ sub init()
     m.fadeInAnimOpacity = m.top.findNode("inOpacity")
 
     m.buttons.observeField("focusedIndex", "buttonFocusChanged")
-    m.favoriteMenu.observeField("buttonSelected", "toggleFavorite")
 end sub
 
 
@@ -51,6 +51,25 @@ sub optionsSet()
         m.menus[0].checkedItem = selectedViewIndex
     end if
 
+    '  Layouts Tab
+    if m.top.options.layout <> invalid
+        layoutContent = CreateObject("roSGNode", "ContentNode")
+        index = 0
+        selectedLayoutIndex = m.selectedLayoutIndex
+
+        for each layout in m.top.options.layout
+            entry = layoutContent.CreateChild("ContentNode")
+            entry.title = layout.Title
+            m.layoutNames.push(layout.Name)
+            if (layout.selected <> invalid and layout.selected = true) or layoutContent.Name = m.top.layout
+                selectedLayoutIndex = index
+            end if
+            index = index + 1
+        end for
+        m.menus[1].content = layoutContent
+        m.menus[1].checkedItem = selectedLayoutIndex
+    end if
+
     ' Sort Tab
     if m.top.options.sort <> invalid
         sortContent = CreateObject("roSGNode", "ContentNode")
@@ -71,15 +90,15 @@ sub optionsSet()
             end if
             index = index + 1
         end for
-        m.menus[1].content = sortContent
-        m.menus[1].checkedItem = m.selectedSortIndex
+        m.menus[2].content = sortContent
+        m.menus[2].checkedItem = m.selectedSortIndex
 
         if m.top.sortAscending = 1
-            m.menus[1].focusedCheckedIconUri = m.global.constants.icons.ascending_black
-            m.menus[1].checkedIconUri = m.global.constants.icons.ascending_white
+            m.menus[2].focusedCheckedIconUri = m.global.constants.icons.ascending_black
+            m.menus[2].checkedIconUri = m.global.constants.icons.ascending_white
         else
-            m.menus[1].focusedCheckedIconUri = m.global.constants.icons.descending_black
-            m.menus[1].checkedIconUri = m.global.constants.icons.descending_white
+            m.menus[2].focusedCheckedIconUri = m.global.constants.icons.descending_black
+            m.menus[2].checkedIconUri = m.global.constants.icons.descending_white
         end if
     end if
 
@@ -98,15 +117,15 @@ sub optionsSet()
             end if
             index = index + 1
         end for
-        m.menus[2].content = filterContent
-        m.menus[2].checkedItem = m.selectedFilterIndex
+        m.menus[3].content = filterContent
+        m.menus[3].checkedItem = m.selectedFilterIndex
     else
         filterContent = CreateObject("roSGNode", "ContentNode")
         entry = filterContent.CreateChild("ContentNode")
         entry.title = "All"
         m.filterNames.push("All")
-        m.menus[2].content = filterContent
-        m.menus[2].checkedItem = 0
+        m.menus[3].content = filterContent
+        m.menus[3].checkedItem = 0
     end if
 end sub
 
@@ -117,65 +136,12 @@ sub buttonFocusChanged()
             m.buttons.setFocus(false)
             m.menus[m.selectedItem].setFocus(false)
             m.menus[m.selectedItem].visible = false
-            m.favoriteMenu.setFocus(true)
         end if
     end if
     m.fadeOutAnimOpacity.fieldToInterp = m.menus[m.selectedItem].id + ".opacity"
     m.fadeInAnimOpacity.fieldToInterp = m.menus[m.buttons.focusedIndex].id + ".opacity"
     m.fadeAnim.control = "start"
     m.selectedItem = m.buttons.focusedIndex
-end sub
-
-sub toggleFavorite()
-    m.favItemsTask = createObject("roSGNode", "FavoriteItemsTask")
-    if m.favoriteMenu.iconUri = "pkg:/images/icons/favorite.png"
-        m.favoriteMenu.iconUri = "pkg:/images/icons/favorite_selected.png"
-        m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite_selected.png"
-        ' Run the task to actually favorite it via API
-        m.favItemsTask.favTask = "Favorite"
-        m.favItemsTask.itemId = m.selectedFavoriteItem.id
-        m.favItemsTask.control = "RUN"
-    else
-        m.favoriteMenu.iconUri = "pkg:/images/icons/favorite.png"
-        m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite.png"
-        m.favItemsTask.favTask = "Unfavorite"
-        m.favItemsTask.itemId = m.selectedFavoriteItem.id
-        m.favItemsTask.control = "RUN"
-    end if
-    ' Make sure we set the Favorite Heart color for the appropriate child
-    setHeartColor("#cc3333")
-end sub
-
-sub setHeartColor(color as string)
-    try
-        for i = 0 to 6
-            node = m.favoriteMenu.getChild(i)
-            if node <> invalid and node.uri <> invalid and node.uri = "pkg:/images/icons/favorite_selected.png"
-                m.favoriteMenu.getChild(i).blendColor = color
-            end if
-        end for
-    catch e
-        print e.number, e.message
-    end try
-end sub
-
-sub saveFavoriteItemSelected(msg)
-    data = msg.GetData()
-    m.selectedFavoriteItem = data
-    ' Favorite button
-    if m.selectedFavoriteItem <> invalid
-        if m.selectedFavoriteItem.favorite = true
-            m.favoriteMenu.iconUri = "pkg:/images/icons/favorite_selected.png"
-            m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite_selected.png"
-            ' Make sure we set the Favorite Heart color for the appropriate child
-            setHeartColor("#cc3333")
-        else
-            m.favoriteMenu.iconUri = "pkg:/images/icons/favorite.png"
-            m.favoriteMenu.focusedIconUri = "pkg:/images/icons/favorite.png"
-            ' Make sure we set the Favorite Heart color for the appropriate child
-            setHeartColor("#cc3333")
-        end if
-    end if
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
@@ -193,12 +159,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
 
         return true
-    else if key = "left"
-        if m.favoriteMenu.hasFocus()
-            m.favoriteMenu.setFocus(false)
-            m.menus[m.selectedItem].visible = true
-            m.buttons.setFocus(true)
-        end if
     else if key = "OK"
         if m.menus[m.selectedItem].isInFocusChain()
             ' Handle View Screen
@@ -206,45 +166,49 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.selectedViewIndex = m.menus[0].itemSelected
                 m.top.view = m.viewNames[m.selectedViewIndex]
             end if
-
-            ' Handle Sort screen
+            ' Handle Layout Screen
             if m.selectedItem = 1
-                if m.menus[1].itemSelected <> m.selectedSortIndex
-                    m.menus[1].focusedCheckedIconUri = m.global.constants.icons.ascending_black
-                    m.menus[1].checkedIconUri = m.global.constants.icons.ascending_white
+                m.selectedLayoutIndex = m.menus[1].itemSelected
+                m.top.layout = m.layoutNames[m.selectedLayoutIndex]
+            end if
+            ' Handle Sort screen
+            if m.selectedItem = 2
+                if m.menus[2].itemSelected <> m.selectedSortIndex
+                    m.menus[2].focusedCheckedIconUri = m.global.constants.icons.ascending_black
+                    m.menus[2].checkedIconUri = m.global.constants.icons.ascending_white
 
-                    m.selectedSortIndex = m.menus[1].itemSelected
+                    m.selectedSortIndex = m.menus[2].itemSelected
                     m.top.sortAscending = true
                     m.top.sortField = m.sortNames[m.selectedSortIndex]
                 else
 
                     if m.top.sortAscending = true
                         m.top.sortAscending = false
-                        m.menus[1].focusedCheckedIconUri = m.global.constants.icons.descending_black
-                        m.menus[1].checkedIconUri = m.global.constants.icons.descending_white
+                        m.menus[2].focusedCheckedIconUri = m.global.constants.icons.descending_black
+                        m.menus[2].checkedIconUri = m.global.constants.icons.descending_white
                     else
                         m.top.sortAscending = true
-                        m.menus[1].focusedCheckedIconUri = m.global.constants.icons.ascending_black
-                        m.menus[1].checkedIconUri = m.global.constants.icons.ascending_white
+                        m.menus[2].focusedCheckedIconUri = m.global.constants.icons.ascending_black
+                        m.menus[2].checkedIconUri = m.global.constants.icons.ascending_white
                     end if
                 end if
             end if
             ' Handle Filter screen
-            if m.selectedItem = 2
-                m.selectedFilterIndex = m.menus[2].itemSelected
+            if m.selectedItem = 3
+                m.selectedFilterIndex = m.menus[3].itemSelected
                 m.top.filter = m.filterNames[m.selectedFilterIndex]
             end if
         end if
         return true
     else if key = "back" or key = "up"
-        m.menus[2].visible = true ' Show Filter contents in case hidden by favorite button
+        m.menus[2].visible = true
         if m.menus[m.selectedItem].isInFocusChain()
             m.buttons.setFocus(true)
             m.menus[m.selectedItem].drawFocusFeedback = false
             return true
         end if
     else if key = "options"
-        m.menus[2].visible = true ' Show Filter contents in case hidden by favorite button
+        m.menus[2].visible = true
         m.menus[m.selectedItem].drawFocusFeedback = false
         return false
     end if

--- a/components/ItemGrid/ItemGridOptions.xml
+++ b/components/ItemGrid/ItemGridOptions.xml
@@ -35,7 +35,7 @@
     <field id="sortField" type="string" value="SortName" />
     <field id="sortAscending" type="boolean" value="false" />
     <field id="filter" type="string" value="All" />
-    <field id="favorite" type="string" value="pooptest" />
+    <field id="favorite" type="string" value="Favorite" />
 
   </interface>
   <script type="text/brightscript" uri="ItemGridOptions.brs" />

--- a/components/ItemGrid/ItemGridOptions.xml
+++ b/components/ItemGrid/ItemGridOptions.xml
@@ -9,15 +9,14 @@
         <Group>
           <RadiobuttonList id="viewMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
           </RadiobuttonList>
-          <RadiobuttonList id="sortMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="1" numRows="8" drawFocusFeedback="false">
+          <RadiobuttonList id="layoutMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="1" drawFocusFeedback="false">
+          </RadiobuttonList>
+          <RadiobuttonList id="sortMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" numRows="8" drawFocusFeedback="false">
           </RadiobuttonList>
           <RadiobuttonList id="filterMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
           </RadiobuttonList>
         </Group>
       </LayoutGroup>
-      <ButtonGroup translation="[1250,50]">
-        <Button id="favoriteMenu" iconUri="pkg:/images/icons/favorite.png" focusedIconUri="pkg:/images/icons/favorite.png" focusBitmapUri="" focusFootprintBitmapUri="" text="Favorite" showFocusFootprint="false"></Button>
-      </ButtonGroup>
     </Group>
 
     <Animation id="fadeAnim" duration="0.5" repeat="false">
@@ -31,11 +30,12 @@
     <field id="options" type="assocarray" onChange="optionsSet" />
     <field id="selectedFavoriteItem" type="node" onChange="saveFavoriteItemSelected" />
 
-    <field id="view" type="string" />
+    <field id="view" type="string" value="Titles"/>
+    <field id="layout" type="string" />
     <field id="sortField" type="string" value="SortName" />
     <field id="sortAscending" type="boolean" value="false" />
     <field id="filter" type="string" value="All" />
-    <field id="favorite" type="string" value="Favorite" />
+    <field id="favorite" type="string" value="pooptest" />
 
   </interface>
   <script type="text/brightscript" uri="ItemGridOptions.brs" />

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -87,6 +87,22 @@ sub loadItems()
         params.append({ IncludeItemTypes: m.top.ItemType })
     end if
 
+
+    if m.top.view = "Favorites"
+        filtered = false
+        for each param in params:
+            if param = "filters"
+                filtered = true
+            end if
+        end for
+        if filtered
+            params["filters"] = params["filters"] + ",IsFavorite"
+        else
+            params.append({ Filters: "IsFavorite" })
+        end if
+        params.append({ isFavorite: true })
+    end if
+
     if m.top.ItemType = "LiveTV"
         url = "LiveTv/Channels"
         params.append({ UserId: get_setting("active_user") })

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -131,14 +131,10 @@ sub loadInitialItems()
 
     sortAscendingStr = get_user_setting("display." + m.top.parentItem.Id + ".sortAscending")
 
-    ' If user has not set a preferred view for this folder, check if they've set a default view
-    if not isValid(m.view)
-        m.view = get_user_setting("itemgrid.movieDefaultView")
-    end if
-
+    if not isValid(m.view) then m.view = "Movies"
     if not isValid(m.sortField) then m.sortField = "SortName"
     if not isValid(m.filter) then m.filter = "All"
-    if not isValid(m.layout) then m.layout = "Movies"
+    if not isValid(m.layout) then m.layout = "grid"
 
     if sortAscendingStr = invalid or sortAscendingStr = "true"
         m.sortAscending = true
@@ -154,9 +150,6 @@ sub loadInitialItems()
         m.loadItemsTask.genreIds = m.top.parentItem.id
         m.loadItemsTask.itemId = m.top.parentItem.parentFolder
         m.loadItemsTask.studioIds = ""
-    else if m.layout = "Movies" or m.options.layout = "Movies"
-        m.loadItemsTask.studioIds = ""
-        m.loadItemsTask.genreIds = ""
     else
         m.loadItemsTask.itemId = m.top.parentItem.Id
     end if
@@ -193,7 +186,7 @@ sub loadInitialItems()
         m.top.imageDisplayMode = "scaleToFit"
         m.selectedMovieOverview.visible = false
         m.infoGroup.visible = false
-    else if LCase(m.options.layout) = "moviesgrid" or LCase(m.layout) = "moviesgrid"
+    else if LCase(m.options.layout) = "grid" or LCase(m.layout) = "grid"
         m.itemGrid.translation = "[96, 60]"
         m.itemGrid.numRows = "3"
         m.selectedMovieOverview.visible = false
@@ -236,8 +229,8 @@ sub setMoviesOptions(options)
     ]
 
     options.layout = [
-        { "Title": tr("Grid"), "Name": "MoviesGrid" },
-        { "Title": tr("Presentation"), "Name": "Movies" }
+        { "Title": tr("Grid"), "Name": "grid" },
+        { "Title": tr("Presentation"), "Name": "presentation" }
     ]
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName" },
@@ -496,7 +489,7 @@ sub onItemFocused()
 
     if LCase(m.options.view) = "studios" or LCase(m.view) = "studios"
         return
-    else if LCase(m.options.layout) = "moviesgrid" or LCase(m.layout) = "moviesgrid"
+    else if m.options.layout = "grid" or m.layout = "grid"
         return
     end if
 

--- a/components/data/MovieData.brs
+++ b/components/data/MovieData.brs
@@ -35,23 +35,23 @@ sub setFields()
 end sub
 
 sub setPoster()
-    if m.top.image <> invalid
+    if isValid(m.top.image)
         m.top.posterURL = m.top.image.url
     else
 
-        if m.top.json.ImageTags.Primary <> invalid
+        if isValid(m.top.json.ImageTags.Primary)
             imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
-        else if m.top.json.BackdropImageTags[0] <> invalid
+        else if isValid(m.top.json.BackdropImageTags)
             imgParams = { "maxHeight": 440 }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
-        else if m.top.json.ParentThumbImageTag <> invalid and m.top.json.ParentThumbItemId <> invalid
+        else if isValid(m.top.json.ParentThumbImageTag) and isValid(m.top.json.ParentThumbItemId)
             imgParams = { "maxHeight": 440, "maxWidth": 295 }
             m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
         end if
 
         ' Add Backdrop Image
-        if m.top.json.BackdropImageTags <> invalid
+        if isValid(m.top.json.BackdropImageTags)
             if m.top.json.BackdropImageTags[0] <> invalid
                 imgParams = { "maxHeight": 720, "maxWidth": 1280 }
                 m.top.backdropURL = ImageURL(m.top.json.id, "Backdrop", imgParams)

--- a/components/data/MovieData.brs
+++ b/components/data/MovieData.brs
@@ -40,8 +40,8 @@ sub setPoster()
     else
 
         if isValid(m.top.json.ImageTags.Primary)
-            imgParams = { "maxHeight": 440, "maxWidth": 295 }
             imgParams = { "maxHeight": 440, "maxWidth": 295, "Tag": m.top.json.ImageTags.Primary }
+            m.top.posterURL = ImageURL(m.top.json.id, "Primary", imgParams)
         else if isValid(m.top.json.BackdropImageTags)
             imgParams = { "maxHeight": 440, "Tag": m.top.json.BackdropImageTags[0] }
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -197,29 +197,6 @@
                         ]
                     },
                     {
-                        "title": "Movies",
-                        "description": "Settings relating to the appearance of pages in Movie Libraries.",
-                        "children": [
-                            {
-                                "title": "Default View",
-                                "description": "Default view for Movie Libraries.",
-                                "settingName": "itemgrid.movieDefaultView",
-                                "type": "radio",
-                                "default": "movies",
-                                "options": [
-                                    {
-                                        "title": "Movies (Presentation)",
-                                        "id": "Movies"
-                                    },
-                                    {
-                                        "title": "Movies (Grid)",
-                                        "id": "MoviesGrid"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
                         "title": "TV Shows",
                         "description": "Settings relating to the appearance of pages in TV Libraries.",
                         "children": [

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -130,19 +130,6 @@
                         "default": "false"
                     },
                     {
-                        "title": "Disable Community Rating for Episodes",
-                        "description": "If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.",
-                        "settingName": "ui.tvshows.disableCommunityRating",
-                        "type": "bool",
-                        "default": "false"
-                    }
-                ]
-            },
-            {
-                "title": "Screensaver",
-                "description": "Options for Jellyfin's screensaver.",
-                "children": [
-                    {
                         "title": "Use Splashscreen as Screensaver",
                         "description": "Use generated splashscreen image as Jellyfin's screensaver background. Jellyfin will need to be closed and reopened for change to take effect.",
                         "settingName": "ui.screensaver.splashBackground",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -129,11 +129,11 @@
                         "default": "false"
                     },
                     {
-                        "title":"Disable Community Rating for Episodes",
+                        "title": "Disable Community Rating for Episodes",
                         "description": "If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.",
                         "settingName": "ui.tvshows.disableCommunityRating",
-                        "type":"bool",
-                        "default":"false"
+                        "type": "bool",
+                        "default": "false"
                     }
                 ]
             },
@@ -167,23 +167,6 @@
                 "title": "Media Grid",
                 "description": "Media Grid options.",
                 "children": [
-                    {
-                        "title": "Movie Library Default View",
-                        "description": "Default view for Movie Libraries.",
-                        "settingName": "itemgrid.movieDefaultView",
-                        "type": "radio",
-                        "default": "movies",
-                        "options": [
-                            {
-                                "title": "Movies (Presentation)",
-                                "id": "Movies"
-                            },
-                            {
-                                "title": "Movies (Grid)",
-                                "id": "MoviesGrid"
-                            }
-                        ]
-                    },
                     {
                         "title": "Movie Library Grid Titles",
                         "description": "Select when to show titles.",


### PR DESCRIPTION
**Changes**
reorganize options modal per conversation from chat.

Here's the basic idea:
The new "views" are going to be known as "Layouts" and will be under their own heading in the options modal.
The layouts currently are "Grid" and "Presentation"
The "Views" menu will now be analogous to the tabs in jf-web, and will include things like "Movies, Suggestions, Trailers, Favorites, Collections, Genres, Studios," etc.
To this end "Favorites" will move from filter to "views"

There are two primary purposes to this change: handle the the new layouts in a practical way, and bring us in line with the information design principles of the web app.  Without this change, implementing new views and new layouts is cumbersome.

To Do
- [x] Apply new layout logic to music libraries
- [x] ~~Replace "default movie view" logic with layout~~ - implicitly completed in #983 
- [x] ~~Resolve musicgenre/presentation problem~~ -music genres essentially have not worked in jellyfin for a long time. https://github.com/jellyfin/jellyfin/issues/6036
 #964 will fix the issue of all griditems having labels all the time.
