### PR TITLE
Fix screensaver activation

### DIFF
--- a/components/mediaPlayers/AudioPlayer.brs
+++ b/components/mediaPlayers/AudioPlayer.brs
@@ -1,6 +1,5 @@
 sub init()
     m.playReported = false
-    m.top.disableScreenSaver = true
     m.top.observeField("state", "audioStateChanged")
 end sub
 
@@ -9,6 +8,8 @@ sub audioStateChanged()
     currentState = LCase(m.top.state)
 
     reportedPlaybackState = "update"
+
+    m.top.disableScreenSaver = (currentState = "playing")
 
     if currentState = "playing" and not m.playReported
         reportedPlaybackState = "start"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes screensaver behavior so the following is true

If music is playing: Custom screensaver
Else: Roku screensaver

## Issues
Fixes #1230
