### PR TITLE
Create Setting for Next Episode Button Time

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -19,6 +19,7 @@ sub init()
     m.nextEpisodeButton = m.top.findNode("nextEpisode")
     m.nextEpisodeButton.text = tr("Next Episode")
     m.nextEpisodeButton.setFocus(false)
+    m.nextupbuttonseconds = get_user_setting("playback.nextupbuttonseconds", "30")
 
     m.showNextEpisodeButtonAnimation = m.top.findNode("showNextEpisodeButton")
     m.hideNextEpisodeButtonAnimation = m.top.findNode("hideNextEpisodeButton")
@@ -77,7 +78,7 @@ end sub
 
 ' Checks if we need to display the Next Episode button
 sub checkTimeToDisplayNextEpisode()
-    if int(m.top.position) >= (m.top.runTime - 30)
+    if int(m.top.position) >= (m.top.runTime - Val(m.nextupbuttonseconds))
         showNextEpisodeButton()
         updateCount()
         return

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -65,7 +65,11 @@ end sub
 '
 'Update count down text
 sub updateCount()
-    m.nextEpisodeButton.text = tr("Next Episode") + " " + Int(m.top.runTime - m.top.position).toStr()
+    nextEpisodeCountdown = Int(m.top.runTime - m.top.position)
+    if nextEpisodeCountdown < 0
+        nextEpisodeCountdown = 0
+    end if
+    m.nextEpisodeButton.text = tr("Next Episode") + " " + nextEpisodeCountdown.toStr()
 end sub
 
 '
@@ -78,6 +82,12 @@ end sub
 
 ' Checks if we need to display the Next Episode button
 sub checkTimeToDisplayNextEpisode()
+    nextEpisodeCountdown = Int(m.top.runTime - m.top.position)
+    if nextEpisodeCountdown < 0
+        hideNextEpisodeButton()
+        return
+    end if
+
     if int(m.top.position) >= (m.top.runTime - Val(m.nextupbuttonseconds))
         showNextEpisodeButton()
         updateCount()

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1098,9 +1098,9 @@
             <translation>If enabled, the number of unwatched episodes in a series/season will be removed.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
-         <message>
+        <message>
             <source>Next Episode Button Time</source>
-            <translation>Next Up button duration</translation>
+            <translation>Next Episode Button Time</translation>
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1098,5 +1098,15 @@
             <translation>If enabled, the number of unwatched episodes in a series/season will be removed.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+         <message>
+            <source>Next Up button duration</source>
+            <translation>Next Up button duration</translation>
+            <extracomment>Settings Menu - Title for option</extracomment>
+        </message>
+        <message>
+            <source>Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.</source>
+            <translation>Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1099,13 +1099,13 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
          <message>
-            <source>Next Up button duration</source>
+            <source>Next Episode Button Time</source>
             <translation>Next Up button duration</translation>
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>
-            <source>Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.</source>
-            <translation>Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.</translation>
+            <source>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</source>
+            <translation>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
     </context>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -38,8 +38,8 @@
                 ]
             },
             {
-                "title": "Next Up button duration",
-                "description": "Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.",
+                "title": "Next Episode Button Time",
+                "description": "Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.",
                 "settingName": "playback.nextupbuttonseconds",
                 "type": "integer",
                 "default": "30"
@@ -113,7 +113,7 @@
                         "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
                         "settingName": "ui.details.maxdaysnextup",
                         "type": "integer",
-                        "default": "30"
+                        "default": "365"
                     },
                     {
                         "title": "Show What's New Popup",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -4,13 +4,6 @@
         "description": "Settings relating to playback and supported codec and media types.",
         "children": [
             {
-                "title": "Cinema Mode",
-                "description": "Cinema Mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.",
-                "settingName": "playback.cinemamode",
-                "type": "bool",
-                "default": "false"
-            },
-            {
                 "title": "Codec Support",
                 "description": "Enable or disable Direct Play support for certain codecs",
                 "children": [
@@ -36,13 +29,6 @@
                         "default": "true"
                     }
                 ]
-            },
-            {
-                "title": "Next Episode Button Time",
-                "description": "Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.",
-                "settingName": "playback.nextupbuttonseconds",
-                "type": "integer",
-                "default": "30"
             },
             {
                 "title": "Playback Bitrate Limits",
@@ -83,6 +69,20 @@
                         "default": "true"
                     }
                 ]
+            },
+            {
+                "title": "Cinema Mode",
+                "description": "Cinema Mode brings the theater experience straight to your living room with the ability to play custom intros before the main feature.",
+                "settingName": "playback.cinemamode",
+                "type": "bool",
+                "default": "false"
+            },
+            {
+                "title": "Next Episode Button Time",
+                "description": "Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.",
+                "settingName": "playback.nextupbuttonseconds",
+                "type": "integer",
+                "default": "30"
             },
             {
                 "title": "Text Subtitles Only",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -43,7 +43,7 @@
                 "settingName": "playback.nextupbuttonseconds",
                 "type": "integer",
                 "default": "30"
-            }
+            },
             {
                 "title": "Playback Bitrate Limits",
                 "description": "Set limits for how high playback bitrates are allowed to be.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -63,6 +63,13 @@
                 "settingName": "playback.subs.onlytext",
                 "type": "bool",
                 "default": "false"
+            },
+            {
+                "title": "Change next up button show duration",
+                "description": "Default is 30 seconds, you can set to 0 to diable the button or set new time in seconds to display the button",
+                "settingName": "playback.nextupbuttonseconds",
+                "type": "integer",
+                "default": "30"
             }
         ]
     },
@@ -86,7 +93,7 @@
                         "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
                         "settingName": "ui.details.maxdaysnextup",
                         "type": "integer",
-                        "default": "365"
+                        "default": "30"
                     },
                     {
                         "title": "Show What's New Popup",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -38,6 +38,13 @@
                 ]
             },
             {
+                "title": "Next Up button duration",
+                "description": "Set Next up button duration. Defualt is 30 seconds from the end of the episode. Set to 0 to disable.",
+                "settingName": "playback.nextupbuttonseconds",
+                "type": "integer",
+                "default": "30"
+            }
+            {
                 "title": "Playback Bitrate Limits",
                 "description": "Set limits for how high playback bitrates are allowed to be.",
                 "children": [
@@ -83,13 +90,6 @@
                 "settingName": "playback.subs.onlytext",
                 "type": "bool",
                 "default": "false"
-            },
-            {
-                "title": "Change next up button show duration",
-                "description": "Default is 30 seconds, you can set to 0 to diable the button or set new time in seconds to display the button",
-                "settingName": "playback.nextupbuttonseconds",
-                "type": "integer",
-                "default": "30"
             }
         ]
     },


### PR DESCRIPTION
Creates a setting for users to customize when the next up button appears. 

The default is 30 seconds

To disable the button set to 0
