### PR TITLE
Add user policy to check if canDelete

### DIFF
--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -155,6 +155,11 @@ sub LoadUserAbilities(user)
     else
         set_user_setting("livetv.canrecord", "false")
     end if
+    if user.Policy.EnableContentDeletion = true
+        set_user_setting("content.candelete", "true")
+    else
+        set_user_setting("content.candelete", "false")
+    end if
 end sub
 
 function initQuickConnect()


### PR DESCRIPTION
Adds the ability to check if user has the EnableContentDeletion policy. 

This will allow use to add a delete media button in a future PR. 