### PR TITLE
Fix default view setting for movie genres

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -136,7 +136,7 @@ sub Main (args as dynamic) as void
                 sceneManager.callFunc("pushScene", group)
             else if selectedItem.type = "Folder" and selectedItem.json.type = "Genre"
                 ' User clicked on a genre folder
-                if selectedItem.collectionType = "movies"
+                if selectedItem.json.MovieCount > 0
                     group = CreateMovieLibraryView(selectedItem)
                 else
                     group = CreateItemGrid(selectedItem)


### PR DESCRIPTION
When a user clicks on View All for a movie genre, the default view setting is honored instead of using the grid layout.