### PR TITLE
selecting items during playback

### DIFF
--- a/components/data/ExtrasData.xml
+++ b/components/data/ExtrasData.xml
@@ -22,5 +22,6 @@
     <field id="posterUrl" type="string" />
     <field id="imageWidth" type="integer" value="234" />
     <field id="json" type="assocarray" />
+    <field id="showDuringPlayback" type="boolean" value="false" />
   </interface>
 </component>

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -79,6 +79,7 @@ sub onPeopleLoaded()
                 person.subTitle = person.json.Type
             end if
             person.Type = "Person"
+            person.showDuringPlayback = true
             row.appendChild(person)
         end for
     end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -120,99 +120,104 @@ sub Main (args as dynamic) as void
                 reportingNode.quickPlayNode.type = ""
             end if
         else if isNodeEvent(msg, "selectedItem")
-            ' If you select a library from ANYWHERE, follow this flow
             selectedItem = msg.getData()
+            playing = m.global.playstatetask.status <> "" and m.global.playstatetask.status <> "stop"
+            showDuringPlayback = isValid(selectedItem.showDuringPlayback) and selectedItem.showDuringPlayback
+            if not playing or showDuringPlayback
 
-            m.selectedItemType = selectedItem.type
+                m.selectedItemType = selectedItem.type
 
-            if selectedItem.type = "CollectionFolder"
-                if selectedItem.collectionType = "movies"
-                    group = CreateMovieLibraryView(selectedItem)
-                else if selectedItem.collectionType = "music"
+                if selectedItem.type = "CollectionFolder"
+                    if selectedItem.collectionType = "movies"
+                        group = CreateMovieLibraryView(selectedItem)
+                    else if selectedItem.collectionType = "music"
+                        group = CreateMusicLibraryView(selectedItem)
+                    else
+                        group = CreateItemGrid(selectedItem)
+                    end if
+                    sceneManager.callFunc("pushScene", group)
+                else if selectedItem.type = "Folder" and selectedItem.json.type = "Genre"
+                    ' User clicked on a genre folder
+                    if selectedItem.collectionType = "movies"
+                        group = CreateMovieLibraryView(selectedItem)
+                    else
+                        group = CreateItemGrid(selectedItem)
+                    end if
+                    sceneManager.callFunc("pushScene", group)
+                else if selectedItem.type = "Folder" and selectedItem.json.type = "MusicGenre"
                     group = CreateMusicLibraryView(selectedItem)
-                else
+                    sceneManager.callFunc("pushScene", group)
+                else if selectedItem.type = "UserView" or selectedItem.type = "Folder" or selectedItem.type = "Channel" or selectedItem.type = "Boxset"
                     group = CreateItemGrid(selectedItem)
-                end if
-                sceneManager.callFunc("pushScene", group)
-            else if selectedItem.type = "Folder" and selectedItem.json.type = "Genre"
-                ' User clicked on a genre folder
-                if selectedItem.collectionType = "movies"
-                    group = CreateMovieLibraryView(selectedItem)
-                else
-                    group = CreateItemGrid(selectedItem)
-                end if
-                sceneManager.callFunc("pushScene", group)
-            else if selectedItem.type = "Folder" and selectedItem.json.type = "MusicGenre"
-                group = CreateMusicLibraryView(selectedItem)
-                sceneManager.callFunc("pushScene", group)
-            else if selectedItem.type = "UserView" or selectedItem.type = "Folder" or selectedItem.type = "Channel" or selectedItem.type = "Boxset"
-                group = CreateItemGrid(selectedItem)
-                sceneManager.callFunc("pushScene", group)
-            else if selectedItem.type = "Episode"
-                ' play episode
-                ' todo: create an episode page to link here
-                video_id = selectedItem.id
-                if selectedItem.selectedAudioStreamIndex <> invalid and selectedItem.selectedAudioStreamIndex > 1
-                    video = CreateVideoPlayerGroup(video_id, invalid, selectedItem.selectedAudioStreamIndex)
-                else
-                    video = CreateVideoPlayerGroup(video_id)
-                end if
-                if video <> invalid and video.errorMsg <> "introaborted"
-                    sceneManager.callFunc("pushScene", video)
-                end if
-            else if selectedItem.type = "Series"
-                group = CreateSeriesDetailsGroup(selectedItem.json)
-            else if selectedItem.type = "Season"
-                group = CreateSeasonDetailsGroupByID(selectedItem.json.SeriesId, selectedItem.id)
-            else if selectedItem.type = "Movie"
-                ' open movie detail page
-                group = CreateMovieDetailsGroup(selectedItem)
-            else if selectedItem.type = "Person"
-                CreatePersonView(selectedItem)
-            else if selectedItem.type = "TvChannel" or selectedItem.type = "Video" or selectedItem.type = "Program"
-                ' play channel feed
-                video_id = selectedItem.id
+                    sceneManager.callFunc("pushScene", group)
+                else if selectedItem.type = "Episode"
+                    ' play episode
+                    ' todo: create an episode page to link here
+                    video_id = selectedItem.id
+                    if selectedItem.selectedAudioStreamIndex <> invalid and selectedItem.selectedAudioStreamIndex > 1
+                        video = CreateVideoPlayerGroup(video_id, invalid, selectedItem.selectedAudioStreamIndex)
+                    else
+                        video = CreateVideoPlayerGroup(video_id)
+                    end if
+                    if video <> invalid and video.errorMsg <> "introaborted"
+                        sceneManager.callFunc("pushScene", video)
+                    end if
+                else if selectedItem.type = "Series"
+                    group = CreateSeriesDetailsGroup(selectedItem.json)
+                else if selectedItem.type = "Season"
+                    group = CreateSeasonDetailsGroupByID(selectedItem.json.SeriesId, selectedItem.id)
+                else if selectedItem.type = "Movie"
+                    ' open movie detail page
+                    group = CreateMovieDetailsGroup(selectedItem)
+                else if selectedItem.type = "Person"
+                    CreatePersonView(selectedItem)
+                else if selectedItem.type = "TvChannel" or selectedItem.type = "Video" or selectedItem.type = "Program"
+                    ' play channel feed
+                    video_id = selectedItem.id
 
-                ' Show Channel Loading spinner
-                dialog = createObject("roSGNode", "ProgressDialog")
-                dialog.title = tr("Loading Channel Data")
-                m.scene.dialog = dialog
-
-                if LCase(selectedItem.subtype()) = "extrasdata"
-                    video = CreateVideoPlayerGroup(video_id, invalid, 1, false, true, false)
-                else
-                    video = CreateVideoPlayerGroup(video_id)
-                end if
-
-                dialog.close = true
-
-                if video <> invalid and video.errorMsg <> "introaborted"
-                    sceneManager.callFunc("pushScene", video)
-                else
-                    dialog = createObject("roSGNode", "Dialog")
-                    dialog.id = "OKDialog"
-                    dialog.title = tr("Error loading Channel Data")
-                    dialog.message = tr("Unable to load Channel Data from the server")
-                    dialog.buttons = [tr("OK")]
+                    ' Show Channel Loading spinner
+                    dialog = createObject("roSGNode", "ProgressDialog")
+                    dialog.title = tr("Loading Channel Data")
                     m.scene.dialog = dialog
-                    m.scene.dialog.observeField("buttonSelected", m.port)
+
+                    if LCase(selectedItem.subtype()) = "extrasdata"
+                        video = CreateVideoPlayerGroup(video_id, invalid, 1, false, true, false)
+                    else
+                        video = CreateVideoPlayerGroup(video_id)
+                    end if
+
+                    dialog.close = true
+
+                    if video <> invalid and video.errorMsg <> "introaborted"
+                        sceneManager.callFunc("pushScene", video)
+                    else
+                        dialog = createObject("roSGNode", "Dialog")
+                        dialog.id = "OKDialog"
+                        dialog.title = tr("Error loading Channel Data")
+                        dialog.message = tr("Unable to load Channel Data from the server")
+                        dialog.buttons = [tr("OK")]
+                        m.scene.dialog = dialog
+                        m.scene.dialog.observeField("buttonSelected", m.port)
+                    end if
+                else if selectedItem.type = "Photo"
+                    ' Nothing to do here, handled in ItemGrid
+                else if selectedItem.type = "MusicArtist"
+                    group = CreateArtistView(selectedItem.json)
+                    if not isValid(group)
+                        message_dialog(tr("Unable to find any albums or songs belonging to this artist"))
+                    end if
+                else if selectedItem.type = "MusicAlbum"
+                    group = CreateAlbumView(selectedItem.json)
+                else if selectedItem.type = "Audio"
+                    m.global.queueManager.callFunc("clear")
+                    m.global.queueManager.callFunc("push", selectedItem.json)
+                    m.global.queueManager.callFunc("playQueue")
+                else
+                    ' TODO - switch on more node types
+                    message_dialog("This type is not yet supported: " + selectedItem.type + ".")
                 end if
-            else if selectedItem.type = "Photo"
-                ' Nothing to do here, handled in ItemGrid
-            else if selectedItem.type = "MusicArtist"
-                group = CreateArtistView(selectedItem.json)
-                if not isValid(group)
-                    message_dialog(tr("Unable to find any albums or songs belonging to this artist"))
-                end if
-            else if selectedItem.type = "MusicAlbum"
-                group = CreateAlbumView(selectedItem.json)
-            else if selectedItem.type = "Audio"
-                m.global.queueManager.callFunc("clear")
-                m.global.queueManager.callFunc("push", selectedItem.json)
-                m.global.queueManager.callFunc("playQueue")
             else
-                ' TODO - switch on more node types
-                message_dialog("This type is not yet supported: " + selectedItem.type + ".")
+                featureDisabledDuringPlayback()
             end if
         else if isNodeEvent(msg, "movieSelected")
             ' If you select a movie from ANYWHERE, follow this flow
@@ -718,4 +723,15 @@ sub SendPerformanceBeacon(signalName as string)
     if m.global.app_loaded = false
         m.scene.signalBeacon(signalName)
     end if
+end sub
+
+sub featureDisabledDuringPlayback()
+    port = CreateObject("roMessagePort")
+    dialog = createObject("roSGNode", "Dialog")
+    dialog.message = tr("Feature not available during playback.")
+    dialog.buttons = [tr("OK")]
+    m.scene.dialog = dialog
+    m.scene.dialog.observeField("buttonSelected", port)
+    wait(0, port)
+    m.scene.dialog.close = true
 end sub


### PR DESCRIPTION
This prevents anything that might appear in the extrasslider from being selected during playback except for Persons. This will likely be used in candry's video nav buttons pr, but it may be convenient to test or merge separately (we may want to merge it in advance and let it get playtested in the meanwhile to reduce the overall testing burden of an already massive pr)

The rationale is that, since we will likely be using the extrasslider during playback to display "Cast" information, we don't want to deal with all the possible outcomes of the user clicking around forever.  the point of the dialog is to give cast info so we allow persondetails only.
