### PR TITLE
Enable confirm partner button + setup RALE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,10 @@
             "request": "launch",
             "name": "Jellyfin Debug: Launch",
             "stopOnEntry": false,
+            // To enable RALE:
+            // set "brightscript.debug.raleTrackerTaskFileLocation": "/absolute/path/to/rale/TrackerTask.xml" in your vscode user settings
+            // set the below field to true
+            "injectRaleTrackerTask": false,
             //WARNING: don't edit this value. Instead, set "brightscript.debug.host": "YOUR_HOST_HERE" in your vscode user settings
             //"host": "${promptForHost}",
             //WARNING: don't edit this value. Instead, set "brightscript.debug.password": "YOUR_PASSWORD_HERE" in your vscode user settings

--- a/manifest
+++ b/manifest
@@ -21,4 +21,6 @@ splash_min_time=1500
 
 ui_resolutions=fhd
 
+confirm_partner_button=1
+
 supports_input_launch=1

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -30,7 +30,7 @@ sub Main (args as dynamic) as void
     m.port = CreateObject("roMessagePort")
     m.screen.setMessagePort(m.port)
     m.scene = m.screen.CreateScene("JFScene")
-    m.screen.show()
+    m.screen.show() ' vscode_rale_tracker_entry
 
     ' Set any initial Global Variables
     m.global = m.screen.getGlobalNode()


### PR DESCRIPTION
Show a popup to confirm exit when hitting a "partner button" on the remote (one of the four buttons on the bottom dedicated to specific apps).

Setup RALE as much as possible to make testing with RALE easier. After this is merged you would need to do the following ONCE:
- [Install the RALE app](https://devtools.web.roku.com/roku-advanced-layout-editor/) on your PC - v3.2.0 is currently the latest release
- [Download `TaskTracker.xml`](https://devtools.web.roku.com/roku-advanced-layout-editor/app/TrackerTask.zip)
- Put `TaskTracker.xml` in a permanent location on your PC (not in a repo)
- Put this setting in your vscode user settings: `"brightscript.debug.raleTrackerTaskFileLocation": "/absolute/path/to/rale/TrackerTask.xml"`

After completing the previous steps you would just need to enable RALE from the launch config:
- Set `"injectRaleTrackerTask": false` to `true`

Now you can launch and debug the app like usual while also having access to the app from RALE

## Changes
- Set `confirm_partner_button=1` - see [here](https://developer.roku.com/en-gb/docs/developer-program/getting-started/architecture/channel-manifest.md#special-purpose-attributes) for more info
- [Setup RALE](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/rale.html) as much as possible to make testing easier
  - NOTE: [The path to `TrackerTask.xml` must be an *absolute* path.](https://rokucommunity.github.io/vscode-brightscript-language/extension-settings.html#brightscriptdebugraletrackertaskfilelocation)



