### PR TITLE
dont show moviedetails buttons until we can click them

### DIFF
--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -134,6 +134,7 @@ sub itemContentChanged()
     setWatchedColor()
     SetUpVideoOptions(itemData.mediaSources)
     SetUpAudioOptions(itemData.mediaStreams)
+    m.buttonGrp.visible = true
 end sub
 
 

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -29,7 +29,7 @@
           <Label id="audio_codec" vertAlign="bottom" height="39" />
           <label id="audio_codec_count" font="font:smallestSystemFont" vertAlign="top" color="#ceffff" />
         </LayoutGroup>
-        <ButtonGroupHoriz id="buttons" itemSpacings="[10]">
+        <ButtonGroupHoriz id="buttons" itemSpacings="[10]" visible="false">
           <Button text="Play" id="play-button" iconUri="" focusedIconUri="" maxWidth="175" minWidth="175" />
           <Button text="Options" id="options-button" iconUri="" focusedIconUri="" maxWidth="250" minWidth="250" />
           <Button text="Watched" id="watched-button" iconUri="" focusedIconUri="" maxWidth="350" minWidth="300" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
candry wrote this code.

**Changes**
dont show buttongroup in MovieDetails until we can click the buttons.

**Issues**
fixes buttongroup shown before content loaded
