### PR TITLE
Fix crash in VideoPlayer.brs

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -31,7 +31,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
 
     ' Special handling for "Programs" or "Vidoes" launched from "On Now" or elsewhere on the home screen...
     ' basically anything that is a Live Channel.
-    if isValid(meta?.json?.ChannelId)
+    if isValid(meta.json) and isValid(meta.json.ChannelId)
         if meta.json.EpisodeTitle <> invalid
             meta.title = meta.json.EpisodeTitle
         else if meta.json.Name <> invalid
@@ -47,7 +47,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
-        if isValid(meta?.json?.RunTimeTicks)
+        if isValid(meta.json) and isValid(meta.json.RunTimeTicks)
             video.runTime = (meta.json.RunTimeTicks / 10000000.0)
         end if
         video.content.contenttype = "episode"

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -47,7 +47,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
-        if isValid(meta.json.RunTimeTicks)
+        if isValid(meta?.json?.RunTimeTicks)
             video.runTime = (meta.json.RunTimeTicks / 10000000.0)
         end if
         video.content.contenttype = "episode"


### PR DESCRIPTION
This was most likely fixed already by #997 but just to be sure this PR also ensures the other objects in the if statement are valid as well. 

**Changes**
- ensure vars are valid before using

**Issues**
Fixes #1060 
