### PR TITLE
Use recommended extensions as default formatters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,12 @@
     "files.associations": {
         "*.ts": "xml"
     },
+    "[xml]": {
+        "editor.defaultFormatter": "redhat.vscode-xml"
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+    },
     "xml.format.maxLineWidth": 0,
     "editor.formatOnSave": true
 }


### PR DESCRIPTION
Force use of our recommended extensions for formatting on save.

## Changes
- Use recommended extensions as default formatters (XML and markdown)
- NOTE: Users who don't have the recomended extensions installed will see a warning in vscode regarding `settings.json`. I believe this is acceptable at the very least regarding XML since it's used throughout the app
![settings json-warning](https://user-images.githubusercontent.com/16514652/226195216-0a80a663-1659-4587-8720-302524607935.PNG)

