### PR TITLE
Replace API check marks for watched items on home view

### DIFF
--- a/components/PlayedCheckmark.brs
+++ b/components/PlayedCheckmark.brs
@@ -1,0 +1,4 @@
+sub init()
+    m.checkmark = m.top.findNode("checkmark")
+    m.checkmark.font.size = 35
+end sub

--- a/components/PlayedCheckmark.brs
+++ b/components/PlayedCheckmark.brs
@@ -1,4 +1,4 @@
 sub init()
-    m.checkmark = m.top.findNode("checkmark")
-    m.checkmark.font.size = 35
+    checkmark = m.top.findNode("checkmark")
+    checkmark.font.size = 48
 end sub

--- a/components/PlayedCheckmark.xml
+++ b/components/PlayedCheckmark.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="PlayedCheckmark" extends="Rectangle">
   <children>
-    <Label id="checkmark" width="60" height="42" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="bottom" text="✓" />
+    <Label id="checkmark" width="60" height="50" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="bottom" text="✓" />
   </children>
   <script type="text/brightscript" uri="PlayedCheckmark.brs" />
 </component>

--- a/components/PlayedCheckmark.xml
+++ b/components/PlayedCheckmark.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="PlayedCheckmark" extends="Rectangle">
+  <children>
+    <Label id="checkmark" width="60" height="42" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="bottom" text="✓" />
+  </children>
+  <script type="text/brightscript" uri="PlayedCheckmark.brs" />
+</component>

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -28,7 +28,7 @@ sub setData()
         end if
 
     else if datum.type = "Episode"
-        m.top.watched = datum.UserData.Played
+        m.top.isWatched = datum.UserData.Played
 
         imgParams = {}
         imgParams.Append({ "maxHeight": 261 })
@@ -69,7 +69,7 @@ sub setData()
         end if
 
     else if datum.type = "Movie"
-        m.top.watched = datum.UserData.Played
+        m.top.isWatched = datum.UserData.Played
 
         imgParams = {}
         imgParams.Append({ "maxHeight": 261 })
@@ -94,7 +94,7 @@ sub setData()
         end if
 
     else if datum.type = "Video"
-        m.top.watched = datum.UserData.Played
+        m.top.isWatched = datum.UserData.Played
 
         imgParams = {}
         imgParams.Append({ "maxHeight": 261 })

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -28,8 +28,9 @@ sub setData()
         end if
 
     else if datum.type = "Episode"
-        imgParams = { "AddPlayedIndicator": datum.UserData.Played }
+        m.top.watched = datum.UserData.Played
 
+        imgParams = {}
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 464 })
 
@@ -68,8 +69,9 @@ sub setData()
         end if
 
     else if datum.type = "Movie"
-        imgParams = { AddPlayedIndicator: datum.UserData.Played }
+        m.top.watched = datum.UserData.Played
 
+        imgParams = {}
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 175 })
 
@@ -92,8 +94,9 @@ sub setData()
         end if
 
     else if datum.type = "Video"
-        imgParams = { AddPlayedIndicator: datum.UserData.Played }
+        m.top.watched = datum.UserData.Played
 
+        imgParams = {}
         imgParams.Append({ "maxHeight": 261 })
         imgParams.Append({ "maxWidth": 175 })
 

--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -13,7 +13,7 @@
     <field id="imageWidth" type="integer" value="464" />
     <field id="PlayedPercentage" type="float" value="0" />
     <field id="usePoster" type="bool" value="false" />
-    <field id="watched" type="bool" value="false" />
+    <field id="isWatched" type="bool" value="false" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />

--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="HomeData" extends="ContentNode">
   <interface>
     <field id="id" type="string" />
@@ -13,6 +13,7 @@
     <field id="imageWidth" type="integer" value="464" />
     <field id="PlayedPercentage" type="float" value="0" />
     <field id="usePoster" type="bool" value="false" />
+    <field id="watched" type="bool" value="false" />
   </interface>
   <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
   <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -9,6 +9,7 @@ sub init()
     m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
     m.unplayedCount = m.top.findNode("unplayedCount")
     m.unplayedEpisodeCount = m.top.findNode("unplayedEpisodeCount")
+    m.playedIndicator = m.top.findNode("playedIndicator")
 
     m.showProgressBarAnimation = m.top.findNode("showProgressBar")
     m.showProgressBarField = m.top.findNode("showProgressBarField")
@@ -37,12 +38,19 @@ sub itemContentChanged()
         m.itemIcon.uri = itemData.iconUrl
     end if
 
-    if LCase(itemData.type) = "series"
-        if get_user_setting("ui.tvshows.disableUnwatchedEpisodeCount", "false") = "false"
-            if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
-                if itemData.json.UserData.UnplayedItemCount > 0
-                    m.unplayedCount.visible = true
-                    m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+    if itemData.watched
+        m.playedIndicator.visible = true
+        m.unplayedCount.visible = false
+    else
+        m.playedIndicator.visible = false
+
+        if LCase(itemData.type) = "series"
+            if get_user_setting("ui.tvshows.disableUnwatchedEpisodeCount", "false") = "false"
+                if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
+                    if itemData.json.UserData.UnplayedItemCount > 0
+                        m.unplayedCount.visible = true
+                        m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+                    end if
                 end if
             end if
         end if

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -38,7 +38,7 @@ sub itemContentChanged()
         m.itemIcon.uri = itemData.iconUrl
     end if
 
-    if itemData.watched
+    if itemData.isWatched
         m.playedIndicator.visible = true
         m.unplayedCount.visible = false
     else
@@ -72,6 +72,8 @@ sub itemContentChanged()
         return
     end if
 
+    playedIndicatorLeftPosition = m.itemPoster.width - 60
+    m.playedIndicator.translation = [playedIndicatorLeftPosition, 0]
 
     m.itemText.height = 34
     m.itemText.font.size = 25

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -7,6 +7,7 @@
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[375, 0]">
         <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
+      <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" translation="[405, 0]" />
     </Poster>
     <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[8,260]">
       <Rectangle id="progress" color="#00a4dcFF" width="0" height="8" />

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -7,7 +7,7 @@
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[375, 0]">
         <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
-      <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" translation="[405, 0]" />
+      <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" />
     </Poster>
     <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[8,260]">
       <Rectangle id="progress" color="#00a4dcFF" width="0" height="8" />

--- a/manifest
+++ b/manifest
@@ -5,8 +5,6 @@ major_version=1
 minor_version=6
 build_version=5
 
-run_as_process=1
-
 ### Main Menu Icons / Channel Poster Artwork
 
 mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png

--- a/manifest
+++ b/manifest
@@ -5,6 +5,8 @@ major_version=1
 minor_version=6
 build_version=5
 
+run_as_process=1
+
 ### Main Menu Icons / Channel Poster Artwork
 
 mm_icon_focus_fhd=pkg:/images/channel-poster_fhd.png


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Updates check marks on watched items on the home view to not use the API played indicator, but the PlayedIndicator component. 

This is 1 of many PRs I'll be opening to add this component across the client. I want to keep the PRs small to make testing easier.

## Issues
This is part of the set of fixes for #402
