### PR TITLE
Wrap alpha menu

### DIFF
--- a/components/ItemGrid/Alpha.brs
+++ b/components/ItemGrid/Alpha.brs
@@ -24,5 +24,20 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
         return true
     end if
+
+    if key = "up"
+        if m.Alphamenu.itemFocused = 0
+            m.Alphamenu.jumpToItem = m.Alphamenu.numRows - 1
+            return true
+        end if
+    end if
+
+    if key = "down"
+        if m.Alphamenu.itemFocused = m.Alphamenu.numRows - 1
+            m.Alphamenu.jumpToItem = 0
+            return true
+        end if
+    end if
+
     return false
 end function


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Makes it so pressing up while on the top of the alpha menu brings you down to the last letter, and pressing down while on the bottom of the alpha menu brings you up to the first letter.


## Issues
Fixes #1210
