### PR TITLE
Alert PR author of merge conflicts + use JF bot

### DIFF
--- a/.github/workflows/auto-close-stale-pr.yml
+++ b/.github/workflows/auto-close-stale-pr.yml
@@ -18,4 +18,4 @@ jobs:
           days-before-pr-stale: 21
           days-before-pr-close: 7
           exempt-draft-pr: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           dirtyLabel: "merge conflict"
           commentOnDirty: "This pull request has merge conflicts. Please resolve the conflicts so the PR can be reviewed. Thanks!"
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          repoToken: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -30,4 +30,5 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: "merge conflict"
+          commentOnDirty: "This pull request has merge conflicts. Please resolve the conflicts so the PR can be reviewed. Thanks!"
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Have the bot leave a PR comment to alert the author in addition to adding the "merge conflict" label
## Changes
- Have bot leave a comment as well as add a `merge conflict` label
- Have automations use jellyfin bot instead of github-actions wherever possible
## Issues
Fixes #1102
