### PR TITLE
options button closes user settings menu

### DIFF
--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -1,5 +1,4 @@
 sub init()
-    print "MAKING THE USER SETTINGS I THINK"
 
     m.top.overhangTitle = tr("Settings")
     m.top.optionsAvailable = false

--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -1,4 +1,5 @@
 sub init()
+    print "MAKING THE USER SETTINGS I THINK"
 
     m.top.overhangTitle = tr("Settings")
     m.top.optionsAvailable = false
@@ -185,6 +186,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if (key = "back" or key = "left") and m.radioSetting.hasFocus()
         m.settingsMenu.setFocus(true)
         return true
+    end if
+
+    if key = "options"
+        m.global.sceneManager.callFunc("popScene")
     end if
 
     if key = "right"

--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -189,6 +189,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if key = "options"
         m.global.sceneManager.callFunc("popScene")
+        return true
     end if
 
     if key = "right"


### PR DESCRIPTION
close the user settings menu when "options" is pressed

**Issues**
fixes #985 
