### PR TITLE
fix select index in button escape

### DIFF
--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -75,9 +75,7 @@ end sub
 sub onButtonGroupEscaped()
     key = m.btnGrp.escape
     if key = "down"
-        m.dscr.setFocus(true)
-        m.dscr.opacity = 1.0
-        m.top.findNode("dscrBorder").color = "#d0d0d0ff"
+        dscrShowFocus()
     end if
 end sub
 


### PR DESCRIPTION
I broke persondetails in my PR such that pressing down from the favbtn still brings up the slider.  this PR corrects the code such that it selects the description dialog.
