### PR TITLE
Rollback roku-log to v0.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "bgv": "npm:button-group-vert@1.0.2",
         "brighterscript-formatter": "1.6.27",
         "intKeyboard": "npm:integer-keyboard@1.0.12",
-        "log": "npm:roku-log@0.10.1",
+        "log": "npm:roku-log@0.9.3",
         "sob": "npm:slide-out-button@1.0.1"
       },
       "devDependencies": {
@@ -651,8 +651,7 @@
       "name": "@rokucommunity/bslib",
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
-      "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA==",
-      "dev": true
+      "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -2153,11 +2152,11 @@
     },
     "node_modules/log": {
       "name": "roku-log",
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/roku-log/-/roku-log-0.10.1.tgz",
-      "integrity": "sha512-kueRBu2CC+REPVU3OJQ0AcHDcv9XxZKSOtGUGVS+/rMo5Wu7PavMhKfK5si1QtwlPyZvYsDWeN9UEoF7rhFD6w==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/roku-log/-/roku-log-0.9.3.tgz",
+      "integrity": "sha512-YzvtSCdmZJeimyZZ/C5Y7tdw6vpNMrZV90pg8EPn3vLAtRjtxN3dOt73s48BVOx2W00M0BEGmeaECObS2RdIqg==",
       "dependencies": {
-        "@rokucommunity/bslib": "^0.1.1"
+        "bslib": "npm:@rokucommunity/bslib@^0.1.1"
       }
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bgv": "npm:button-group-vert@1.0.2",
     "brighterscript-formatter": "1.6.27",
     "intKeyboard": "npm:integer-keyboard@1.0.12",
-    "log": "npm:roku-log@0.10.1",
+    "log": "npm:roku-log@0.9.3",
     "sob": "npm:slide-out-button@1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Using the latest version of roku-log (v0.10.1) prevents the app from compiling. Rollback to the latest working version - v0.9.3


![compile-error-bslib](https://user-images.githubusercontent.com/16514652/236628806-8e4af1fe-bbeb-497d-8c6b-75b545dd0111.PNG)
