### PR TITLE
Add support for ass format subtitles for custom caption

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -252,6 +252,14 @@ function getDeviceProfile() as object
         })
     end if
 
+    ' Allow more subtitles types to be streamed without transcoding
+    if get_user_setting("playback.subs.custom") = "true"
+        deviceProfile.SubtitleProfiles.push({
+            "Format": "ass",
+            "Method": "External"
+        })
+    end if
+
     return deviceProfile
 end function
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

This patch add support for parsing and rendering ass format subtitles.

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Modify `deviceCapabilities` to allow direct stream ass subtitle tracks without transcoding.
- Add simple ass file parser.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- Currently the parser simply translate ass Dialogue instructions to pure texts, ignoring any other instructions and control sequences in the `Text` field. As the rendering is customized its possible to honor ass style.
- More control sequence (e.g. \N) could be processed in the parser.
