### PR TITLE
New persondetails view

### DIFF
--- a/components/OverviewDialog.xml
+++ b/components/OverviewDialog.xml
@@ -29,7 +29,7 @@
     <StdDlgTitleArea id="titleArea" />
     <StdDlgContentArea id="contentArea">
       <StdDlgTextItem id="description"
-          namedTextStyle="secondary" />
+          namedTextStyle="normal" />
     </StdDlgContentArea>
   </children>
 </component>

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -15,7 +15,16 @@ sub loadPerson()
     itemData = item.json
     m.top.Id = itemData.id
     m.top.findNode("Name").Text = itemData.Name
+    m.top.findNode("Name").font.size = 70
     if itemData.PremiereDate <> invalid and itemData.PremiereDate <> ""
+        lifeStringLabel = createObject("rosgnode", "Label")
+        lifeStringLabel.id = "premierDate"
+        lifeStringLabel.font = "font:SmallestBoldSystemFont"
+        lifeStringLabel.height = "100"
+        lifeStringLabel.vertAlign = "bottom"
+        m.top.findNode("Name").vertAlign = "top"
+        m.top.findNode("Name").font.size = 60
+        m.top.findNode("title_rectangle").appendChild(lifeStringLabel)
         birthDate = CreateObject("roDateTime")
         birthDate.FromISO8601String(itemData.PremiereDate)
         deathDate = CreateObject("roDatetime")
@@ -38,7 +47,11 @@ sub loadPerson()
         lifeString = lifeString + " * " + tr("Age") + ": " + stri(age)
         m.top.findNode("premierDate").Text = lifeString
     end if
-    m.dscr.text = itemData.Overview
+    if itemData.Overview <> invalid and itemData.Overview <> ""
+        m.dscr.text = itemData.Overview
+    else
+        m.dscr.text = tr("Biographical information for this person is not currently available.")
+    end if
     if item.posterURL <> invalid and item.posterURL <> ""
         m.top.findnode("personImage").uri = item.posterURL
     else

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -2,7 +2,6 @@ sub init()
     m.dscr = m.top.findNode("description")
     m.vidsList = m.top.findNode("extrasGrid")
     m.btnGrp = m.top.findNode("buttons")
-    m.btnGrp.observeField("escape", "onButtonGroupEscaped")
     m.favBtn = m.top.findNode("favorite-button")
     m.extrasGrp = m.top.findNode("extrasGrp")
     m.top.findNode("VertSlider").keyValue = "[[30, 998], [30, 789], [30, 580], [30,371 ], [30, 162]]"
@@ -67,17 +66,6 @@ sub dscrShowFocus()
     end if
 end sub
 
-sub onButtonGroupEscaped()
-    key = m.btnGrp.escape
-    if key = "down"
-        m.vidsList.setFocus(true)
-        m.top.findNode("VertSlider").reverse = false
-        m.top.findNode("pplAnime").control = "start"
-    else if key = "up" and m.dscr.isTextEllipsized
-        dscrShowFocus()
-    end if
-end sub
-
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
@@ -95,17 +83,31 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = "down"
+        if m.favBtn.hasFocus()
+            m.dscr.setFocus(true)
+            m.dscr.opacity = 1.0
+            m.top.findNode("dscrBorder").color = "#d0d0d0ff"
+            return true
+        else if m.dscr.hasFocus()
+            m.dscr.opacity = 0.6
+            m.top.findNode("dscrBorder").color = "#data202020ff"
+            m.vidsList.setFocus(true)
+            m.top.findNode("VertSlider").reverse = false
+            m.top.findNode("pplAnime").control = "start"
+            return true
+        end if
+    else if key = "up"
         if m.dscr.hasFocus()
             m.favBtn.setFocus(true)
             m.dscr.opacity = 0.6
             m.top.findNode("dscrBorder").color = "#data202020ff"
             return true
-        end if
-    else if key = "up"
-        if m.vidsList.isInFocusChain() and m.vidsList.itemFocused = 0
+        else if m.vidsList.isInFocusChain() and m.vidsList.itemFocused = 0
             m.top.findNode("VertSlider").reverse = true
             m.top.findNode("pplAnime").control = "start"
-            m.favBtn.setFocus(true)
+            m.dscr.setFocus(true)
+            m.dscr.opacity = 1.0
+            m.top.findNode("dscrBorder").color = "#d0d0d0ff"
             return true
         end if
     end if

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -5,9 +5,7 @@ sub init()
     m.btnGrp.observeField("escape", "onButtonGroupEscaped")
     m.favBtn = m.top.findNode("favorite-button")
     m.extrasGrp = m.top.findNode("extrasGrp")
-    m.top.findNode("VertSlider").keyValue = "[[30, 998], [30, 789], [30, 580], [30,371 ], [30, 162]]"
     m.extrasGrp.opacity = 1.0
-    m.extrasGrp.translation = "[30, 998]"
     m.dscr.observeField("isTextEllipsized", "onEllipsisChanged")
     createDialogPallete()
     m.top.optionsAvailable = false

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -6,7 +6,6 @@ sub init()
     m.favBtn = m.top.findNode("favorite-button")
     m.extrasGrp = m.top.findNode("extrasGrp")
     m.extrasGrp.opacity = 1.0
-    m.dscr.observeField("isTextEllipsized", "onEllipsisChanged")
     createDialogPallete()
     m.top.optionsAvailable = false
 end sub
@@ -48,26 +47,19 @@ sub loadPerson()
     m.vidsList.callFunc("loadPersonVideos", m.top.Id)
 
     setFavoriteColor()
-    m.favBtn.setFocus(true)
-end sub
-
-sub onEllipsisChanged()
-    if m.dscr.isTextEllipsized
-        dscrShowFocus()
-    end if
+    if not m.favBtn.hasFocus() then dscrShowFocus()
 end sub
 
 sub dscrShowFocus()
-    if m.dscr.isTextEllipsized
-        m.dscr.setFocus(true)
-        m.dscr.opacity = 1.0
-        m.top.findNode("dscrBorder").color = "#d0d0d0ff"
-    end if
+    m.dscr.setFocus(true)
+    m.dscr.opacity = 1.0
+    m.top.findNode("dscrBorder").color = "#d0d0d0ff"
 end sub
 
 sub onButtonGroupEscaped()
     key = m.btnGrp.escape
     if key = "down"
+        print "key down"
         m.dscr.setFocus(true)
         m.dscr.opacity = 1.0
         m.top.findNode("dscrBorder").color = "#d0d0d0ff"
@@ -108,9 +100,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         else if m.vidsList.isInFocusChain() and m.vidsList.itemFocused = 0
             m.top.findNode("VertSlider").reverse = true
             m.top.findNode("pplAnime").control = "start"
-            m.dscr.setFocus(true)
-            m.dscr.opacity = 1.0
-            m.top.findNode("dscrBorder").color = "#d0d0d0ff"
+            dscrShowFocus()
             return true
         end if
     end if
@@ -139,13 +129,6 @@ sub createFullDscrDlg()
     dlg.overview = m.dscr.text
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
-    border = createObject("roSGNode", "Poster")
-    border.uri = "pkg:/images/hd_focul_9.png"
-    border.blendColor = "#c9c9c9ff"
-    border.width = dlg.width + 6
-    border.height = dlg.height + 6
-    border.translation = [dlg.translation[0] - 3, dlg.translation[1] - 3]
-    border.visible = true
 
 end sub
 

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -2,6 +2,7 @@ sub init()
     m.dscr = m.top.findNode("description")
     m.vidsList = m.top.findNode("extrasGrid")
     m.btnGrp = m.top.findNode("buttons")
+    m.btnGrp.observeField("escape", "onButtonGroupEscaped")
     m.favBtn = m.top.findNode("favorite-button")
     m.extrasGrp = m.top.findNode("extrasGrp")
     m.top.findNode("VertSlider").keyValue = "[[30, 998], [30, 789], [30, 580], [30,371 ], [30, 162]]"
@@ -66,11 +67,20 @@ sub dscrShowFocus()
     end if
 end sub
 
+sub onButtonGroupEscaped()
+    key = m.btnGrp.escape
+    if key = "down"
+        m.dscr.setFocus(true)
+        m.dscr.opacity = 1.0
+        m.top.findNode("dscrBorder").color = "#d0d0d0ff"
+    end if
+end sub
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
     if key = "OK"
-        if m.dscr.hasFocus() and m.dscr.isTextEllipsized
+        if m.dscr.hasFocus()
             createFullDscrDlg()
             return true
         end if
@@ -83,12 +93,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = "down"
-        if m.favBtn.hasFocus()
-            m.dscr.setFocus(true)
-            m.dscr.opacity = 1.0
-            m.top.findNode("dscrBorder").color = "#d0d0d0ff"
-            return true
-        else if m.dscr.hasFocus()
+        if m.dscr.hasFocus()
             m.dscr.opacity = 0.6
             m.top.findNode("dscrBorder").color = "#data202020ff"
             m.vidsList.setFocus(true)
@@ -130,19 +135,13 @@ end sub
 
 sub createFullDscrDlg()
     dlg = CreateObject("roSGNode", "OverviewDialog")
-    dlg.Title = tr("Press 'OK' to Close")
-    dlg.width = 1290
+    dlg.Title = m.top.itemContent.json.Name
+    dlg.width = 1400
     dlg.palette = m.dlgPalette
     dlg.overview = [m.dscr.text]
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
-    border = createObject("roSGNode", "Poster")
-    border.uri = "pkg:/images/hd_focul_9.png"
-    border.blendColor = "#c9c9c9ff"
-    border.width = dlg.width + 6
-    border.height = dlg.height + 6
-    border.translation = [dlg.translation[0] - 3, dlg.translation[1] - 3]
-    border.visible = true
+
 end sub
 
 sub createDialogPallete()

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -51,6 +51,8 @@ sub loadPerson()
         m.dscr.text = itemData.Overview
     else
         m.dscr.text = tr("Biographical information for this person is not currently available.")
+        m.dscr.horizAlign = "center"
+        m.dscr.vertAlign = "center"
     end if
     if item.posterURL <> invalid and item.posterURL <> ""
         m.top.findnode("personImage").uri = item.posterURL

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -138,9 +138,16 @@ sub createFullDscrDlg()
     dlg.Title = m.top.itemContent.json.Name
     dlg.width = 1290
     dlg.palette = m.dlgPalette
-    dlg.overview = [m.dscr.text]
+    dlg.overview = m.dscr.text
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
+    border = createObject("roSGNode", "Poster")
+    border.uri = "pkg:/images/hd_focul_9.png"
+    border.blendColor = "#c9c9c9ff"
+    border.width = dlg.width + 6
+    border.height = dlg.height + 6
+    border.translation = [dlg.translation[0] - 3, dlg.translation[1] - 3]
+    border.visible = true
 
 end sub
 

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -136,7 +136,7 @@ end sub
 sub createFullDscrDlg()
     dlg = CreateObject("roSGNode", "OverviewDialog")
     dlg.Title = m.top.itemContent.json.Name
-    dlg.width = 1400
+    dlg.width = 1290
     dlg.palette = m.dlgPalette
     dlg.overview = [m.dscr.text]
     m.fullDscrDlg = dlg

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -14,16 +14,17 @@ sub loadPerson()
     item = m.top.itemContent
     itemData = item.json
     m.top.Id = itemData.id
-    m.top.findNode("Name").Text = itemData.Name
-    m.top.findNode("Name").font.size = 70
+    name = m.top.findNode("Name")
+    name.Text = itemData.Name
+    name.font.size = 70
     if itemData.PremiereDate <> invalid and itemData.PremiereDate <> ""
         lifeStringLabel = createObject("rosgnode", "Label")
         lifeStringLabel.id = "premierDate"
         lifeStringLabel.font = "font:SmallestBoldSystemFont"
         lifeStringLabel.height = "100"
         lifeStringLabel.vertAlign = "bottom"
-        m.top.findNode("Name").vertAlign = "top"
-        m.top.findNode("Name").font.size = 60
+        name.vertAlign = "top"
+        name.font.size = 60
         m.top.findNode("title_rectangle").appendChild(lifeStringLabel)
         birthDate = CreateObject("roDateTime")
         birthDate.FromISO8601String(itemData.PremiereDate)
@@ -45,7 +46,7 @@ sub loadPerson()
             end if
         end if
         lifeString = lifeString + " * " + tr("Age") + ": " + stri(age)
-        m.top.findNode("premierDate").Text = lifeString
+        lifeStringLabel.Text = lifeString
     end if
     if itemData.Overview <> invalid and itemData.Overview <> ""
         m.dscr.text = itemData.Overview

--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -75,7 +75,6 @@ end sub
 sub onButtonGroupEscaped()
     key = m.btnGrp.escape
     if key = "down"
-        print "key down"
         m.dscr.setFocus(true)
         m.dscr.opacity = 1.0
         m.top.findNode("dscrBorder").color = "#d0d0d0ff"

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -19,15 +19,15 @@
           </ButtonGroupHoriz>
         </LayoutGroup>
       <LayoutGroup id="personInfoGroup"
-          layoutDirection="horiz" itemSpacings="[36]">
+          layoutDirection="horiz" itemSpacings="[46]">
         <Poster id="personImage"
-            width="400" height="600" />
+            width="430" height="645" />
         <LayoutGroup id="vertSpacer" layoutDirection="vert" itemSpacings="[24]">
           <LayoutGroup id="dataGroup>" layoutDirection="vert" translation="[450,180]">
-            <Rectangle id="dscrBorder" height="600" width="1362" color="0x202020ff" visible="true">
-              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1356" color="0x202020ff">
+            <Rectangle id="dscrBorder" height="645" width="1322" color="0x202020ff" visible="true">
+              <Rectangle id='dscrRect' translation="[3, 3]" height="639" width="1316" color="0x202020ff">
               <Label id="description"
-                  height="582" width="1320" wrap="true" translation="[18, 15]"
+                  height="627" width="1280" wrap="true" translation="[18, 15]"
                   font="font:SmallestSystemFont" color="#e4e4e4ff" ellipsisText=" ...  (-OK- for More)" />
               </Rectangle>
             </Rectangle>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -6,33 +6,26 @@
     <field id="selectedItem" type="node" alias="extrasGrid.selectedItem" alwaysNotify="true" />
   </interface>
   <children>
-    <LayoutGroup id="main_group"
-        layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]">
-      <LayoutGroup id="personInfoGroup"
-          layoutDirection="horiz" itemSpacings="[36]">
-        <Poster id="personImage"
-            width="300" height="450" />
+    <LayoutGroup id="main_group" layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]">
+      <LayoutGroup id="BannerGroup" layoutDirection="horiz" itemSpacings="[36]">
+        <LayoutGroup id="TitleGroup" layoutDirection="vert">
+          <Label id="name" font="font:LargeBoldSystemFont" height="60" width="1300" />
+          <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
+        </LayoutGroup>
+        <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
+      </LayoutGroup>
+      <LayoutGroup id="personInfoGroup" layoutDirection="horiz" itemSpacings="[36]">
+        <Poster id="personImage" width="400" height="600" />
         <LayoutGroup id="vertSpacer" layoutDirection="vert" itemSpacings="[24]">
-          <LayoutGroup id="dataGroup>" layoutDirection="vert"
-                translation="[450,180]">
-            <Label id="name" font="font:MediumBoldSystemFont" height="45" width="1200" />
-            <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
-            <Rectangle id="dscrBorder"
-                height="360" width="1422"
-                color="0x202020ff">
-              <Rectangle id='dscrRect' translation="[3, 3]"
-                  height="354" width="1416"
-                  color="0x202020ff">
+          <LayoutGroup id="dataGroup>" layoutDirection="vert" translation="[450,180]">
+            <Rectangle id="dscrBorder" height="600" width="1322" color="0x202020ff">
+              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1316" color="0x202020ff">
               <Label id="description"
-                  height="342" width="1380" wrap="true" translation="[18, 15]"
+                  height="600" width="1280" wrap="true" translation="[18, 15]" opacity="0.6"
                   font="font:SmallestSystemFont" color="#e4e4e4ff" ellipsisText=" ...  (-OK- for More)" />
               </Rectangle>
             </Rectangle>
           </LayoutGroup>
-          <ButtonGroupHoriz id="buttons" >
-            <Button id="favorite-button" text="Favorite"
-                iconUri="" focusedIconUri="" />
-          </ButtonGroupHoriz>
         </LayoutGroup>
       </LayoutGroup>
     </LayoutGroup>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -7,15 +7,15 @@
   </interface>
   <children>
     <LayoutGroup id="main_group"
-        layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]">
-        <LayoutGroup id="header_group" layoutdirection="horiz">
-          <LayoutGroup id="title_group" layoutdirection="vert" itemSpacings="[11]">
-            <Label id="name" font="font:LargeBoldSystemFont" height="45" width="1386" />
-            <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
+        layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]" >
+        <LayoutGroup id="header_group" layoutdirection="horiz" >
+          <LayoutGroup id="title_group" layoutdirection="vert" itemSpacings="[11]" >
+            <Rectangle id="title_rectangle" height="100" width="1426" color="#262626">
+              <Label id="name" font="font:LargeBoldSystemFont" height="100" width="1426" vertAlign="bottom" />
+            </Rectangle>
           </LayoutGroup>
-          <ButtonGroupHoriz id="buttons" >
-            <Button id="favorite-button" text="Favorite"
-                iconUri="" focusedIconUri="" />
+          <ButtonGroupHoriz id="buttons" vertAlign="center">
+            <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
           </ButtonGroupHoriz>
         </LayoutGroup>
       <LayoutGroup id="personInfoGroup"
@@ -24,10 +24,10 @@
             width="400" height="600" />
         <LayoutGroup id="vertSpacer" layoutDirection="vert" itemSpacings="[24]">
           <LayoutGroup id="dataGroup>" layoutDirection="vert" translation="[450,180]">
-            <Rectangle id="dscrBorder" height="600" width="1322" color="0x202020ff" visible="true">
-              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1316" color="0x202020ff">
+            <Rectangle id="dscrBorder" height="600" width="1362" color="0x202020ff" visible="true">
+              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1356" color="0x202020ff">
               <Label id="description"
-                  height="582" width="1280" wrap="true" translation="[18, 15]"
+                  height="582" width="1320" wrap="true" translation="[18, 15]"
                   font="font:SmallestSystemFont" color="#e4e4e4ff" ellipsisText=" ...  (-OK- for More)" />
               </Rectangle>
             </Rectangle>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -6,24 +6,33 @@
     <field id="selectedItem" type="node" alias="extrasGrid.selectedItem" alwaysNotify="true" />
   </interface>
   <children>
-    <LayoutGroup id="main_group" layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]">
-      <LayoutGroup id="BannerGroup" layoutDirection="horiz" itemSpacings="[36]">
-        <LayoutGroup id="TitleGroup" layoutDirection="vert">
-          <Label id="name" font="font:LargeBoldSystemFont" height="60" width="1300" />
-          <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
+    <LayoutGroup id="main_group"
+        layoutdirection="vert" translation="[60, 180]" itemSpacings="[36]">
+        <LayoutGroup id="header_group" layoutdirection="horiz">
+          <LayoutGroup id="title_group" layoutdirection="vert" itemSpacings="[11]">
+            <Label id="name" font="font:LargeBoldSystemFont" height="45" width="1386" />
+            <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
+          </LayoutGroup>
+          <ButtonGroupHoriz id="buttons" >
+            <Button id="favorite-button" text="Favorite"
+                iconUri="" focusedIconUri="" />
+          </ButtonGroupHoriz>
         </LayoutGroup>
-        <ButtonGroupHoriz id="buttons" >
-          <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
-        </ButtonGroupHoriz>
-      </LayoutGroup>
-      <LayoutGroup id="personInfoGroup" layoutDirection="horiz" itemSpacings="[36]">
-        <Poster id="personImage" width="400" height="600" />
+      <LayoutGroup id="personInfoGroup"
+          layoutDirection="horiz" itemSpacings="[36]">
+        <Poster id="personImage"
+            width="400" height="600" />
         <LayoutGroup id="vertSpacer" layoutDirection="vert" itemSpacings="[24]">
-          <LayoutGroup id="dataGroup>" layoutDirection="vert" translation="[450,180]">
-            <Rectangle id="dscrBorder" height="600" width="1322" color="0x202020ff">
-              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1316" color="0x202020ff">
+          <LayoutGroup id="dataGroup>" layoutDirection="vert"
+                translation="[450,180]">
+            <Rectangle id="dscrBorder"
+                height="600" width="1322"
+                color="0x202020ff">
+              <Rectangle id='dscrRect' translation="[3, 3]"
+                  height="594" width="1316"
+                  color="0x202020ff">
               <Label id="description"
-                  height="600" width="1280" wrap="true" translation="[18, 15]" opacity="0.6"
+                  height="582" width="1280" wrap="true" translation="[18, 15]"
                   font="font:SmallestSystemFont" color="#e4e4e4ff" ellipsisText=" ...  (-OK- for More)" />
               </Rectangle>
             </Rectangle>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -14,7 +14,7 @@
               <Label id="name" font="font:LargeBoldSystemFont" height="100" width="1426" vertAlign="bottom" />
             </Rectangle>
           </LayoutGroup>
-          <ButtonGroupHoriz id="buttons" vertAlign="center">
+          <ButtonGroupHoriz id="buttons" >
             <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
           </ButtonGroupHoriz>
         </LayoutGroup>

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -23,14 +23,9 @@
         <Poster id="personImage"
             width="400" height="600" />
         <LayoutGroup id="vertSpacer" layoutDirection="vert" itemSpacings="[24]">
-          <LayoutGroup id="dataGroup>" layoutDirection="vert"
-                translation="[450,180]">
-            <Rectangle id="dscrBorder"
-                height="600" width="1322"
-                color="0x202020ff">
-              <Rectangle id='dscrRect' translation="[3, 3]"
-                  height="594" width="1316"
-                  color="0x202020ff">
+          <LayoutGroup id="dataGroup>" layoutDirection="vert" translation="[450,180]">
+            <Rectangle id="dscrBorder" height="600" width="1322" color="0x202020ff" visible="true">
+              <Rectangle id='dscrRect' translation="[3, 3]" height="594" width="1316" color="0x202020ff">
               <Label id="description"
                   height="582" width="1280" wrap="true" translation="[18, 15]"
                   font="font:SmallestSystemFont" color="#e4e4e4ff" ellipsisText=" ...  (-OK- for More)" />

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -12,7 +12,9 @@
           <Label id="name" font="font:LargeBoldSystemFont" height="60" width="1300" />
           <label id="premierDate" font="font:SmallestBoldSystemFont" height="48" vertAlign="top" />
         </LayoutGroup>
-        <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
+        <ButtonGroupHoriz id="buttons" >
+          <Button id="favorite-button" text="Favorite" iconUri="" focusedIconUri="" />
+        </ButtonGroupHoriz>
       </LayoutGroup>
       <LayoutGroup id="personInfoGroup" layoutDirection="horiz" itemSpacings="[36]">
         <Poster id="personImage" width="400" height="600" />

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -59,7 +59,6 @@ sub onAdditionalPartsLoaded()
     else
         m.top.rowItemSize = [[234, 396]]
     end if
-    m.top.translation = "[75,10]"
 
     ' Load Cast and Crew and everything else...
     m.LoadPeopleTask.peopleList = m.people

--- a/components/extras/ExtrasSlider.xml
+++ b/components/extras/ExtrasSlider.xml
@@ -9,7 +9,7 @@
         showRowLabel="true"
         showRowCounter="true"
         visible="true"
-        translation="[12,18]"
+        translation="[75,10]"
         itemComponentName="ExtrasItem" />
       <Animation id="pplAnime" duration=".4" repeat="false" >
         <Vector2DFieldInterpolator

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1112,5 +1112,9 @@
             <translation>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+        <message>
+            <source>Biographical information for this person is not currently available.</source>
+            <translation>Biographical information for this person is not currently available.</translation>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1112,9 +1112,5 @@
             <translation>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
-        <message>
-            <source>Biographical information for this person is not currently available.</source>
-            <translation>Biographical information for this person is not currently available.</translation>
-        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1049,5 +1049,9 @@
             <source>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</source>
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
+        <message>
+            <source>Biographical information for this person is not currently available.</source>
+            <translation>Biographical information for this person is not currently available.</translation>
+        </message>
     </context>
 </TS>


### PR DESCRIPTION
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
muck about with the layout to make better use of space.
increase text size in dialog
always allow dialog selection even if the text is not ellipsized
set focus to description by default instead of fav menu, assuming that the use pattern will be to inspect the description before favoriting.

react to missing birthdate info by increasing Name size to elliminate deadspace. 

- [x] unbreak the overview dialog

