### PR TITLE
Reset loop mode when user changes song

### DIFF
--- a/components/music/AudioPlayerView.brs
+++ b/components/music/AudioPlayerView.brs
@@ -254,12 +254,22 @@ function previousClicked() as boolean
         m.global.audioPlayer.control = "stop"
     end if
 
+    ' Reset loop mode due to manual user interaction
+    if m.global.audioPlayer.loopMode = "one"
+        resetLoopModeToDefault()
+    end if
+
     m.global.queueManager.callFunc("moveBack")
     pageContentChanged()
 
 
     return true
 end function
+
+sub resetLoopModeToDefault()
+    m.global.audioPlayer.loopMode = ""
+    setLoopButtonImage()
+end sub
 
 function loopClicked() as boolean
 
@@ -289,6 +299,11 @@ end sub
 
 function nextClicked() as boolean
     if m.playlistTypeCount > 1 then return false
+
+    ' Reset loop mode due to manual user interaction
+    if m.global.audioPlayer.loopMode = "one"
+        resetLoopModeToDefault()
+    end if
 
     if m.global.queueManager.callFunc("getPosition") < m.global.queueManager.callFunc("getCount") - 1
         LoadNextSong()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Resets audio player loop mode to default when user clicks to go forward or backward.

## Issues
Fixes #1108
