### PR TITLE
Make workflows use latest LTS release + cache npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,13 @@ on:
       - 'locale/**'
 jobs:
   run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
-          node-version: "18.13.0"
+          node-version: "lts/*"
+          cache: "npm"
       - run: npm ci
       - run: npx ropm install
       - run: make dev

--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -6,12 +6,13 @@ on:
 
 jobs:
   test-build-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: "18.13.0"
+          node-version: "lts/*"
+          cache: "npm"
       - run: npm ci
       - run: npx ropm install
       - run: npm run validate

--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -6,12 +6,13 @@ on:
 
 jobs:
   test-build-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: "18.13.0"
+          node-version: "lts/*"
+          cache: "npm"
       - run: npm ci
       - run: npx ropm install
       - run: npm run validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,12 +3,13 @@ on: [push, pull_request]
 
 jobs:
   run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: "18.13.0"
+          node-version: "lts/*"
+          cache: "npm"
       - run: npm ci
       - run: npx ropm install
       - run: npm run validate


### PR DESCRIPTION
Use latest LTS release of ubuntu and node - this should prevent us from having to manually update the versions in the future. Also, force workflows to cache npm packages for faster execution time and to save bandwidth

**Changes**
- Make workflows use latest LTS release of ubuntu and node
- Cache npm packages

**Issues**
Extends PR #976
Fixes #977