### PR TITLE
Only show next episode popup if web client setting is turned on

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -86,7 +86,7 @@ end sub
 ' Runs Next Episode button animation and sets focus to button
 sub showNextEpisodeButton()
     if m.top.content.contenttype <> 4 then return
-    if m.top.userConfig.EnableNextEpisodeAutoPlay and not m.nextEpisodeButton.visible
+    if m.global.userConfig.EnableNextEpisodeAutoPlay and not m.nextEpisodeButton.visible
         m.showNextEpisodeButtonAnimation.control = "start"
         m.nextEpisodeButton.setFocus(true)
         m.nextEpisodeButton.visible = true

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -86,7 +86,7 @@ end sub
 ' Runs Next Episode button animation and sets focus to button
 sub showNextEpisodeButton()
     if m.top.content.contenttype <> 4 then return
-    if not m.nextEpisodeButton.visible
+    if m.top.userConfig.EnableNextEpisodeAutoPlay and not m.nextEpisodeButton.visible
         m.showNextEpisodeButtonAnimation.control = "start"
         m.nextEpisodeButton.setFocus(true)
         m.nextEpisodeButton.visible = true

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -11,6 +11,7 @@
     <field id="directPlaySupported" type="boolean" />
     <field id="systemOverlay" type="boolean" value="false" />
     <field id="showID" type="string" />
+    <field id="userConfig" type="assocarray" />
 
     <field id="transcodeParams" type="assocarray" />
     <field id="transcodeAvailable" type="boolean" value="false" />
@@ -35,12 +36,12 @@
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
     <JFButton id="nextEpisode"
-              opacity="0"
-              textColor="#f0f0f0"
-              focusedTextColor="#202020"
-              focusFootprintBitmapUri="pkg:/images/option-menu-bg.9.png"
-              focusBitmapUri="pkg:/images/white.9.png"
-              translation="[1500, 900]" />
+      opacity="0"
+      textColor="#f0f0f0"
+      focusedTextColor="#202020"
+      focusFootprintBitmapUri="pkg:/images/option-menu-bg.9.png"
+      focusBitmapUri="pkg:/images/white.9.png"
+      translation="[1500, 900]" />
 
     <!--animation for the play next episode button-->
     <Animation id="showNextEpisodeButton" duration="1.0" repeat="false" easeFunction="inQuad">

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -11,7 +11,6 @@
     <field id="directPlaySupported" type="boolean" />
     <field id="systemOverlay" type="boolean" value="false" />
     <field id="showID" type="string" />
-    <field id="userConfig" type="assocarray" />
 
     <field id="transcodeParams" type="assocarray" />
     <field id="transcodeAvailable" type="boolean" value="false" />

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="Home" extends="JFGroup">
   <children>
     <Poster id="backdrop" loadDisplayMode="scaleToZoom" width="1920" height="1200" />
@@ -7,7 +7,6 @@
   </children>
   <interface>
     <field id="selectedItem" alias="homeRows.selectedItem" />
-    <field id="userConfig" alias="homeRows.userConfig" />
     <field id="quickPlayNode" alias="homeRows.quickPlayNode" />
     <field id="timeLastRefresh" type="integer" />
     <function name="refresh" />

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -97,7 +97,7 @@ sub onLibrariesLoaded()
 
     ' validate library data
     if isValid(m.libraryData) and m.libraryData.count() > 0
-        userConfig = m.top.userConfig
+        userConfig = m.global.userConfig
 
         ' populate My Media row
         filteredMedia = filterNodeArray(m.libraryData, "id", userConfig.MyMediaExcludes)

--- a/components/home/HomeRows.xml
+++ b/components/home/HomeRows.xml
@@ -2,7 +2,6 @@
 <component name="HomeRows" extends="RowList">
   <interface>
     <field id="selectedItem" type="node" alwaysNotify="true" />
-    <field id="userConfig" type="assocarray" />
     <field id="quickPlayNode" type="node" alwaysNotify="true" />
     <function name="updateHomeRows" />
     <function name="loadLibraries" />

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -98,7 +98,7 @@ end sub
 '
 ' Runs Next Episode button animation and sets focus to button
 sub showNextEpisodeButton()
-    if not m.nextEpisodeButton.visible
+    if m.global.userConfig.EnableNextEpisodeAutoPlay and not m.nextEpisodeButton.visible
         m.showNextEpisodeButtonAnimation.control = "start"
         m.nextEpisodeButton.setFocus(true)
         m.nextEpisodeButton.visible = true

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="VideoPlayerView" extends="Video">
   <interface>
     <field id="backPressed" type="boolean" alwaysNotify="true" />

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -47,12 +47,13 @@ sub Main (args as dynamic) as void
     app_start:
     ' First thing to do is validate the ability to use the API
     if not LoginFlow() then return
+    ' remove previous scenes from the stack
     sceneManager.callFunc("clearScenes")
-
+    ' save user config
+    m.global.addFields({ userConfig: m.user.configuration })
     ' load home page
     sceneManager.currentUser = m.user.Name
     group = CreateHomeGroup()
-    group.userConfig = m.user.configuration
     group.callFunc("loadLibraries")
     sceneManager.callFunc("pushScene", group)
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -2,7 +2,6 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     ' Get video controls and UI
     video = CreateObject("roSGNode", "JFVideo")
     video.id = id
-    video.userConfig = m.user.configuration
     AddVideoContent(video, mediaSourceId, audio_stream_idx, subtitle_idx, -1, forceTranscoding, showIntro, allowResumeDialog)
 
     if video.errorMsg = "introaborted"

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -2,6 +2,7 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     ' Get video controls and UI
     video = CreateObject("roSGNode", "JFVideo")
     video.id = id
+    video.userConfig = m.user.configuration
     AddVideoContent(video, mediaSourceId, audio_stream_idx, subtitle_idx, -1, forceTranscoding, showIntro, allowResumeDialog)
 
     if video.errorMsg = "introaborted"


### PR DESCRIPTION
## Changes
- check web client setting before showing next episode popup
- save `m.user.configuration` to a global var for easy access from components - `m.global.userConfig`
  - remove `userConfig` field from XML nodes that were using it

## Issues
Fixes #1099 
