### PR TITLE
use JF_BOT_TOKEN for project board automation

### DIFF
--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           project: Ongoing development
           column: In progress
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
   label:
     name: Labeling 🏷️
     runs-on: ubuntu-latest


### PR DESCRIPTION
${{ secrets.GITHUB_TOKEN }} doesnt work with the project board automation because GITHUB_TOKEN only has read access but needs permission to write