### PR TITLE
Create Album Artists view for music library

### DIFF
--- a/components/ItemGrid/ItemGridOptions.xml
+++ b/components/ItemGrid/ItemGridOptions.xml
@@ -9,11 +9,11 @@
       </LayoutGroup>
       <LayoutGroup id="menuOptions" horizAlignment="center" translation="[860,200]" itemSpacings="[50]">
         <Group>
-          <RadiobuttonList id="viewMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
+          <RadiobuttonList id="viewMenu" itemSize="[600, 75]" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
           </RadiobuttonList>
-          <RadiobuttonList id="sortMenu" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="1" numRows="8" drawFocusFeedback="false">
+          <RadiobuttonList id="sortMenu" itemSize="[600, 75]" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="1" numRows="8" drawFocusFeedback="false">
           </RadiobuttonList>
-          <RadiobuttonList id="filterMenu" checkOnSelect="false" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
+          <RadiobuttonList id="filterMenu" itemSize="[600, 75]" checkOnSelect="false" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
           </RadiobuttonList>
         </Group>
       </LayoutGroup>

--- a/components/ItemGrid/LoadItemsTask2.brs
+++ b/components/ItemGrid/LoadItemsTask2.brs
@@ -109,6 +109,13 @@ sub loadItems()
             Fields: "Genres"
         })
         params.IncludeItemTypes = "MusicAlbum,Audio"
+    else if m.top.ItemType = "AlbumArtists"
+        url = "Artists/AlbumArtists"
+        params.append({
+            UserId: get_setting("active_user"),
+            Fields: "Genres"
+        })
+        params.IncludeItemTypes = "MusicAlbum,Audio"
     else if m.top.ItemType = "MusicAlbum"
         url = Substitute("Users/{0}/Items/", get_setting("active_user"))
         params.append({ ImageTypeLimit: 1 })

--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -148,6 +148,11 @@ sub loadInitialItems()
         m.top.showItemTitles = "hidealways"
     else if LCase(m.view) = "artistsgrid" or LCase(m.options.view) = "artistsgrid"
         m.loadItemsTask.genreIds = ""
+    else if LCase(m.view) = "albumartistsgrid" or LCase(m.options.view) = "albumartistsgrid"
+        m.loadItemsTask.genreIds = ""
+    else if LCase(m.view) = "albumartistspresentation" or LCase(m.options.view) = "albumartistspresentation"
+        m.loadItemsTask.genreIds = ""
+        m.top.showItemTitles = "hidealways"
     else
         m.loadItemsTask.itemId = m.top.parentItem.Id
     end if
@@ -179,6 +184,12 @@ sub loadInitialItems()
     else if LCase(m.options.view) = "artistsgrid" or LCase(m.view) = "artistsgrid"
         m.itemGrid.translation = "[96, 60]"
         m.itemGrid.numRows = "4"
+    else if LCase(m.options.view) = "albumartistsgrid" or LCase(m.view) = "albumartistsgrid"
+        m.loadItemsTask.itemType = "AlbumArtists"
+        m.itemGrid.translation = "[96, 60]"
+        m.itemGrid.numRows = "4"
+    else if LCase(m.options.view) = "albumartistspresentation" or LCase(m.view) = "albumartistspresentation"
+        m.loadItemsTask.itemType = "AlbumArtists"
     else if LCase(m.options.view) = "genres" or LCase(m.view) = "genres"
         m.loadItemsTask.itemType = ""
         m.loadItemsTask.recursive = true
@@ -206,6 +217,8 @@ sub setMusicOptions(options)
     options.views = [
         { "Title": tr("Artists (Presentation)"), "Name": "ArtistsPresentation" },
         { "Title": tr("Artists (Grid)"), "Name": "ArtistsGrid" },
+        { "Title": tr("Album Artists (Presentation)"), "Name": "AlbumArtistsPresentation" },
+        { "Title": tr("Album Artists (Grid)"), "Name": "AlbumArtistsGrid" },
         { "Title": tr("Albums"), "Name": "Albums" },
         { "Title": tr("Genres"), "Name": "Genres" }
     ]
@@ -446,6 +459,10 @@ sub onItemFocused()
     end if
 
     if LCase(m.options.view) = "artistsgrid" or LCase(m.view) = "artistsgrid"
+        return
+    end if
+
+    if LCase(m.options.view) = "albumartistsgrid" or LCase(m.view) = "albumartistsgrid"
         return
     end if
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -979,8 +979,16 @@
             <translation>Artists (Presentation)</translation>
         </message>
         <message>
+            <source>Album Artists (Presentation)</source>
+            <translation>Album Artists (Presentation)</translation>
+        </message>
+        <message>
             <source>Artists (Grid)</source>
             <translation>Artists (Grid)</translation>
+        </message>
+        <message>
+            <source>Album Artists (Grid)</source>
+            <translation>Album Artists (Grid)</translation>
         </message>
         <message>
             <source>Song</source>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Creates an Album Artist view for music libraries. Both Presentation and Grid layouts are supported.

Widens the option items to support longer view options, and widens the sort and filter options so they are consistent.

## Issues
Fixes #972
