### PR TITLE
Add valid checks to fallback font api call

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -68,7 +68,7 @@ sub Main (args as dynamic) as void
             filename = APIRequest("FallbackFont/Fonts").GetToString()
             if isValid(filename)
                 filename = re.match(filename)
-                if filename.count() > 0
+                if isValid(filename) and filename.count() > 0
                     filename = filename[1]
                     APIRequest("FallbackFont/Fonts/" + filename).gettofile("tmp:/font")
                 end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -60,13 +60,19 @@ sub Main (args as dynamic) as void
     m.scene.observeField("exit", m.port)
 
     ' Downloads and stores a fallback font to tmp:/
-    if parseJSON(APIRequest("/System/Configuration/encoding").GetToString())["EnableFallbackFont"] = true
-        re = CreateObject("roRegex", "Name.:.(.*?).,.Size", "s")
-        filename = APIRequest("FallbackFont/Fonts").GetToString()
-        filename = re.match(filename)
-        if filename.count() > 0
-            filename = filename[1]
-            APIRequest("FallbackFont/Fonts/" + filename).gettofile("tmp:/font")
+    configEncoding = api_API().system.getconfigurationbyname("encoding")
+
+    if isValid(configEncoding) and isValid(configEncoding.EnableFallbackFont)
+        if configEncoding.EnableFallbackFont
+            re = CreateObject("roRegex", "Name.:.(.*?).,.Size", "s")
+            filename = APIRequest("FallbackFont/Fonts").GetToString()
+            if isValid(filename)
+                filename = re.match(filename)
+                if filename.count() > 0
+                    filename = filename[1]
+                    APIRequest("FallbackFont/Fonts/" + filename).gettofile("tmp:/font")
+                end if
+            end if
         end if
     end if
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Checks fallback font API call returns valid before using returned property.

## Issues
Fixes #1177
