### PR TITLE
make title scrolling consistent in extras slider

### DIFF
--- a/components/extras/ExtrasItem.brs
+++ b/components/extras/ExtrasItem.brs
@@ -24,8 +24,10 @@ end sub
 sub focusChanged()
     if m.top.itemHasFocus = true
         m.name.repeatCount = -1
+        m.role.repeatCount = -1
     else
         m.name.repeatCount = 0
+        m.role.repeatCount = 0
     end if
 
     if m.deviceInfo.IsAudioGuideEnabled() = true

--- a/components/extras/ExtrasItem.brs
+++ b/components/extras/ExtrasItem.brs
@@ -11,7 +11,7 @@ sub showContent()
         cont = m.top.itemContent
         m.name.text = cont.labelText
         m.name.maxWidth = cont.imageWidth
-        m.role.Width = cont.imageWidth
+        m.role.maxWidth = cont.imageWidth
         m.posterImg.uri = cont.posterUrl
         m.posterImg.width = cont.imageWidth
         m.role.Text = cont.subTitle

--- a/components/extras/ExtrasItem.brs
+++ b/components/extras/ExtrasItem.brs
@@ -22,6 +22,12 @@ sub showContent()
 end sub
 
 sub focusChanged()
+    if m.top.itemHasFocus = true
+        m.name.repeatCount = -1
+    else
+        m.name.repeatCount = 0
+    end if
+
     if m.deviceInfo.IsAudioGuideEnabled() = true
         txt2Speech = CreateObject("roTextToSpeech")
         txt2Speech.Flush()

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -12,7 +12,10 @@
         horizAlign="center" vertAlign="bottom"
         maxWidth="266" height="48"
         font="font:SmallestBoldSystemFont" repeatCount="0"/>
-      <Label id="SubTitle" horizAlign="center" vertAlign="center" font="font:SmallestBoldSystemFont" height="32" color="#A7A7A7FF"  />
+      <ScrollingLabel id="SubTitle"
+        horizAlign="center" vertAlign="center"
+        maxWidth="234" height="32"
+        font="font:SmallestBoldSystemFont" color="#A7A7A7FF" repeatCount = "0" />
     </LayoutGroup> 
   </children>
 </component>

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -8,8 +8,11 @@
   <children>
     <LayoutGroup layoutDirection="vert" >
       <Poster id="posterImg" width="234" height="300" translation="[8,243]" failedBitmapUri="pkg:/images/baseline_person_white_48dp.png" />
-      <ScrollingLabel id="pLabel" horizAlign="center" vertAlign="bottom" maxWidth="266" font="font:SmallestBoldSystemFont" height="48"  />
+      <ScrollingLabel id="pLabel"
+        horizAlign="center" vertAlign="bottom"
+        maxWidth="266" height="48"
+        font="font:SmallestBoldSystemFont" repeatCount="0"/>
       <Label id="SubTitle" horizAlign="center" vertAlign="center" font="font:SmallestBoldSystemFont" height="32" color="#A7A7A7FF"  />
-    </LayoutGroup>
+    </LayoutGroup> 
   </children>
 </component>

--- a/components/extras/ExtrasItem.xml
+++ b/components/extras/ExtrasItem.xml
@@ -10,11 +10,11 @@
       <Poster id="posterImg" width="234" height="300" translation="[8,243]" failedBitmapUri="pkg:/images/baseline_person_white_48dp.png" />
       <ScrollingLabel id="pLabel"
         horizAlign="center" vertAlign="bottom"
-        maxWidth="266" height="48"
+        height="48"
         font="font:SmallestBoldSystemFont" repeatCount="0"/>
       <ScrollingLabel id="SubTitle"
         horizAlign="center" vertAlign="center"
-        maxWidth="234" height="32"
+        height="32"
         font="font:SmallestBoldSystemFont" color="#A7A7A7FF" repeatCount = "0" />
     </LayoutGroup> 
   </children>


### PR DESCRIPTION
only scroll name labels in the extras slider if they have focus.  this is more consistent and more visually appropriate.

**Changes**
only scroll pLabel in ExtrasItem if it has focus.
