### PR TITLE
Refresh all home view data

### DIFF
--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -238,11 +238,6 @@ end sub
 '
 ' Draws and animates item progress bar
 sub drawProgressBar(itemData)
-
-    ' Don't redraw progress bar if it's already been drawn
-    ' Allow a slight tolerance for rounding issues.
-    if abs(m.itemProgress.width - (m.itemPoster.width * (itemData.PlayedPercentage / 100))) < 5 then return
-
     m.itemProgressBackground.width = itemData.imageWidth
     m.itemProgressBackground.visible = true
     m.showProgressBarField.keyValue = [0, m.itemPoster.width * (itemData.PlayedPercentage / 100)]

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -238,6 +238,11 @@ end sub
 '
 ' Draws and animates item progress bar
 sub drawProgressBar(itemData)
+
+    ' Don't redraw progress bar if it's already been drawn
+    ' Allow a slight tolerance for rounding issues.
+    if abs(m.itemProgress.width - (m.itemPoster.width * (itemData.PlayedPercentage / 100))) < 5 then return
+
     m.itemProgressBackground.width = itemData.imageWidth
     m.itemProgressBackground.visible = true
     m.showProgressBarField.keyValue = [0, m.itemPoster.width * (itemData.PlayedPercentage / 100)]

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -148,8 +148,9 @@ sub updateHomeRows()
     else
         m.global.playstateTask.unobserveField("state")
     end if
-    m.LoadContinueTask.observeField("content", "updateContinueItems")
-    m.LoadContinueTask.control = "RUN"
+
+    m.LoadLibrariesTask.observeField("content", "onLibrariesLoaded")
+    m.LoadLibrariesTask.control = "RUN"
 end sub
 
 sub updateFavoritesItems()

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -234,10 +234,6 @@ sub updateNextUpItems()
     m.LoadNextUpTask.unobserveField("content")
     m.LoadNextUpTask.content = []
 
-    print "updateNextUpItems()"
-
-    print itemData
-
     if itemData = invalid then return
 
     homeRows = m.top.content

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -131,9 +131,10 @@ end sub
 sub updateHomeRows()
     if m.global.playstateTask.state = "run"
         m.global.playstateTask.observeField("state", "updateHomeRows")
-    else
-        m.global.playstateTask.unobserveField("state")
+        return
     end if
+
+    m.global.playstateTask.unobserveField("state")
 
     m.LoadContinueTask.observeField("content", "updateContinueItems")
     m.LoadContinueTask.control = "RUN"


### PR DESCRIPTION
## Changes
When refresh is called, refresh all home data, for all rows.

This rolls back changes made to homerows.brs that converted the data loads from linear to async.

## Issues
Fixes #1184