### PR TITLE
Show "Actor" when an actor has an empty role

### DIFF
--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -72,7 +72,7 @@ sub onPeopleLoaded()
         row = m.top.content.createChild("ContentNode")
         row.Title = tr("Cast & Crew")
         for each person in people
-            if person.json.type = "Actor" and person.json.Role <> invalid and Str(person.json.Role).Trim() <> ""
+            if person.json.type = "Actor" and person.json.Role <> invalid and person.json.Role.ToStr().Trim() <> ""
                 person.subTitle = "as " + person.json.Role
             else
                 person.subTitle = person.json.Type

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -72,7 +72,7 @@ sub onPeopleLoaded()
         row = m.top.content.createChild("ContentNode")
         row.Title = tr("Cast & Crew")
         for each person in people
-            if person.json.type = "Actor" and person.json.Role <> invalid
+            if person.json.type = "Actor" and person.json.Role <> invalid and Str(person.json.Role).Trim() <> ""
                 person.subTitle = "as " + person.json.Role
             else
                 person.subTitle = person.json.Type


### PR DESCRIPTION
For the extras cast and crew section, it appears that some actors have empty "roles". 

**Changes**
Instead of showing "as " when the actor's role is empty, show "Actor" instead.

**Issues**
Fixes #1032
alternative to #1034