### PR TITLE
Update custom subtitle task to prevent crashes.

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -30,8 +30,12 @@ sub init()
 
     m.top.observeField("state", "onState")
     m.top.observeField("content", "onContentChange")
+    m.top.observeField("allowCaptions", "onAllowCaptionsChange")
+end sub
 
-    'Captions
+sub onAllowCaptionsChange()
+    if not m.top.allowCaptions then return
+
     m.captionGroup = m.top.findNode("captionGroup")
     m.captionGroup.createchildren(9, "LayoutGroup")
     m.captionTask = createObject("roSGNode", "captionTask")
@@ -129,7 +133,9 @@ end sub
 
 ' When Video Player state changes
 sub onPositionChanged()
-    m.captionTask.currentPos = Int(m.top.position * 1000)
+    if isValid(m.captionTask)
+        m.captionTask.currentPos = Int(m.top.position * 1000)
+    end if
     ' Check if dialog is open
     m.dialog = m.top.getScene().findNode("dialogBackground")
     if not isValid(m.dialog)
@@ -140,7 +146,9 @@ end sub
 '
 ' When Video Player state changes
 sub onState(msg)
-    m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
+    if isValid(m.captionTask)
+        m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
+    end if
     ' When buffering, start timer to monitor buffering process
     if m.top.state = "buffering" and m.bufferCheckTimer <> invalid
 

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -16,6 +16,7 @@
     <field id="transcodeAvailable" type="boolean" value="false" />
     <field id="retryWithTranscoding" type="boolean" value="false" />
     <field id="isTranscoded" type="boolean" />
+    <field id="allowCaptions" type="boolean" value="false" />
     <field id="transcodeReasons" type="array" />
 
     <field id="videoId" type="string" />

--- a/components/captionTask.brs
+++ b/components/captionTask.brs
@@ -33,8 +33,7 @@ sub setFont()
         m.font.uri = "tmp:/font"
         m.font.size = m.fontSize
     else
-        reg = CreateObject("roFontRegistry")
-        m.font = reg.GetDefaultFont(m.fontSize, false, false)
+        m.font = "font:LargeSystemFont"
     end if
 end sub
 
@@ -56,6 +55,7 @@ function newlabel(txt)
     label = CreateObject("roSGNode", "Label")
     label.text = txt
     label.font = m.font
+    label.font.size = m.fontSize
     label.color = m.textColor
     label.opacity = m.textOpac
     return label

--- a/components/captionTask.brs
+++ b/components/captionTask.brs
@@ -28,9 +28,9 @@ end sub
 
 sub setFont()
     fs = CreateObject("roFileSystem")
-    fontlist = fs.Find("tmp:/", "font")
-    if fontlist.count() > 0
-        m.font.uri = "tmp:/" + fontlist[0]
+
+    if fs.Exists("tmp:/font")
+        m.font.uri = "tmp:/font"
         m.font.size = m.fontSize
     else
         reg = CreateObject("roFontRegistry")
@@ -89,7 +89,7 @@ function newRect(lg)
 end function
 
 
-sub updateCaption ()
+sub updateCaption()
     m.top.currentCaption = []
     if LCase(m.top.playerState) = "playingon"
         m.top.currentPos = m.top.currentPos + 100

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -540,9 +540,11 @@ function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_
     startMediaLoadingSpinner()
     ' Video is Playing
     video = VideoPlayer(video_id, mediaSourceId, audio_stream_idx, defaultSubtitleTrackFromVid(video_id), forceTranscoding, showIntro, allowResumeDialog)
-    video.allowCaptions = true
 
     if video = invalid then return invalid
+
+    video.allowCaptions = true
+
     if video.errorMsg = "introaborted" then return video
     video.observeField("selectSubtitlePressed", m.port)
     video.observeField("selectPlaybackInfoPressed", m.port)

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -540,6 +540,7 @@ function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_
     startMediaLoadingSpinner()
     ' Video is Playing
     video = VideoPlayer(video_id, mediaSourceId, audio_stream_idx, defaultSubtitleTrackFromVid(video_id), forceTranscoding, showIntro, allowResumeDialog)
+    video.allowCaptions = true
 
     if video = invalid then return invalid
     if video.errorMsg = "introaborted" then return video

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -332,6 +332,7 @@ function PlayIntroVideo(video_id, audio_stream_idx) as boolean
             if lcase(introVideos.items[0].name) = "rick roll'd" then return true
 
             introVideo = VideoPlayer(introVideos.items[0].id, introVideos.items[0].id, audio_stream_idx, defaultSubtitleTrackFromVid(video_id), false, false)
+            introVideo.allowCaptions = false
 
             port = CreateObject("roMessagePort")
             introVideo.observeField("state", port)

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -332,7 +332,9 @@ function PlayIntroVideo(video_id, audio_stream_idx) as boolean
             if lcase(introVideos.items[0].name) = "rick roll'd" then return true
 
             introVideo = VideoPlayer(introVideos.items[0].id, introVideos.items[0].id, audio_stream_idx, defaultSubtitleTrackFromVid(video_id), false, false)
-            introVideo.allowCaptions = false
+            if isValid(introVideo)
+                introVideo.allowCaptions = false
+            end if
 
             port = CreateObject("roMessagePort")
             introVideo.observeField("state", port)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Within the custom subtitle task, change the fs.Find() function to use fs.Exists() instead. This appears to fix a crashing issue when two videos are played in close succession.

Prevent subtitle task from initializing for intro videos.

Fix fallback, default font syntax for custom subtitles if no fallback font is found.

## Issues
Fixes #1128

## Testing Considerations
This modifies logic in the new custom subtitle rendering, so you'll want to ensure videos still work with and without the custom renderer enabled, with and without fallback fonts enabled on the server, and with and without fallback font files available.

The only way I've been able to cause the reboot issue is to hit play on an episode, then within the first second of the video, hit back, then play the episode again.