### PR TITLE
Update readme - fix channel and matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Jellyfin Roku App is a Jellyfin client for Roku Devices.  This is still very
 
 ## Getting Started
 
-The channel is available on the [Roku Channel Store](https://my.roku.com/add/jellyfin).
+The channel is available on the [Roku Channel Store](https://channelstore.roku.com/details/cc5e559d08d9ec87c5f30dcebdeebc12/jellyfin).
 
 ## Getting Involved<a name="get_involved"></a>
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <img src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg" alt="Translation status" />
 </a>
 <br/>
-<a href="https://matrix.to/#/+jellyfin:matrix.org">
+<a href="https://matrix.to/#/#jellyfin-dev-roku:matrix.org">
 <img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"/>
 </a>
 <a href="https://www.reddit.com/r/jellyfin">


### PR DESCRIPTION
## Changes
- Make the matrix chat badge link to the Roku dev channel
- Update Roku channel store link. We were still using the same link from beta

Old channel link took you to a login page followed by this:
![roku-channel-link](https://user-images.githubusercontent.com/16514652/227563621-691eb05c-5348-48d7-901d-41b1d7d7f8b7.PNG)

New link takes you directly to this page instead:
![roku-channel-link2](https://user-images.githubusercontent.com/16514652/227563704-f12d02ce-4f98-4a0e-8a20-a5640a171f2d.PNG)

