### PR TITLE
Graceful episode playback failure

### DIFF
--- a/components/FailureDialog.xml
+++ b/components/FailureDialog.xml
@@ -2,10 +2,6 @@
 <!-- A Failure Dialog is a regular dialog, except it takes key releases -->
 <!-- instead of presses so we don't unintentionally trigger playback -->
 <component name="FailureDialog" extends="Dialog">
-  <interface>
-      <field id="Title" type="string" onchange="setTitle" />
-      <field id="Overview" type="string" onChange="setOverview" />
-  </interface>
   <script type="text/brightscript">
   <![CDATA[
   function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/FailureDialog.xml
+++ b/components/FailureDialog.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- A Failure Dialog is a regular dialog, except it takes key releases -->
+<!-- instead of presses so we don't unintentionally trigger playback -->
+<component name="FailureDialog" extends="Dialog">
+  <interface>
+      <field id="Title" type="string" onchange="setTitle" />
+      <field id="Overview" type="string" onChange="setOverview" />
+  </interface>
+  <script type="text/brightscript">
+  <![CDATA[
+  function onKeyEvent(key as string, press as boolean) as boolean
+      if press = true then return false
+
+      if key = "OK"
+          m.top.close = true
+      end if
+
+      return true
+  end function
+  ]]>
+  </script>
+</component>

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -114,9 +114,7 @@ sub onState(msg)
             ' If an error was encountered, Display dialog
             dialog = createObject("roSGNode", "Dialog")
             dialog.title = tr("Error During Playback")
-            dialog.buttons = [tr("OK")]
             dialog.message = tr("An error was encountered while playing this item.")
-            dialog.observeField("buttonSelected", "dialogClosed")
             m.top.getScene().dialog = dialog
         end if
 
@@ -199,9 +197,7 @@ sub bufferCheck(msg)
             ' If buffering has stopped Display dialog
             dialog = createObject("roSGNode", "Dialog")
             dialog.title = tr("Error Retrieving Content")
-            dialog.buttons = [tr("OK")]
             dialog.message = tr("There was an error retrieving the data for this item from the server.")
-            dialog.observeField("buttonSelected", "dialogClosed")
             m.top.getScene().dialog = dialog
 
             ' Stop playback and exit player
@@ -210,14 +206,6 @@ sub bufferCheck(msg)
         end if
     end if
 
-end sub
-
-'
-' Clean up on Dialog Closed
-sub dialogClosed(msg)
-    sourceNode = msg.getRoSGNode()
-    sourceNode.unobserveField("buttonSelected")
-    sourceNode.close = true
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -112,7 +112,7 @@ sub onState(msg)
             m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
         else
             ' If an error was encountered, Display dialog
-            dialog = createObject("roSGNode", "FailureDialog")
+            dialog = createObject("roSGNode", "PlaybackDialog")
             dialog.title = tr("Error During Playback")
             dialog.buttons = [tr("OK")]
             dialog.message = tr("An error was encountered while playing this item.")
@@ -196,7 +196,7 @@ sub bufferCheck(msg)
             m.top.callFunc("refresh")
         else
             ' If buffering has stopped Display dialog
-            dialog = createObject("roSGNode", "FailureDialog")
+            dialog = createObject("roSGNode", "PlaybackDialog")
             dialog.title = tr("Error Retrieving Content")
             dialog.buttons = [tr("OK")]
             dialog.message = tr("There was an error retrieving the data for this item from the server.")

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -112,8 +112,9 @@ sub onState(msg)
             m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
         else
             ' If an error was encountered, Display dialog
-            dialog = createObject("roSGNode", "Dialog")
+            dialog = createObject("roSGNode", "FailureDialog")
             dialog.title = tr("Error During Playback")
+            dialog.buttons = [tr("OK")]
             dialog.message = tr("An error was encountered while playing this item.")
             m.top.getScene().dialog = dialog
         end if
@@ -195,8 +196,9 @@ sub bufferCheck(msg)
             m.top.callFunc("refresh")
         else
             ' If buffering has stopped Display dialog
-            dialog = createObject("roSGNode", "Dialog")
+            dialog = createObject("roSGNode", "FailureDialog")
             dialog.title = tr("Error Retrieving Content")
+            dialog.buttons = [tr("OK")]
             dialog.message = tr("There was an error retrieving the data for this item from the server.")
             m.top.getScene().dialog = dialog
 

--- a/components/PlaybackDialog.brs
+++ b/components/PlaybackDialog.brs
@@ -1,0 +1,8 @@
+function onKeyEvent(key as string, press as boolean) as boolean
+
+    if key = "OK"
+        m.top.close = true
+    end if
+
+    return true
+end function

--- a/components/PlaybackDialog.brs
+++ b/components/PlaybackDialog.brs
@@ -2,7 +2,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if key = "OK"
         m.top.close = true
+        return true
     end if
 
-    return true
+    return false
 end function

--- a/components/PlaybackDialog.xml
+++ b/components/PlaybackDialog.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- A Failure Dialog is a regular dialog, except it takes key releases -->
-<!-- instead of presses so we don't unintentionally trigger playback -->
-<component name="FailureDialog" extends="Dialog">
+<!-- A PlaybackDialog is a regular dialog, except it takes key releases -->
+<!-- instead of presses so that key releases don't fall into other listeners -->
+<component name="PlaybackDialog" extends="Dialog">
   <script type="text/brightscript">
   <![CDATA[
   function onKeyEvent(key as string, press as boolean) as boolean
-      if press = true then return false
 
       if key = "OK"
           m.top.close = true

--- a/components/PlaybackDialog.xml
+++ b/components/PlaybackDialog.xml
@@ -2,16 +2,5 @@
 <!-- A PlaybackDialog is a regular dialog, except it takes key releases -->
 <!-- instead of presses so that key releases don't fall into other listeners -->
 <component name="PlaybackDialog" extends="Dialog">
-  <script type="text/brightscript">
-  <![CDATA[
-  function onKeyEvent(key as string, press as boolean) as boolean
-
-      if key = "OK"
-          m.top.close = true
-      end if
-
-      return true
-  end function
-  ]]>
-  </script>
+  <script type="text/brightscript" uri="PlaybackDialog.brs" />
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -505,7 +505,11 @@ sub Main (args as dynamic) as void
                 else if node.showID = invalid
                     sceneManager.callFunc("popScene")
                 else
-                    autoPlayNextEpisode(node.id, node.showID)
+                    if video.errorMsg = ""
+                        autoPlayNextEpisode(node.id, node.showID)
+                    else
+                        sceneManager.callFunc("popScene")
+                    end if
                 end if
             end if
         else if type(msg) = "roDeviceInfoEvent"

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -442,7 +442,6 @@ function getAudioInfo(meta as object) as object
 end function
 
 sub autoPlayNextEpisode(videoID as string, showID as string)
-    print "THIS CODE IS RUNNING NOW"
     ' use web client setting
     if m.user.Configuration.EnableNextEpisodeAutoPlay
         ' query API for next episode ID

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -46,7 +46,11 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
-        video.runTime = (meta.json.RunTimeTicks / 10000000.0)
+        if isValid(meta.json.RunTimeTicks)
+            video.runTime = (meta.json.RunTimeTicks / 10000000.0)
+        else
+            video.runTime = invalid
+        end if
         video.content.contenttype = "episode"
     end if
 
@@ -438,6 +442,7 @@ function getAudioInfo(meta as object) as object
 end function
 
 sub autoPlayNextEpisode(videoID as string, showID as string)
+    print "THIS CODE IS RUNNING NOW"
     ' use web client setting
     if m.user.Configuration.EnableNextEpisodeAutoPlay
         ' query API for next episode ID

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -48,8 +48,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     if m.videotype = "Episode" or m.videotype = "Series"
         if isValid(meta.json.RunTimeTicks)
             video.runTime = (meta.json.RunTimeTicks / 10000000.0)
-        else
-            video.runTime = invalid
         end if
         video.content.contenttype = "episode"
     end if


### PR DESCRIPTION
#575 changed TVEpisodes.brs such that it attempts playback of failed media repeatedly because it hears the "OK" press that is used to close the error dialog and initiates playback logic.  This causes the failed media to play over and over until "back" is pressed instead of "ok"
~~this pr removes the buttons from playback failure dialogs, forcing the user to press "back" instead.  I don't love removing the ok button, but i don't see a better way.~~
solved this issue by extending Dialog, and overloading the keypress listener to eat releases instead of presses. now works as expected with no compromises.

other changes: handle invalid runtimeticks and don't autoplay next episode if the last episode failed.
**Issues**
fixes #989 