### PR TITLE
Remove unneeded RunTime property from Video Components

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -44,7 +44,6 @@ sub LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtit
     videotype = LCase(meta.type)
 
     if videotype = "episode" or videotype = "series"
-        video.runTime = (meta.json.RunTimeTicks / 10000000.0)
         video.content.contenttype = "episode"
     end if
 

--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -100,7 +100,7 @@ end sub
 '
 'Update count down text
 sub updateCount()
-    nextEpisodeCountdown = Int(m.top.runTime - m.top.position)
+    nextEpisodeCountdown = Int(m.top.duration - m.top.position)
     if nextEpisodeCountdown < 0
         nextEpisodeCountdown = 0
     end if
@@ -119,7 +119,7 @@ end sub
 sub checkTimeToDisplayNextEpisode()
     if m.top.content.contenttype <> 4 then return
 
-    if int(m.top.position) >= (m.top.runTime - 30)
+    if int(m.top.position) >= (m.top.duration - 30)
         showNextEpisodeButton()
         updateCount()
         return

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -22,8 +22,6 @@
     <field id="videoId" type="string" />
     <field id="mediaSourceId" type="string" />
     <field id="audioIndex" type="integer" />
-    <field id="runTime" type="integer" />
-
   </interface>
   <script type="text/brightscript" uri="JFVideo.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -23,7 +23,6 @@
     <field id="videoId" type="string" />
     <field id="mediaSourceId" type="string" />
     <field id="audioIndex" type="integer" />
-    <field id="runTime" type="integer" />
   </interface>
   <script type="text/brightscript" uri="VideoPlayerView.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -47,9 +47,6 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     if m.videotype = "Episode" or m.videotype = "Series"
-        if isValid(meta.json) and isValid(meta.json.RunTimeTicks)
-            video.runTime = (meta.json.RunTimeTicks / 10000000.0)
-        end if
         video.content.contenttype = "episode"
     end if
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Removes RunTime property from video components as it's a duplicate of a property that Roku automatically sets.

## Issues
Fixes #1190
