### PR TITLE
Remove duplicate translation entries

### DIFF
--- a/locale/de_DE/translations.ts
+++ b/locale/de_DE/translations.ts
@@ -6,7 +6,7 @@
         <name>default</name>
         <message>
             <source>192.168.1.100:8096 or https://example.com/jellyfin</source>
-            <translation>Standard: 192.168.1.100:8096 oder https://example.com/jellyfin</translation>
+            <translation>192.168.1.100:8096 oder https://example.com/jellyfin</translation>
         </message>
         <message>
             <source>Cancel</source>

--- a/locale/lv/translations.ts
+++ b/locale/lv/translations.ts
@@ -192,59 +192,6 @@
             <source>Unable to load Channel Data from the server</source>
             <translation>Nespēja ielādēt Kanālu Datus no servera</translation>
         </message>
-    </context>
-    <context>
-        <name></name>
-        <message>
-            <comment>Message displayed in Item Grid when no item to display. %1 is container type (e.g. Boxset, Collection, Folder, etc)</comment>
-            <source>NO_ITEMS</source>
-            <translation>Šī %1 nesatur vienumus</translation>
-        </message>
-        <message>
-            <source>An error was encountered while playing this item.</source>
-            <translation>Notika kļūda atskaņojot šo vienumu.</translation>
-            <extracomment>Dialog detail when error occurs during playback</extracomment>
-        </message>
-        <message>
-            <source>There was an error retrieving the data for this item from the server.</source>
-            <translation>Notika kļūda saņemot datus šim vienumam no servera.</translation>
-            <extracomment>Dialog detail when unable to load Content from Server</extracomment>
-        </message>
-        <message>
-            <source>Error During Playback</source>
-            <translation>Kļūda Atskaņošanas Laikā</translation>
-            <extracomment>Dialog title when error occurs during playback</extracomment>
-        </message>
-        <message>
-            <source>Error Retrieving Content</source>
-            <translation>Kļūda Saņemot Saturu</translation>
-            <extracomment>Dialog title when unable to load Content from Server</extracomment>
-        </message>
-        <message>
-            <source>An error was encountered while playing this item.</source>
-            <translation>Notika kļūda atskaņojot šo vienumu.</translation>
-            <extracomment>Dialog detail when error occurs during playback</extracomment>
-        </message>
-        <message>
-            <comment>Message displayed in Item Grid when no item to display. %1 is container type (e.g. Boxset, Collection, Folder, etc)</comment>
-            <source>NO_ITEMS</source>
-            <translation>Šī %1 nesatur vienumus</translation>
-        </message>
-        <message>
-            <source>There was an error retrieving the data for this item from the server.</source>
-            <translation>Notika kļūda saņemot datus šim vienumam no servera.</translation>
-            <extracomment>Dialog detail when unable to load Content from Server</extracomment>
-        </message>
-        <message>
-            <source>Error During Playback</source>
-            <translation>Kļūda Atskaņošanas Laikā</translation>
-            <extracomment>Dialog title when error occurs during playback</extracomment>
-        </message>
-        <message>
-            <source>Error Retrieving Content</source>
-            <translation>Kļūda Saņemot Saturu</translation>
-            <extracomment>Dialog title when unable to load Content from Server</extracomment>
-        </message>
         <message>
             <comment>Message displayed in Item Grid when no item to display. %1 is container type (e.g. Boxset, Collection, Folder, etc)</comment>
             <source>NO_ITEMS</source>


### PR DESCRIPTION
This is a work in progress.

Weblate is currently broken. We should probably merge the fixes in this PR before turning it back on or at least right after it's turned back on. Fixing merge conflicts on this PR after weblate is turned back on sounds like a nightmare

**Changes**
- Remove all duplicate entries
- Only use one `context` tag with `name=default`

**Issues**
Working on #1056 
