### PR TITLE
Add support for ass format subtitles for custom caption (reopen)

### DIFF
--- a/components/captionTask.brs
+++ b/components/captionTask.brs
@@ -39,12 +39,17 @@ end sub
 
 sub fetchCaption()
     m.captionTimer.control = "stop"
-    re = CreateObject("roRegex", "(http.*?\.vtt)", "s")
-    url = re.match(m.top.url)[0]
-    if url <> invalid
-        m.reader.setUrl(url)
+    re = CreateObject("roRegex", "(http.*?\.(vtt|ass))", "s")
+    url = re.match(m.top.url)
+    if url[0] <> invalid
+        m.reader.setUrl(url[0])
         text = m.reader.GetToString()
-        m.captionList = parseVTT(text)
+        subtype = url[2]
+        if subtype = "vtt"
+            m.captionList = parseVTT(text)
+        else if subtype = "ass"
+            m.captionList = parseASS(text)
+        end if
         m.captionTimer.control = "start"
     else
         m.captionTimer.control = "stop"
@@ -143,5 +148,65 @@ function parseVTT(lines)
             end if
         end if
     end for
+    return entries
+end function
+
+function trimASSText(text)
+    text = text.trim()
+    ' filter out style override
+    ' TODO: honor the style and style override
+    ' TODO: inline comments
+    re = CreateObject("roRegex", "\{(?:[^}{]+|(?R))*+\}", "s")
+    text = re.ReplaceAll(text, "")
+    return text
+end function
+
+function parseASS(lines)
+    lines = lines.split(chr(10))
+
+    reFormat = CreateObject("roRegex", "Format: (.*)", "s")
+    reLine = CreateObject("roRegex", "Dialogue: (.*)", "s")
+
+    startIndex = -1
+    endIndex = -1
+    textIndex = -1
+
+    entries = []
+
+    for i = 0 to lines.count() - 1
+        format = reFormat.match(lines[i])[1]
+        if format <> invalid
+            format = format.tokenize(",")
+            for j = 0 to format.count() - 1
+                f = format[j].trim()
+                if f = "Start"
+                    startIndex = j
+                else if f = "End"
+                    endIndex = j
+                else if f = "Text"
+                    ' Text should always be the last field
+                    textIndex = j
+                end if
+            end for
+        end if
+
+        if startIndex <> -1
+            dialoge = reLine.match(lines[i])[1]
+            if dialoge <> invalid
+                dialoge = dialoge.split(",")
+                msStart = toMs(dialoge[startIndex].trim())
+                msEnd = toMs(dialoge[endIndex].trim())
+                text = []
+                for j = textIndex to dialoge.count() - 1
+                    text.push(dialoge[j])
+                end for
+                trimmed = trimASSText(text.join(","))
+
+                entry = { "start": msStart, "end": msEnd, "text": trimmed }
+                entries.push(entry)
+            end if
+        end if
+    end for
+
     return entries
 end function

--- a/components/captionTask.xml
+++ b/components/captionTask.xml
@@ -7,6 +7,7 @@
               <field id="currentPos" type="int" />
        </interface>
        <script type="text/brightscript" uri="captionTask.brs" />
+       <script type="text/brightscript" uri="pkg:/source/utils/misc.brs" />
        <script type="text/brightscript" uri="pkg:/source/utils/config.brs" />
        <script type="text/brightscript" uri="pkg:/source/api/baserequest.brs" />
        <children>

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -252,6 +252,14 @@ function getDeviceProfile() as object
         })
     end if
 
+    ' Allow more subtitles types to be streamed without transcoding
+    if get_user_setting("playback.subs.custom") = "true"
+        deviceProfile.SubtitleProfiles.push({
+            "Format": "ass",
+            "Method": "External"
+        })
+    end if
+
     return deviceProfile
 end function
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
This patch add support for parsing and rendering ass format subtitles. Reopen of #1075.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
- Modify `deviceCapabilities` to allow direct stream ass subtitle tracks without transcoding, when `playback.subs.custom` is enabled.
- Add simple ass file parser. Currently only hard linebreak ("\N") is handled by parser. All style control sequences and drawing instructions are ignored.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
- Currently the parser simply translate ass Dialogue instructions to pure texts, ignoring any other style in the Text field. As the renderer is customized its possible to honor ass style.
- Complex ass style/effects could cause slowdown when parsing and playing subtitles. 