### PR TITLE
Add current playback time and song length to the sides of the audio progress bar

### DIFF
--- a/components/music/AudioPlayerView.brs
+++ b/components/music/AudioPlayerView.brs
@@ -114,6 +114,8 @@ sub setupInfoNodes()
     m.numberofsongsField = m.top.findNode("numberofsongs")
     m.shuffleIndicator = m.top.findNode("shuffleIndicator")
     m.loopIndicator = m.top.findNode("loopIndicator")
+    m.positionTimestamp = m.top.findNode("positionTimestamp")
+    m.totalLengthTimestamp = m.top.findNode("totalLengthTimestamp")
 end sub
 
 sub bufferPositionChanged()
@@ -155,6 +157,13 @@ sub audioPositionChanged()
     ' Use animation to make the display smooth
     m.playPositionAnimationWidth.keyValue = [m.playPosition.width, playPositionBarWidth]
     m.playPositionAnimation.control = "start"
+
+    ' Update displayed position timestamp
+    if isValid(m.global.audioPlayer.position)
+        m.positionTimestamp.text = secondsToHuman(m.global.audioPlayer.position)
+    else
+        m.positionTimestamp.text = "0:00"
+    end if
 
     ' Only fall into screensaver logic if the user has screensaver enabled in Roku settings
     if m.screenSaverTimeout > 0
@@ -415,6 +424,9 @@ sub pageContentChanged()
         setScreenTitle(currentItem)
         setOnScreenTextValues(currentItem)
         m.songDuration = currentItem.RunTimeTicks / 10000000.0
+
+        ' Update displayed total audio length
+        m.totalLengthTimestamp.text = ticksToHuman(currentItem.RunTimeTicks)
     end if
 
     m.LoadAudioStreamTask.itemId = currentItem.id
@@ -470,6 +482,9 @@ sub onMetaDataLoaded()
 
         if isValid(data.json.RunTimeTicks)
             m.songDuration = data.json.RunTimeTicks / 10000000.0
+
+            ' Update displayed total audio length
+            m.totalLengthTimestamp.text = ticksToHuman(data.json.RunTimeTicks)
         end if
     end if
 end sub

--- a/components/music/AudioPlayerView.xml
+++ b/components/music/AudioPlayerView.xml
@@ -4,6 +4,8 @@
     <Poster id="backdrop" opacity=".5" loadDisplayMode="scaleToZoom" width="1920" height="1200" blendColor="#3f3f3f" />
     <Poster id="shuffleIndicator" width="64" height="64" uri="pkg:/images/icons/shuffleIndicator-off.png" translation="[1150,775]" opacity="0" />
     <Poster id="loopIndicator" width="64" height="64" uri="pkg:/images/icons/loopIndicator-off.png" translation="[700,775]" opacity="0" />
+    <Label id="positionTimestamp" width="100" height="25" horizAlign="right" font="font:SmallestSystemFont" translation="[590,825]" color="#999999" text="0:00" />
+    <Label id="totalLengthTimestamp" width="100" height="25" horizAlign="left" font="font:SmallestSystemFont" translation="[1230,825]" color="#999999" />
     <LayoutGroup id="toplevel" layoutDirection="vert" horizAlignment="center" translation="[960,175]" itemSpacings="[40]">
       <LayoutGroup id="main_group" layoutDirection="vert" horizAlignment="center" itemSpacings="[15]">
         <Poster id="albumCover" width="500" height="500" />

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -41,6 +41,18 @@ function ticksToHuman(ticks as longinteger) as string
     return r
 end function
 
+function secondsToHuman(totalSeconds as integer) as string
+    hours = stri(int(totalSeconds / 3600)).trim()
+    minutes = stri(int((totalSeconds - (val(hours) * 3600)) / 60)).trim()
+    seconds = stri(totalSeconds - (val(hours) * 3600) - (val(minutes) * 60)).trim()
+    if val(hours) > 0 and val(minutes) < 10 then minutes = "0" + minutes
+    if val(seconds) < 10 then seconds = "0" + seconds
+    r = ""
+    if val(hours) > 0 then r = hours + ":"
+    r = r + minutes + ":" + seconds
+    return r
+end function
+
 ' Format time as 12 or 24 hour format based on system clock setting
 function formatTime(time) as string
     hours = time.getHours()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
On the audio player view adds the current playback timestamp to the left of the progress bar, and adds the total song length to the right of the progress bar.

## Issues
Fixes #1170
