### PR TITLE
Add using fallback font to display localized content (resource title, description, etc.)

### DIFF
--- a/components/ItemGrid/GridItem.brs
+++ b/components/ItemGrid/GridItem.brs
@@ -26,6 +26,7 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
+    updateFont(m.top)
 end sub
 
 sub itemContentChanged()

--- a/components/ItemGrid/GridItem.xml
+++ b/components/ItemGrid/GridItem.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="GridItem" extends="Group">
   <children>
     <maskGroup id="posterMask" maskUri="pkg:/images/postermask.png" scaleRotateCenter="[145, 212.5]" scale="[0.85,0.85]">
@@ -20,4 +20,5 @@
   </interface>
   <script type="text/brightscript" uri="GridItem.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -23,6 +23,7 @@ sub setupNodes()
     m.genreList = m.top.findNode("genrelist")
     m.infoGroup = m.top.findNode("infoGroup")
     m.star = m.top.findNode("star")
+    updateFont(m.top)
 end sub
 
 sub init()

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="JFOverhang" extends="Group">
   <children>
     <Poster id="overlayLogo" uri="pkg:/images/logo.png" translation="[70, 53]" width="270" height="72" />
     <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[375, 53]" itemSpacings="30">
-      <Rectangle id="overlayLeftSeperator" color="#666666" width="2" height="64"/>
+      <Rectangle id="overlayLeftSeperator" color="#666666" width="2" height="64" />
       <ScrollingLabel id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" maxWidth="1100" repeatCount="0" />
     </LayoutGroup>
     <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="30" translation="[1820, 53]" horizAlignment="right">
       <Label id="overlayCurrentUser" font="font:MediumSystemFont" width="300" horizAlign="right" vertAlign="center" height="64" />
-      <Rectangle id="overlayRightSeperator" color="#666666" width="2" height="64" visible="false"/>
+      <Rectangle id="overlayRightSeperator" color="#666666" width="2" height="64" visible="false" />
       <LayoutGroup id="overlayTimeGroup" layoutDirection="horiz" horizAlignment="right" itemSpacings="0">
         <Label id="overlayHours" font="font:MediumSystemFont" vertAlign="center" height="64" />
         <Label font="font:MediumSystemFont" text=":" vertAlign="center" height="64" />

--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -202,6 +202,7 @@ end sub
 ' Update overhang title
 sub updateOverhangTitle(msg)
     m.overhang.title = msg.getData()
+    updateFont(m.overhang)
 end sub
 
 

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="SceneManager" extends="Group">
   <interface>
     <function name="pushScene" />
@@ -16,4 +16,5 @@
     <field id="returnData" type="assocarray" />
   </interface>
   <script type="text/brightscript" uri="SceneManager.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -18,6 +18,7 @@ sub init()
     posterBackgrounds = m.global.constants.poster_bg_pallet
     m.backdrop.color = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
 
+    updateFont(m.top)
 end sub
 
 

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="HomeItem" extends="Group">
   <children>
     <Rectangle id="backdrop" width="464" height="261" translation="[8,5]" />
@@ -26,4 +26,5 @@
   <script type="text/brightscript" uri="pkg:/source/api/Image.brs" />
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
+  <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
 </component>

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -25,6 +25,8 @@ sub init()
     m.trailerButton.text = tr("Play Trailer")
 
     m.top.observeField("itemContent", "itemContentChanged")
+
+    updateFont(m.top)
 end sub
 
 sub OnScreenShown()

--- a/components/tvshows/TVShowDetails.brs
+++ b/components/tvshows/TVShowDetails.brs
@@ -8,6 +8,8 @@ sub init()
     m.getShuffleEpisodesTask = createObject("roSGNode", "getShuffleEpisodesTask")
     m.Shuffle = m.top.findNode("Shuffle")
     m.extrasSlider.visible = true
+
+    updateFont(m.top)
 end sub
 
 sub itemContentChanged()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -49,15 +49,6 @@ sub Main (args as dynamic) as void
     if not LoginFlow() then return
     sceneManager.callFunc("clearScenes")
 
-    ' load home page
-    sceneManager.currentUser = m.user.Name
-    group = CreateHomeGroup()
-    group.userConfig = m.user.configuration
-    group.callFunc("loadLibraries")
-    sceneManager.callFunc("pushScene", group)
-
-    m.scene.observeField("exit", m.port)
-
     ' Downloads and stores a fallback font to tmp:/
     if parseJSON(APIRequest("/System/Configuration/encoding").GetToString())["EnableFallbackFont"] = true
         re = CreateObject("roRegex", "Name.:.(.*?).,.Size", "s")
@@ -67,7 +58,24 @@ sub Main (args as dynamic) as void
             filename = filename[1]
             APIRequest("FallbackFont/Fonts/" + filename).gettofile("tmp:/font")
         end if
+
+
+        ' Check the result font
+        fs = CreateObject("roFileSystem")
+        fontlist = fs.Find("tmp:/", "font")
+        if fontlist.count() > 0
+            m.global.addFields({ fallbackFont: "tmp:/" + fontlist[0] })
+        end if
     end if
+
+    ' load home page
+    sceneManager.currentUser = m.user.Name
+    group = CreateHomeGroup()
+    group.userConfig = m.user.configuration
+    group.callFunc("loadLibraries")
+    sceneManager.callFunc("pushScene", group)
+
+    m.scene.observeField("exit", m.port)
 
     ' Only show the Whats New popup the first time a user runs a new client version.
     if appInfo.GetVersion() <> get_setting("LastRunVersion")

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -352,3 +352,24 @@ sub stopLoadingSpinner()
         m.scene.dialog.close = true
     end if
 end sub
+
+sub updateFont(parent)
+    if m.global.fallbackFont <> invalid
+        updateFontWorker(parent)
+    end if
+end sub
+
+sub updateFontWorker(parent)
+    for each node in parent.getChildren(-1, 0)
+        if node.font <> invalid
+            node.font.uri = m.global.fallbackFont
+            if node.isSubType("Label")
+                node.lineSpacing = 0
+            end if
+        else if node.rowLabelFont <> invalid
+            node.rowLabelFont.uri = m.global.fallbackFont
+        end if
+
+        updateFontWorker(node)
+    end for
+end sub


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

This patch leverage the fallback font to display CJK chars in 

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Move the load of fallback font before the render of home page
- Create new global field, `fallbackFont` to save the filepath of fallback font
- Create a function, `updateFont`, if fallback font exists, recursively udpate the font.uri for components that needs to use the fallback font 
- Apply the function to several major layouts.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- The fallback font changes the demenssion of elements, results in mismatched layout
- Not all labels are modified in this patch.
- The recursive function changes all labels under a top node, instead of labels that need to be localized. This causes broken style in components like buttons. 

**Improvement**
- In general, more fine grained font change should be applied, e.g. replace font by type name. As I'm new to project and brs I may need help to find precise localtion of the labels in the components.
- Localizations could be implemented using the same method.
