### PR TITLE
Fix episode reporting for Next Up data

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -28,8 +28,6 @@ sub init()
     m.getNextEpisodeTask = createObject("roSGNode", "GetNextEpisodeTask")
     m.getNextEpisodeTask.observeField("nextEpisodeData", "onNextEpisodeDataLoaded")
 
-    m.top.observeField("state", "onState")
-    m.top.observeField("content", "onContentChange")
     m.top.observeField("allowCaptions", "onAllowCaptionsChange")
 end sub
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Removes duplicated observeField() calls, which resulted in episode reporting not working properly with Next Up API calls.

## Issues
Fixes #1186
