### PR TITLE
Fix music shuffle function

### DIFF
--- a/components/manager/QueueManager.brs
+++ b/components/manager/QueueManager.brs
@@ -1,7 +1,9 @@
 sub init()
     m.queue = []
+    m.originalQueue = []
     m.queueTypes = []
     m.position = 0
+    m.shuffleEnabled = false
 end sub
 
 ' Clear all content from play queue
@@ -25,6 +27,11 @@ end function
 ' Return the item currently in focus from the play queue
 function getCurrentItem()
     return getItemByIndex(m.position)
+end function
+
+' Return whether or not shuffle is enabled
+function getIsShuffled()
+    return m.shuffleEnabled
 end function
 
 ' Return the item in the passed index from the play queue
@@ -108,6 +115,54 @@ sub setPosition(newPosition)
     m.position = newPosition
 end sub
 
+' Reset shuffle to off state
+sub resetShuffle()
+    m.shuffleEnabled = false
+end sub
+
+' Toggle shuffleEnabled state
+sub toggleShuffle()
+    m.shuffleEnabled = not m.shuffleEnabled
+
+    if m.shuffleEnabled
+        shuffleQueueItems()
+        return
+    end if
+
+    resetQueueItemOrder()
+end sub
+
+' Reset queue items back to original, unshuffled order
+sub resetQueueItemOrder()
+    set(m.originalQueue)
+end sub
+
+' Return original, unshuffled queue
+function getUnshuffledQueue()
+    return m.originalQueue
+end function
+
+' Save a copy of the original queue and randomize order of queue items
+sub shuffleQueueItems()
+    ' By calling getQueue 2 different ways, Roku avoids needing to do a deep copy
+    m.originalQueue = m.global.queueManager.callFunc("getQueue")
+    songIDArray = getQueue()
+
+    ' Move the currently playing song to the front of the queue
+    temp = top()
+    songIDArray[0] = getCurrentItem()
+    songIDArray[getPosition()] = temp
+
+    for i = 1 to songIDArray.count() - 1
+        j = Rnd(songIDArray.count() - 1)
+        temp = songIDArray[i]
+        songIDArray[i] = songIDArray[j]
+        songIDArray[j] = temp
+    end for
+
+    set(songIDArray)
+end sub
+
 ' Return the fitst item in the play queue
 function top()
     return getItemByIndex(0)
@@ -115,7 +170,7 @@ end function
 
 ' Replace play queue with passed array
 sub set(items)
-    setPosition(0)
+    clear()
     m.queue = items
     for each item in items
         m.queueTypes.push(getItemType(item))

--- a/components/manager/QueueManager.xml
+++ b/components/manager/QueueManager.xml
@@ -5,19 +5,23 @@
     <function name="deleteAtIndex" />
     <function name="getCount" />
     <function name="getCurrentItem" />
+    <function name="getIsShuffled" />
     <function name="getItemByIndex" />
     <function name="getPosition" />
     <function name="getQueue" />
     <function name="getQueueTypes" />
     <function name="getQueueUniqueTypes" />
+    <function name="getUnshuffledQueue" />
     <function name="moveBack" />
     <function name="moveForward" />
     <function name="peek" />
     <function name="playQueue" />
     <function name="pop" />
     <function name="push" />
+    <function name="resetShuffle" />
     <function name="set" />
     <function name="setPosition" />
+    <function name="toggleShuffle" />
     <function name="top" />
   </interface>
   <script type="text/brightscript" uri="QueueManager.brs" />

--- a/components/music/AudioPlayerView.brs
+++ b/components/music/AudioPlayerView.brs
@@ -112,7 +112,6 @@ sub setupInfoNodes()
     m.playPosition = m.top.findNode("playPosition")
     m.bufferPosition = m.top.findNode("bufferPosition")
     m.seekBar = m.top.findNode("seekBar")
-    m.numberofsongsField = m.top.findNode("numberofsongs")
     m.shuffleIndicator = m.top.findNode("shuffleIndicator")
     m.loopIndicator = m.top.findNode("loopIndicator")
 end sub
@@ -339,13 +338,13 @@ function shuffleClicked() as boolean
         m.shuffleIndicator.opacity = ".4"
         m.shuffleIndicator.uri = m.shuffleIndicator.uri.Replace("-on", "-off")
         m.global.queueManager.callFunc("setPosition", currentSongIndex)
-        setFieldTextValue("numberofsongs", "Track " + stri(m.global.queueManager.callFunc("getPosition") + 1) + "/" + stri(m.global.queueManager.callFunc("getCount")))
-
+        setTrackNumberDisplay()
         return true
     end if
 
     m.shuffleIndicator.opacity = "1"
     m.shuffleIndicator.uri = m.shuffleIndicator.uri.Replace("-off", "-on")
+    setTrackNumberDisplay()
 
     return true
 end function
@@ -355,6 +354,10 @@ sub setShuffleIconState()
         m.shuffleIndicator.opacity = "1"
         m.shuffleIndicator.uri = m.shuffleIndicator.uri.Replace("-off", "-on")
     end if
+end sub
+
+sub setTrackNumberDisplay()
+    setFieldTextValue("numberofsongs", "Track " + stri(m.global.queueManager.callFunc("getPosition") + 1) + "/" + stri(m.global.queueManager.callFunc("getCount")))
 end sub
 
 sub LoadNextSong()
@@ -498,14 +501,8 @@ end sub
 ' Populate on screen text variables
 sub setOnScreenTextValues(json)
     if isValid(json)
-        currentSongIndex = m.global.queueManager.callFunc("getPosition")
-
-        if m.global.queueManager.callFunc("getIsShuffled")
-            currentSongIndex = findCurrentSongIndex(m.global.queueManager.callFunc("getUnshuffledQueue"))
-        end if
-
         if m.playlistTypeCount = 1
-            setFieldTextValue("numberofsongs", "Track " + stri(currentSongIndex + 1) + "/" + stri(m.global.queueManager.callFunc("getCount")))
+            setTrackNumberDisplay()
         end if
 
         setFieldTextValue("artist", json.Artists[0])

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -239,6 +239,7 @@ sub Main (args as dynamic) as void
                 group = CreatePlaylistView(selectedItem.json)
             else if selectedItem.type = "Audio"
                 m.global.queueManager.callFunc("clear")
+                m.global.queueManager.callFunc("resetShuffle")
                 m.global.queueManager.callFunc("push", selectedItem.json)
                 m.global.queueManager.callFunc("playQueue")
             else
@@ -280,6 +281,7 @@ sub Main (args as dynamic) as void
             screenContent = msg.getRoSGNode()
 
             m.global.queueManager.callFunc("clear")
+            m.global.queueManager.callFunc("resetShuffle")
             m.global.queueManager.callFunc("push", screenContent.albumData.items[selectedIndex])
             m.global.queueManager.callFunc("playQueue")
         else if isNodeEvent(msg, "playItem")
@@ -288,6 +290,7 @@ sub Main (args as dynamic) as void
             screenContent = msg.getRoSGNode()
 
             m.global.queueManager.callFunc("clear")
+            m.global.queueManager.callFunc("resetShuffle")
             m.global.queueManager.callFunc("push", screenContent.albumData.items[selectedIndex])
             m.global.queueManager.callFunc("playQueue")
         else if isNodeEvent(msg, "playAllSelected")
@@ -297,6 +300,7 @@ sub Main (args as dynamic) as void
             m.spinner.visible = true
 
             m.global.queueManager.callFunc("clear")
+            m.global.queueManager.callFunc("resetShuffle")
             m.global.queueManager.callFunc("set", screenContent.albumData.items)
             m.global.queueManager.callFunc("playQueue")
         else if isNodeEvent(msg, "playArtistSelected")
@@ -304,6 +308,7 @@ sub Main (args as dynamic) as void
             screenContent = msg.getRoSGNode()
 
             m.global.queueManager.callFunc("clear")
+            m.global.queueManager.callFunc("resetShuffle")
             m.global.queueManager.callFunc("set", CreateArtistMix(screenContent.pageContent.id).Items)
             m.global.queueManager.callFunc("playQueue")
 
@@ -323,6 +328,7 @@ sub Main (args as dynamic) as void
                 if isValid(screenContent.albumData.items)
                     if screenContent.albumData.items.count() > 0
                         m.global.queueManager.callFunc("clear")
+                        m.global.queueManager.callFunc("resetShuffle")
                         m.global.queueManager.callFunc("set", CreateInstantMix(screenContent.albumData.items[0].id).Items)
                         m.global.queueManager.callFunc("playQueue")
 
@@ -334,6 +340,7 @@ sub Main (args as dynamic) as void
             if not viewHandled
                 ' Create instant mix based on selected artist
                 m.global.queueManager.callFunc("clear")
+                m.global.queueManager.callFunc("resetShuffle")
                 m.global.queueManager.callFunc("set", CreateInstantMix(screenContent.pageContent.id).Items)
                 m.global.queueManager.callFunc("playQueue")
             end if
@@ -381,6 +388,7 @@ sub Main (args as dynamic) as void
                 group = CreateAlbumView(node.json)
             else if node.type = "Audio"
                 m.global.queueManager.callFunc("clear")
+                m.global.queueManager.callFunc("resetShuffle")
                 m.global.queueManager.callFunc("push", node.json)
                 m.global.queueManager.callFunc("playQueue")
             else if node.type = "Person"
@@ -395,6 +403,7 @@ sub Main (args as dynamic) as void
                 selectedIndex = msg.getData()
                 screenContent = msg.getRoSGNode()
                 m.global.queueManager.callFunc("clear")
+                m.global.queueManager.callFunc("resetShuffle")
                 m.global.queueManager.callFunc("push", screenContent.albumData.items[node.id])
                 m.global.queueManager.callFunc("playQueue")
             else


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes music shuffle functionality. Moves shuffle responsibility out of audio player view and to the queue manager.

## Issues
Fixes #1172
