### PR TITLE
Fix crash in JFOverhang.brs

### DIFF
--- a/components/JFOverhang.brs
+++ b/components/JFOverhang.brs
@@ -101,6 +101,7 @@ sub updateTime()
 end sub
 
 sub resetTime()
+    if m.hideClock then return
     m.currentTimeTimer.control = "stop"
     m.currentTimeTimer.control = "start"
     updateTime()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -558,7 +558,12 @@ sub Main (args as dynamic) as void
             event = msg.GetInfo()
             group = sceneManager.callFunc("getActiveScene")
             if event.exitedScreensaver = true
-                sceneManager.callFunc("resetTime")
+                ' refresh time
+                hideClock = get_user_setting("ui.design.hideclock")
+                if isValid(hideClock) and hideClock = "false"
+                    sceneManager.callFunc("resetTime")
+                end if
+                ' refresh the current view
                 if group.subtype() = "Home"
                     currentTime = CreateObject("roDateTime").AsSeconds()
                     group.timeLastRefresh = currentTime

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -558,11 +558,7 @@ sub Main (args as dynamic) as void
             event = msg.GetInfo()
             group = sceneManager.callFunc("getActiveScene")
             if event.exitedScreensaver = true
-                ' refresh time
-                hideClock = get_user_setting("ui.design.hideclock")
-                if isValid(hideClock) and hideClock = "false"
-                    sceneManager.callFunc("resetTime")
-                end if
+                sceneManager.callFunc("resetTime")
                 ' refresh the current view
                 if group.subtype() = "Home"
                     currentTime = CreateObject("roDateTime").AsSeconds()


### PR DESCRIPTION
We were still calling `resetTime` after exiting the screensaver regardless of what the hideClock setting was set to

**Issues**
Fixes #1069
Introduced by #697
