### PR TITLE
update extras loading and slider

### DIFF
--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -31,9 +31,26 @@ sub updateSize()
     m.top.rowItemSpacing = [36, 36]
 end sub
 
-sub loadParts(data as object)
+sub loadParts(data as object, playback = false)
+    m.top.content = CreateObject("roSGNode", "ContentNode") ' The row Node
     m.top.parentId = data.id
     m.people = data.People
+    m.LoadPeopleTask.peopleList = m.people
+    m.LoadPeopleTask.control = "RUN"
+    if not playback
+        m.LoadAdditionalPartsTask.itemId = m.top.parentId
+        m.LoadAdditionalPartsTask.control = "RUN"
+        m.LikeThisTask.itemId = m.top.parentId
+        m.LikeThisTask.control = "RUN"
+        m.SpecialFeaturesTask.itemId = m.top.parentId
+        m.SpecialFeaturesTask.control = "RUN"
+        m.LoadShowsTask.itemId = m.personId
+        m.LoadShowsTask.observeField("content", "onShowsLoaded")
+        m.LoadShowsTask.control = "RUN"
+        m.LoadSeriesTask.itemId = m.personId
+        m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
+        m.LoadSeriesTask.control = "RUN"
+    end if
     m.LoadAdditionalPartsTask.itemId = m.top.parentId
     m.LoadAdditionalPartsTask.control = "RUN"
 end sub
@@ -49,8 +66,6 @@ sub onAdditionalPartsLoaded()
     parts = m.LoadAdditionalPartsTask.content
     m.LoadAdditionalPartsTask.unobserveField("content")
 
-    data = CreateObject("roSGNode", "ContentNode") ' The row Node
-    m.top.content = data
     if parts <> invalid and parts.count() > 0
         row = buildRow("Additional Parts", parts, 464)
         addRowSize([464, 291])
@@ -61,9 +76,7 @@ sub onAdditionalPartsLoaded()
     end if
     m.top.translation = "[75,10]"
 
-    ' Load Cast and Crew and everything else...
-    m.LoadPeopleTask.peopleList = m.people
-    m.LoadPeopleTask.control = "RUN"
+
 end sub
 
 sub onPeopleLoaded()
@@ -82,8 +95,6 @@ sub onPeopleLoaded()
             row.appendChild(person)
         end for
     end if
-    m.LikeThisTask.itemId = m.top.parentId
-    m.LikeThisTask.control = "RUN"
 end sub
 
 sub onLikeThisLoaded()
@@ -107,9 +118,6 @@ sub onLikeThisLoaded()
         end for
         addRowSize([234, 396])
     end if
-    ' Special Features next...
-    m.SpecialFeaturesTask.itemId = m.top.parentId
-    m.SpecialFeaturesTask.control = "RUN"
 end sub
 
 function onSpecialFeaturesLoaded()
@@ -150,9 +158,6 @@ sub onMoviesLoaded()
         m.top.rowItemSize = [[234, 396]]
     end if
     m.top.content = rlContent
-    m.LoadShowsTask.itemId = m.personId
-    m.LoadShowsTask.observeField("content", "onShowsLoaded")
-    m.LoadShowsTask.control = "RUN"
 end sub
 
 sub onShowsLoaded()
@@ -163,9 +168,6 @@ sub onShowsLoaded()
         addRowSize([502, 396])
         m.top.content.appendChild(row)
     end if
-    m.LoadSeriesTask.itemId = m.personId
-    m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
-    m.LoadSeriesTask.control = "RUN"
 end sub
 
 sub onSeriesLoaded()

--- a/components/extras/ExtrasSlider.xml
+++ b/components/extras/ExtrasSlider.xml
@@ -3,7 +3,7 @@
   <children>
     <Rectangle id="extrasGrp" color="#0A0010" opacity="0.3" width="1860" height="900" translation="[30, 1014]" >
       <ExtrasRowList id="extrasGrid"
-        itemSpacing="[ 60, 132]"
+        itemSpacing="[ 60, 100]"
         rowLabelOffset="[ [9, 24] ]"
         numRows="2"
         showRowLabel="true"
@@ -15,7 +15,7 @@
         <Vector2DFieldInterpolator
             id="VertSlider"
             key="[0.0, 0.25, 0.50, 75.0, 1.0]"
-            keyValue="[[30, 1014], [30, 804], [30, 588], [30,375 ], [30, 162]]"
+            keyValue="[[30, 1014], [30, 900], [30, 786], [30,672], [30, 518]]"
             fieldToInterp="extrasGrp.translation" />
         <FloatFieldInterpolator
             id="extrasFader"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
Pretty soon we will start using the ExtrasSlider to display cast information during playback.  To facilitate this, we need to elliminate the deadspace when you are looking at the bottom item in the rowlist (a problem through the entire app) and we need to modify which items we load (the cast slider should *only* show cast info, not extras or anything else).  This pr accomplishes both of those things.  It is, for reasons not clear to me, necessary to call the AdditionalParts task in order to get the slider to work.  Will fix that if I figure out why. For the time being, the cast dialog would still show additional parts if they existed and it were called (its not called in this pr).

also, it seems to make the overall load time a bit faster

**Issues**
this is to segue us into candry's videonav buttons pr
