### PR TITLE
Stop spinner when intro video starts & disable intros on playlists

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -70,6 +70,9 @@ sub LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtit
         end if
     end if
 
+    ' For phase 1 of playlist support, we don't support intros yet
+    showIntro = false
+
     ' Don't attempt to play an intro for an intro video
     if showIntro
         ' Do not play intros when resuming playback

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -337,6 +337,7 @@ function PlayIntroVideo(video_id, audio_stream_idx) as boolean
             introVideo.observeField("state", port)
             m.global.sceneManager.callFunc("pushScene", introVideo)
             introPlaying = true
+            stopLoadingSpinner()
 
             while introPlaying
                 msg = wait(0, port)


### PR DESCRIPTION
## Changes
1. Hides spinner for intro video playback.
2. Disables intro video playback for phase 1 of playlist support. #1086 Adds intro video support to playlists

## Issues
Fixes #1125 #1126 
