### PR TITLE
Add build badge + rework readme

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -71,7 +71,7 @@ That's it! VSCode will auto-package the project, sideload it to the specified de
 
 Out of the box, the BrightScript extension will prompt you to pick a Roku device (from devices found on your local network) and enter a password on every launch. If you'd prefer to hardcode this information rather than entering it every time, you can set these values in your VSCode user settings:
 
-```js
+```json
 {
     "brightscript.debug.host": "YOUR_ROKU_HOST_HERE",
     "brightscript.debug.password": "YOUR_ROKU_DEV_PASSWORD_HERE",

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -27,7 +27,7 @@ Follow the steps below to install the app on your personal Roku device. This wil
 
 ## Developer Mode
 
-Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created, you will need these later.
+Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created - you will need these!
 
 ## Clone the GitHub Repo
 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ For more advanced deployment methods, access to crash logs, or to learn how to s
 
 ## Feature Requests
 
-New feature requests are always welcome but before creating an issue please read though the [existing issues](https://github.com/jellyfin/jellyfin-roku/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) to see if someone has already raised one for what you're looking for.
+New feature requests are always welcome but before creating an issue please read through the [existing issues](https://github.com/jellyfin/jellyfin-roku/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) to see if someone has already raised one for what you're looking for.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <h1 style="text-align: center;">Jellyfin Roku</h1>
 <h2 style="text-align: center;">Part of the <a href="https://jellyfin.media">Jellyfin</a> Project</h2>
 
@@ -39,4 +38,4 @@ To test the latest features before they get released:
 
 ## Advanced
 
-For more advanced deployment methods, access to crashlogs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md)
+For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg?logo=reddit "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
 [![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg "GPL 2.0 License")](LICENSE)
 
-The Jellyfin Roku App is a Jellyfin client for Roku Devices and is still very much a work in progress. Please get involved if you can!
+Jellyfin Roku is the official Jellyfin client for Roku. Please get involved if you can!
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ New feature requests are always welcome but before creating an issue please read
 To test the latest features before they get released:
 
 1. Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created - you will need these!
-2. Download the [latest build](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable) from the unstable branch
-3. Access your roku device by putting your Roku's IP from step 1 into a browser i.e. `http://192.168.1.2`
-4. Log in with credentials from step 1
-5. Upload and install the zip file downloaded in step 2
+2. Download the [latest build](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable) from the unstable branch.
+3. Put your Roku's IP from step 1 into a browser i.e. `http://192.168.1.2` and press enter.
+4. Log in with credentials from step 1.
+5. Upload and install the zip file downloaded in step 2.
 
 > NOTE: The beta app will always be at the bottom of your Roku's channel list and it will *not* automatically update.
 
 ## Advanced
 
-For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md)
+For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md).

--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
-<h1 style="text-align: center;">Jellyfin app for Roku</h1>
-<h3 style="text-align: center;">Part of the <a href="https://jellyfin.media/">Jellyfin</a> Project</h3>
 
-<p align="center">
-<img alt="Logo banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
-<br/><br/>
-<a href="https://github.com/jellyfin/jellyfin-roku">
-<img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg"/>
-</a>
-<a href="https://github.com/jellyfin/jellyfin-roku/releases">
-<img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg"/>
-</a>
-<a href="https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget">
-<img src="https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg" alt="Translation status" />
-</a>
-<br/>
-<a href="https://matrix.to/#/#jellyfin-dev-roku:matrix.org">
-<img alt="Chat on Matrix" src="https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix"/>
-</a>
-<a href="https://www.reddit.com/r/jellyfin">
-<img alt="Join our Subreddit" src="https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg"/>
-</a>
-</p>
+<h1 style="text-align: center;">Jellyfin Roku</h1>
+<h2 style="text-align: center;">Part of the <a href="https://jellyfin.media">Jellyfin</a> Project</h2>
 
-The Jellyfin Roku App is a Jellyfin client for Roku Devices.  This is still very much a work in progress, so we would encourage you to [get involved](#get_involved) if you can.
+[![Logo Banner](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true)](https://jellyfin.media)
 
-## Getting Started
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jellyfin/jellyfin-roku/build-dev.yml?logo=github&branch=unstable)](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable)
+[![Current Release](https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg)](https://github.com/jellyfin/jellyfin-roku/releases)
+[![Translation Status](https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg)](https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget)
+[![Matrix](https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix)](https://matrix.to/#/#jellyfin-dev-roku:matrix.org)
+[![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
+[![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg)](LICENSE)
 
-The channel is available on the [Roku Channel Store](https://channelstore.roku.com/details/cc5e559d08d9ec87c5f30dcebdeebc12/jellyfin).
+The Jellyfin Roku App is a Jellyfin client for Roku Devices and is still very much a work in progress. Please get involved if you can!
 
-## Getting Involved<a name="get_involved"></a>
+## Install
 
-No matter what your interests or skill are, you can help to make this client better for everyone by simply using the client and letting us know if you find a problem with it.   Either give us a shout on [matrix](https://matrix.to/#/+jellyfin:matrix.org) or create a GitHub issue.
+Download the latest release on the [Roku Channel Store](https://channelstore.roku.com/details/cc5e559d08d9ec87c5f30dcebdeebc12/jellyfin).
 
-Feature requests are always welcome too, but please have a read though the existing issues to see if someone has already raised one for something similar.
+## Get Involved
 
-If you fancy some development, then read the [DEVGUIDE](DEVGUIDE.md) to find out the best ways to help.
+No matter what your interests or skills are you can help make this client better for everyone by simply using the client and giving feedback to the developers when things break. [Create an issue](https://github.com/jellyfin/jellyfin-roku/issues/new/choose) here on GitHub or give us a shout on [matrix](https://matrix.to/#/#jellyfin-dev-roku:matrix.org).
 
-As Roku have severely limited their Beta channel program, the best way to test pre-release versions is by following the [DEVGUIDE](DEVGUIDE.md) to install and test the latest changes.  Feedback is always welcome.
+## Feature Requests
+
+New feature requests are always welcome but before creating an issue please read though the [existing issues](https://github.com/jellyfin/jellyfin-roku/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) to see if someone has already raised one for what you're looking for.
+
+## Beta Test
+
+To test the latest features before they get released:
+
+1. Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created - you will need these!
+2. Download the [latest build](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable) from the unstable branch
+3. Access your roku device by putting your Roku's IP from step 1 into a browser i.e. `http://192.168.1.2`
+4. Log in with credentials from step 1
+5. Upload and install the zip file downloaded in step 2
+
+> NOTE: The beta app will always be at the bottom of your Roku's channel list and it will *not* automatically update.
+
+## Advanced
+
+For more advanced deployment methods, access to crashlogs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg?logo=reddit "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
 [![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg "GPL 2.0 License")](LICENSE)
 
-Jellyfin Roku is the official Jellyfin client for Roku. Please get involved if you can!
+Jellyfin Roku is the official Jellyfin client for Roku devices. We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<h1 style="text-align: center;">Jellyfin Roku</h1>
-<h2 style="text-align: center;">Part of the <a href="https://jellyfin.media">Jellyfin</a> Project</h2>
+<h1 align="center">Jellyfin Roku</h1>
+<h2 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h2>
 
 [![Logo Banner](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true "Jellyfin")](https://jellyfin.media)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg?logo=reddit "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
 [![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg "GPL 2.0 License")](LICENSE)
 
-Jellyfin Roku is the official Jellyfin client for Roku devices. We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
+Jellyfin Roku is the official Jellyfin client for Roku devices. We welcome all contributions and pull requests! If you have a larger feature in mind please [open an issue](https://github.com/jellyfin/jellyfin-roku/issues/new?assignees=&labels=feature&template=feature_request.md&title=) so we can discuss the implementation before you start.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 style="text-align: center;">Jellyfin Roku</h1>
 <h2 style="text-align: center;">Part of the <a href="https://jellyfin.media">Jellyfin</a> Project</h2>
 
-[![Logo Banner](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true)](https://jellyfin.media)
+[![Logo Banner](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true "Jellyfin")](https://jellyfin.media)
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/jellyfin/jellyfin-roku/build-dev.yml?logo=github&branch=unstable)](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable)
-[![Current Release](https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg)](https://github.com/jellyfin/jellyfin-roku/releases)
-[![Translation Status](https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg)](https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget)
-[![Matrix](https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix)](https://matrix.to/#/#jellyfin-dev-roku:matrix.org)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jellyfin/jellyfin-roku/build-dev.yml?logo=github&branch=unstable "Build Status")](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable)
+[![Current Release](https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg "Current Release")](https://github.com/jellyfin/jellyfin-roku/releases)
+[![Translation Status](https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg "Translation Status")](https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget)
+[![Matrix](https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix "Chat on Matrix")](https://matrix.to/#/#jellyfin-dev-roku:matrix.org)
 [![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
-[![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg "GPL 2.0 License")](LICENSE)
 
 The Jellyfin Roku App is a Jellyfin client for Roku Devices and is still very much a work in progress. Please get involved if you can!
 
@@ -19,10 +19,6 @@ Download the latest release on the [Roku Channel Store](https://channelstore.rok
 ## Get Involved
 
 No matter what your interests or skills are you can help make this client better for everyone by simply using the client and giving feedback to the developers when things break. [Create an issue](https://github.com/jellyfin/jellyfin-roku/issues/new/choose) here on GitHub or give us a shout on [matrix](https://matrix.to/#/#jellyfin-dev-roku:matrix.org).
-
-## Feature Requests
-
-New feature requests are always welcome but before creating an issue please read though the [existing issues](https://github.com/jellyfin/jellyfin-roku/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) to see if someone has already raised one for what you're looking for.
 
 ## Beta Test
 
@@ -39,3 +35,7 @@ To test the latest features before they get released:
 ## Advanced
 
 For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md).
+
+## Feature Requests
+
+New feature requests are always welcome but before creating an issue please read though the [existing issues](https://github.com/jellyfin/jellyfin-roku/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) to see if someone has already raised one for what you're looking for.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ No matter what your interests or skills are you can help make this client better
 To test the latest features before they get released:
 
 1. Put your Roku device in [developer mode](https://blog.roku.com/developer/2016/02/04/developer-setup-guide). Write down your Roku device IP and the password you created - you will need these!
-2. Download the [latest build](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable) from the unstable branch.
+2. Download the [latest build](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable). Select the first item listed then click the link at the bottom of the page i.e. `Jellyfin-Roku-dev-d3352495c579f6adeca085cdbc137ac36e70d558`. This will download a zip file to your computer.
 3. Put your Roku's IP from step 1 into a browser i.e. `http://192.168.1.2` and press enter.
 4. Log in with credentials from step 1.
 5. Upload and install the zip file downloaded in step 2.
@@ -34,7 +34,7 @@ To test the latest features before they get released:
 
 ## Advanced
 
-For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment to write some code yourself please see the [DEVGUIDE](DEVGUIDE.md).
+For more advanced deployment methods, access to crash logs, or to learn how to setup a developer environment so you can write some code yourself please read the [DEVGUIDE](DEVGUIDE.md).
 
 ## Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Logo Banner](https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true "Jellyfin")](https://jellyfin.media)
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/jellyfin/jellyfin-roku/build-dev.yml?logo=github&branch=unstable "Build Status")](https://github.com/jellyfin/jellyfin-roku/actions/workflows/build-dev.yml?query=branch%3Aunstable)
-[![Current Release](https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg "Current Release")](https://github.com/jellyfin/jellyfin-roku/releases)
+[![Current Release](https://img.shields.io/github/release/jellyfin/jellyfin-roku.svg?logo=github "Current Release")](https://github.com/jellyfin/jellyfin-roku/releases)
 [![Translation Status](https://translate.jellyfin.org/widgets/jellyfin/-/jellyfin-roku/svg-badge.svg "Translation Status")](https://translate.jellyfin.org/projects/jellyfin/jellyfin-roku/?utm_source=widget)
 [![Matrix](https://img.shields.io/matrix/jellyfin:matrix.org.svg?logo=matrix "Chat on Matrix")](https://matrix.to/#/#jellyfin-dev-roku:matrix.org)
-[![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
+[![Reddit](https://img.shields.io/badge/reddit-r%2Fjellyfin-%23FF5700.svg?logo=reddit "Join our Subreddit")](https://www.reddit.com/r/jellyfin)
 [![License](https://img.shields.io/github/license/jellyfin/jellyfin-roku.svg "GPL 2.0 License")](LICENSE)
 
 The Jellyfin Roku App is a Jellyfin client for Roku Devices and is still very much a work in progress. Please get involved if you can!

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -3,6 +3,7 @@ VSCode
 BrightScript
 sideload
 Sideload
+Reddit
 DEVGUIDE
 ing
 hardcode


### PR DESCRIPTION
I just wanted to add a build badge 🤷 

## Changes
- Add build badge that shows latest unstable build status and links the unstable workflows (for easy access to build zips for install)
- Converted the badge HTML to markdown ( left the branding stuff at top because there's no way to center things without HTML)
  - The badges are no longer centered but now left aligned and wrap
- Reworked the main text to hopefully be a bit easier to read and also help people get a beta/unstable release running

