### PR TITLE
Respect user's audio preference from the server

### DIFF
--- a/components/data/ChannelData.xml
+++ b/components/data/ChannelData.xml
@@ -2,6 +2,6 @@
 <component name="ChannelData" extends="JFContentItem">
   <interface>
     <field id="channelID" type="string" />
-    <field id="selectedAudioStreamIndex" type="integer" value="1" />
+    <field id="selectedAudioStreamIndex" type="integer" value="0" />
   </interface>
 </component>

--- a/components/data/ExtrasData.xml
+++ b/components/data/ExtrasData.xml
@@ -19,7 +19,7 @@
     <field id="Type" type="string" />
     <field id="subTitle" type="string" />
     <field id="labelText" type="string" />
-    <field id="selectedAudioStreamIndex" type="integer" value="1" />
+    <field id="selectedAudioStreamIndex" type="integer" value="0" />
     <field id="posterUrl" type="string" />
     <field id="imageWidth" type="integer" value="234" />
     <field id="json" type="assocarray" />

--- a/components/data/HomeData.xml
+++ b/components/data/HomeData.xml
@@ -14,7 +14,7 @@
     <field id="PlayedPercentage" type="float" value="0" />
     <field id="usePoster" type="bool" value="false" />
     <field id="isWatched" type="bool" value="false" />
-    <field id="selectedAudioStreamIndex" type="integer" value="1" />
+    <field id="selectedAudioStreamIndex" type="integer" value="0" />
     <field id="startingPoint" type="longinteger" value="0" />
   </interface>
 </component>

--- a/components/data/MovieData.xml
+++ b/components/data/MovieData.xml
@@ -9,6 +9,6 @@
     <field id="mediaSources" type="array" />
     <field id="startingPoint" type="longinteger" value="0" />
     <field id="mediaSourceId" type="string" />
-    <field id="selectedAudioStreamIndex" type="integer" value="1" />
+    <field id="selectedAudioStreamIndex" type="integer" value="0" />
   </interface>
 </component>

--- a/components/data/PlaylistData.xml
+++ b/components/data/PlaylistData.xml
@@ -5,7 +5,7 @@
     <field id="title" type="string" />
     <field id="image" type="node" onChange="setPoster" />
     <field id="overview" type="string" />
-    <field id="selectedAudioStreamIndex" type="integer" value="1" />
+    <field id="selectedAudioStreamIndex" type="integer" value="0" />
     <field id="startingPoint" type="longinteger" value="0" />
   </interface>
 </component>

--- a/components/tvshows/TVEpisodeRowWithOptions.brs
+++ b/components/tvshows/TVEpisodeRowWithOptions.brs
@@ -35,8 +35,12 @@ end sub
 '
 'Check if options updated and any reloading required
 sub audioOptionsClosed()
-    if m.currentSelected <> invalid and m.tvListOptions.audioStreamIndex <> m.top.selectedAudioStreamIndex
-        m.top.objects.items[m.currentSelected].selectedAudioStreamIndex = m.tvListOptions.audioStreamIndex
+    if m.currentSelected <> invalid
+        ' If the user opened the audio options, we report back even if they left the selection alone.
+        ' Otherwise, the users' lang peference from the server will take over.
+        '
+        ' Note: If track 1 is selected, Roku reports "0", if another track is selected and user selects track 1, it reports "1"
+        m.top.objects.items[m.currentSelected].selectedAudioStreamIndex = m.tvListOptions.audioStreamIndex = 0 ? 1 : m.tvListOptions.audioStreamIndex
     end if
 end sub
 

--- a/components/tvshows/TVEpisodeRowWithOptions.brs
+++ b/components/tvshows/TVEpisodeRowWithOptions.brs
@@ -38,9 +38,7 @@ sub audioOptionsClosed()
     if m.currentSelected <> invalid
         ' If the user opened the audio options, we report back even if they left the selection alone.
         ' Otherwise, the users' lang peference from the server will take over.
-        '
-        ' Note: If track 1 is selected, Roku reports "0", if another track is selected and user selects track 1, it reports "1"
-        ' In other words, we force 0 to be "1" to let other parts of the code know that the user opened the Audio Options dialog. We can't report back "0" in this case.
+        ' To do this, we interpret anything other than "0" as the user opened the audio options.
         m.top.objects.items[m.currentSelected].selectedAudioStreamIndex = m.tvListOptions.audioStreamIndex = 0 ? 1 : m.tvListOptions.audioStreamIndex
     end if
 end sub

--- a/components/tvshows/TVEpisodeRowWithOptions.brs
+++ b/components/tvshows/TVEpisodeRowWithOptions.brs
@@ -40,6 +40,7 @@ sub audioOptionsClosed()
         ' Otherwise, the users' lang peference from the server will take over.
         '
         ' Note: If track 1 is selected, Roku reports "0", if another track is selected and user selects track 1, it reports "1"
+        ' In other words, we force 0 to be "1" to let other parts of the code know that the user opened the Audio Options dialog. We can't report back "0" in this case.
         m.top.objects.items[m.currentSelected].selectedAudioStreamIndex = m.tvListOptions.audioStreamIndex = 0 ? 1 : m.tvListOptions.audioStreamIndex
     end if
 end sub

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -121,9 +121,10 @@ sub Main (args as dynamic) as void
             itemNode = reportingNode.quickPlayNode
             if isValid(itemNode) and isValid(itemNode.id) and itemNode.id <> ""
                 if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
+                    audio_stream_idx = 0
                     if isValid(itemNode.selectedAudioStreamIndex) and itemNode.selectedAudioStreamIndex > 0
                         audio_stream_idx = itemNode.selectedAudioStreamIndex
-                    else
+                    else if isValid(itemNode.json) and isValid(itemNode.json.MediaStreams)
                         audio_stream_idx = FindPreferredAudioStream(itemNode.json.MediaStreams)
                     end if
 
@@ -187,9 +188,10 @@ sub Main (args as dynamic) as void
                     sceneManager.callFunc("pushScene", group)
                 else if selectedItemType = "Episode"
                     ' User has selected a TV episode they want us to play
+                    audio_stream_idx = 0
                     if isValid(selectedItem.selectedAudioStreamIndex) and selectedItem.selectedAudioStreamIndex > 0
                         audio_stream_idx = selectedItem.selectedAudioStreamIndex
-                    else
+                    else if isValid(selectedItem.json) and isValid(selectedItem.json.id)
                         audio_stream_idx = FindPreferredAudioStream(invalid, selectedItem.json.id)
                     end if
 

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -121,9 +121,10 @@ sub Main (args as dynamic) as void
             itemNode = reportingNode.quickPlayNode
             if isValid(itemNode) and isValid(itemNode.id) and itemNode.id <> ""
                 if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
-                    audio_stream_idx = 0
-                    if isValid(itemNode.selectedAudioStreamIndex)
+                    if isValid(itemNode.selectedAudioStreamIndex) and itemNode.selectedAudioStreamIndex > 0
                         audio_stream_idx = itemNode.selectedAudioStreamIndex
+                    else
+                        audio_stream_idx = FindPreferredAudioStream(itemNode.json.MediaStreams)
                     end if
 
                     itemNode.selectedAudioStreamIndex = audio_stream_idx
@@ -186,9 +187,10 @@ sub Main (args as dynamic) as void
                     sceneManager.callFunc("pushScene", group)
                 else if selectedItemType = "Episode"
                     ' User has selected a TV episode they want us to play
-                    audio_stream_idx = 0
-                    if isValid(selectedItem.selectedAudioStreamIndex)
+                    if isValid(selectedItem.selectedAudioStreamIndex) and selectedItem.selectedAudioStreamIndex > 0
                         audio_stream_idx = selectedItem.selectedAudioStreamIndex
+                    else
+                        audio_stream_idx = FindPreferredAudioStream(invalid, selectedItem.json.id)
                     end if
 
                     selectedItem.selectedAudioStreamIndex = audio_stream_idx
@@ -404,6 +406,7 @@ sub Main (args as dynamic) as void
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Episode"
+                audioPreference = FindPreferredAudioStream(invalid, node.id)
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Audio"

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -122,6 +122,10 @@ sub Main (args as dynamic) as void
             if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
                 if itemNode.type = "Episode" and itemNode.selectedAudioStreamIndex <> invalid and itemNode.selectedAudioStreamIndex > 1
                     video = CreateVideoPlayerGroup(itemNode.id, invalid, itemNode.selectedAudioStreamIndex)
+                else if get_user_setting("display.playback.AudioLanguagePreference") <> invalid
+                    langPreference = get_user_setting("display.playback.AudioLanguagePreference")
+                    preferredLang = FindPreferredAudioStream(itemNode.json.MediaStreams, langPreference)
+                    video = CreateVideoPlayerGroup(itemNode.id, invalid, preferredLang)
                 else
                     video = CreateVideoPlayerGroup(itemNode.id)
                 end if
@@ -610,3 +614,15 @@ sub Main (args as dynamic) as void
     end while
 
 end sub
+
+function FindPreferredAudioStream(streams, preferredLanguage)
+
+    for i = 0 to streams.Count() - 1
+        if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
+            return i
+        end if
+    end for
+
+    return 0
+
+end function

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -122,12 +122,9 @@ sub Main (args as dynamic) as void
             if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
                 if itemNode.type = "Episode" and itemNode.selectedAudioStreamIndex <> invalid and itemNode.selectedAudioStreamIndex > 1
                     video = CreateVideoPlayerGroup(itemNode.id, invalid, itemNode.selectedAudioStreamIndex)
-                else if get_user_setting("display.playback.AudioLanguagePreference") <> invalid
-                    langPreference = get_user_setting("display.playback.AudioLanguagePreference")
-                    preferredLang = FindPreferredAudioStream(itemNode.json.MediaStreams, langPreference)
-                    video = CreateVideoPlayerGroup(itemNode.id, invalid, preferredLang)
                 else
-                    video = CreateVideoPlayerGroup(itemNode.id)
+                    preferredLang = FindPreferredAudioStream(itemNode.json.MediaStreams)
+                    video = CreateVideoPlayerGroup(itemNode.id, invalid, preferredLang)
                 end if
                 if video <> invalid and video.errorMsg <> "introaborted"
                     sceneManager.callFunc("pushScene", video)
@@ -615,14 +612,21 @@ sub Main (args as dynamic) as void
 
 end sub
 
-function FindPreferredAudioStream(streams, preferredLanguage)
+function FindPreferredAudioStream(streams)
+    preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
+    playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
 
-    for i = 0 to streams.Count() - 1
-        if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
-            return i
-        end if
-    end for
+    if playDefault <> invalid and playDefault = "true"
+        return 1
+    end if
 
-    return 0
+    if preferredLanguage <> invalid
+        for i = 0 to streams.Count() - 1
+            if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
+                return i
+            end if
+        end for
+    end if
 
+    return 1
 end function

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -613,7 +613,7 @@ sub Main (args as dynamic) as void
 
 end sub
 
-function FindPreferredAudioStream(streams, id = "")
+function FindPreferredAudioStream(streams as dynamic, id = "" as string) as integer
     preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
     playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
 

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -172,7 +172,8 @@ sub Main (args as dynamic) as void
                 if selectedItem.selectedAudioStreamIndex <> invalid and selectedItem.selectedAudioStreamIndex > 1
                     video = CreateVideoPlayerGroup(video_id, invalid, selectedItem.selectedAudioStreamIndex)
                 else
-                    video = CreateVideoPlayerGroup(video_id)
+                    preferredLang = FindPreferredAudioStream(invalid, video_id)
+                    video = CreateVideoPlayerGroup(video_id, invalid, preferredLang)
                 end if
                 if video <> invalid and video.errorMsg <> "introaborted"
                     sceneManager.callFunc("pushScene", video)
@@ -612,9 +613,23 @@ sub Main (args as dynamic) as void
 
 end sub
 
-function FindPreferredAudioStream(streams)
+function FindPreferredAudioStream(streams, id = "")
     preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
     playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
+
+    ' Do we already have the MediaStreams or not?
+    if streams = invalid
+        userId = get_setting("active_user")
+        url = Substitute("Users/{0}/Items/{1}", userId, id)
+        resp = APIRequest(url)
+        jsonResponse = getJson(resp)
+        if jsonResponse <> invalid and jsonResponse.MediaStreams <> invalid
+            streams = jsonResponse.MediaStreams
+        else
+            ' we can't find the streams? return the default track
+            return 1
+        end if
+    end if
 
     if playDefault <> invalid and playDefault = "true"
         return 1

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -120,7 +120,7 @@ sub Main (args as dynamic) as void
             itemNode = reportingNode.quickPlayNode
             if itemNode = invalid or itemNode.id = "" then return
             if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
-                if itemNode.type = "Episode" and itemNode.selectedAudioStreamIndex <> invalid and itemNode.selectedAudioStreamIndex > 1
+                if itemNode.type = "Episode" and itemNode.selectedAudioStreamIndex <> invalid and itemNode.selectedAudioStreamIndex > 0
                     video = CreateVideoPlayerGroup(itemNode.id, invalid, itemNode.selectedAudioStreamIndex)
                 else
                     preferredLang = FindPreferredAudioStream(itemNode.json.MediaStreams)

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -612,36 +612,3 @@ sub Main (args as dynamic) as void
     end while
 
 end sub
-
-function FindPreferredAudioStream(streams as dynamic, id = "" as string) as integer
-    preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
-    playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
-
-    ' Do we already have the MediaStreams or not?
-    if streams = invalid
-        userId = get_setting("active_user")
-        url = Substitute("Users/{0}/Items/{1}", userId, id)
-        resp = APIRequest(url)
-        jsonResponse = getJson(resp)
-        if jsonResponse <> invalid and jsonResponse.MediaStreams <> invalid
-            streams = jsonResponse.MediaStreams
-        else
-            ' we can't find the streams? return the default track
-            return 1
-        end if
-    end if
-
-    if playDefault <> invalid and playDefault = "true"
-        return 1
-    end if
-
-    if preferredLanguage <> invalid
-        for i = 0 to streams.Count() - 1
-            if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
-                return i
-            end if
-        end for
-    end if
-
-    return 1
-end function

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -837,13 +837,12 @@ sub playbackOptionDialog(time as longinteger, meta as object)
 end sub
 
 function FindPreferredAudioStream(streams as dynamic, id = "" as string) as integer
-    preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
-    playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
+    preferredLanguage = m.user.Configuration.AudioLanguagePreference
+    playDefault = m.user.Configuration.PlayDefaultAudioTrack
 
     ' Do we already have the MediaStreams or not?
     if streams = invalid
-        userId = get_setting("active_user")
-        url = Substitute("Users/{0}/Items/{1}", userId, id)
+        url = Substitute("Users/{0}/Items/{1}", m.user.id, id)
         resp = APIRequest(url)
         jsonResponse = getJson(resp)
         if jsonResponse <> invalid and jsonResponse.MediaStreams <> invalid
@@ -854,7 +853,7 @@ function FindPreferredAudioStream(streams as dynamic, id = "" as string) as inte
         end if
     end if
 
-    if playDefault <> invalid and playDefault = "true"
+    if playDefault <> invalid and playDefault = true
         return 1
     end if
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -814,3 +814,36 @@ sub UpdateSavedServerList()
         end if
     end if
 end sub
+
+function FindPreferredAudioStream(streams as dynamic, id = "" as string) as integer
+    preferredLanguage = get_user_setting("display.playback.AudioLanguagePreference")
+    playDefault = get_user_setting("display.playback.PlayDefaultAudioTrack")
+
+    ' Do we already have the MediaStreams or not?
+    if streams = invalid
+        userId = get_setting("active_user")
+        url = Substitute("Users/{0}/Items/{1}", userId, id)
+        resp = APIRequest(url)
+        jsonResponse = getJson(resp)
+        if jsonResponse <> invalid and jsonResponse.MediaStreams <> invalid
+            streams = jsonResponse.MediaStreams
+        else
+            ' we can't find the streams? return the default track
+            return 1
+        end if
+    end if
+
+    if playDefault <> invalid and playDefault = "true"
+        return 1
+    end if
+
+    if preferredLanguage <> invalid
+        for i = 0 to streams.Count() - 1
+            if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
+                return i
+            end if
+        end for
+    end if
+
+    return 1
+end function

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -845,12 +845,10 @@ function FindPreferredAudioStream(streams as dynamic, id = "" as string) as inte
         url = Substitute("Users/{0}/Items/{1}", m.user.id, id)
         resp = APIRequest(url)
         jsonResponse = getJson(resp)
-        if jsonResponse <> invalid and jsonResponse.MediaStreams <> invalid
-            streams = jsonResponse.MediaStreams
-        else
-            ' we can't find the streams? return the default track
-            return 1
-        end if
+
+        if jsonResponse = invalid or jsonResponse.MediaStreams = invalid then return 1
+
+        streams = jsonResponse.MediaStreams
     end if
 
     if playDefault <> invalid and playDefault = true
@@ -859,7 +857,7 @@ function FindPreferredAudioStream(streams as dynamic, id = "" as string) as inte
 
     if preferredLanguage <> invalid
         for i = 0 to streams.Count() - 1
-            if streams[i].Type = "Audio" and streams[i].Language = preferredLanguage
+            if LCase(streams[i].Type) = "audio" and LCase(streams[i].Language) = LCase(preferredLanguage)
                 return i
             end if
         end for

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -146,6 +146,15 @@ sub LoadUserPreferences()
     else
         unset_user_setting("display.livetv.landing")
     end if
+
+    ' Get users custom configuration
+    resp = APIRequest("Users/Me")
+    jsonResponse = getJson(resp)
+    if jsonResponse <> invalid and jsonResponse.Configuration <> invalid and jsonResponse.Configuration["AudioLanguagePreference"] <> invalid
+        set_user_setting("display.playback.AudioLanguagePreference", jsonResponse.Configuration["AudioLanguagePreference"])
+    else
+        unset_user_setting("display.playback.AudioLanguagePreference")
+    end if
 end sub
 
 sub LoadUserAbilities(user)

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -150,10 +150,20 @@ sub LoadUserPreferences()
     ' Get users custom configuration
     resp = APIRequest("Users/Me")
     jsonResponse = getJson(resp)
-    if jsonResponse <> invalid and jsonResponse.Configuration <> invalid and jsonResponse.Configuration["AudioLanguagePreference"] <> invalid
-        set_user_setting("display.playback.AudioLanguagePreference", jsonResponse.Configuration["AudioLanguagePreference"])
-    else
-        unset_user_setting("display.playback.AudioLanguagePreference")
+    if jsonResponse <> invalid
+        if jsonResponse.Configuration <> invalid
+            if jsonResponse.Configuration["AudioLanguagePreference"] <> invalid
+                set_user_setting("display.playback.AudioLanguagePreference", jsonResponse.Configuration["AudioLanguagePreference"])
+            else
+                unset_user_setting("display.playback.AudioLanguagePreference")
+            end if
+
+            if jsonResponse.Configuration["PlayDefaultAudioTrack"] <> invalid
+                set_user_setting("display.playback.PlayDefaultAudioTrack", jsonResponse.Configuration["PlayDefaultAudioTrack"] ? "true" : "false")
+            else
+                unset_user_setting("display.playback.PlayDefaultAudioTrack")
+            end if
+        end if
     end if
 end sub
 

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -146,25 +146,6 @@ sub LoadUserPreferences()
     else
         unset_user_setting("display.livetv.landing")
     end if
-
-    ' Get users custom configuration
-    resp = APIRequest("Users/Me")
-    jsonResponse = getJson(resp)
-    if jsonResponse <> invalid
-        if jsonResponse.Configuration <> invalid
-            if jsonResponse.Configuration["AudioLanguagePreference"] <> invalid
-                set_user_setting("display.playback.AudioLanguagePreference", jsonResponse.Configuration["AudioLanguagePreference"])
-            else
-                unset_user_setting("display.playback.AudioLanguagePreference")
-            end if
-
-            if jsonResponse.Configuration["PlayDefaultAudioTrack"] <> invalid
-                set_user_setting("display.playback.PlayDefaultAudioTrack", jsonResponse.Configuration["PlayDefaultAudioTrack"] ? "true" : "false")
-            else
-                unset_user_setting("display.playback.PlayDefaultAudioTrack")
-            end if
-        end if
-    end if
 end sub
 
 sub LoadUserAbilities(user)


### PR DESCRIPTION
Uses the user's Default Playback preferences for TV Shows from the Server.

## Changes
* Reads the user's Playback preference: "Preferred audio language" and "Play default audio track regardless of language".
* Saves this information in settings.
* Uses these settings when playing a TV episode (unless the user has opened the Audio Selection Options).

## Issues
Fixes: #806 
Fixes: #356 

I tested this from "Next Up", "Continue Watching" and the TV Show episode list page.