### PR TITLE
Convert deeplink to global queue & add error dialog to video player

### DIFF
--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -77,11 +77,11 @@ sub onPlaybackErrorButtonSelected(msg)
     sourceNode.close = true
 end sub
 
-sub showPlaybackErrorDialog()
+sub showPlaybackErrorDialog(errorMessage as string)
     dialog = createObject("roSGNode", "Dialog")
     dialog.title = tr("Error During Playback")
     dialog.buttons = [tr("OK")]
-    dialog.message = tr("An error was encountered while playing this item.")
+    dialog.message = errorMessage
     dialog.observeField("buttonSelected", "onPlaybackErrorButtonSelected")
     dialog.observeField("wasClosed", "onPlaybackErrorDialogClosed")
     m.top.getScene().dialog = dialog
@@ -96,12 +96,12 @@ sub onVideoContentLoaded()
 
     ' If we have nothing to play, return to previous screen
     if not isValid(videoContent)
-        showPlaybackErrorDialog()
+        showPlaybackErrorDialog(tr("There was an error retrieving the data for this item from the server."))
         return
     end if
 
     if not isValid(videoContent[0])
-        showPlaybackErrorDialog()
+        showPlaybackErrorDialog(tr("There was an error retrieving the data for this item from the server."))
         return
     end if
 
@@ -211,7 +211,7 @@ sub onState(msg)
             m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
         else
             ' If an error was encountered, Display dialog
-            showPlaybackErrorDialog()
+            showPlaybackErrorDialog(tr("Error During Playback"))
         end if
 
         ' Stop playback and exit player
@@ -291,7 +291,7 @@ sub bufferCheck(msg)
             m.top.callFunc("refresh")
         else
             ' If buffering has stopped Display dialog
-            showPlaybackErrorDialog()
+            showPlaybackErrorDialog(tr("There was an error retrieving the data for this item from the server."))
 
             ' Stop playback and exit player
             m.top.control = "stop"

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -91,32 +91,33 @@ sub onVideoContentLoaded()
     m.LoadMetaDataTask.unobserveField("content")
     m.LoadMetaDataTask.control = "STOP"
 
+    videoContent = m.LoadMetaDataTask.content
     m.LoadMetaDataTask.content = []
 
     ' If we have nothing to play, return to previous screen
-    if not isValid(m.LoadMetaDataTask.content)
+    if not isValid(videoContent)
         showPlaybackErrorDialog()
         return
     end if
 
-    if not isValid(m.LoadMetaDataTask.content[0])
+    if not isValid(videoContent[0])
         showPlaybackErrorDialog()
         return
     end if
 
-    if m.LoadMetaDataTask.content.count() = 0
+    if videoContent.count() = 0
         showPlaybackErrorDialog()
         return
     end if
 
-    m.top.content = m.LoadMetaDataTask.content[0].content
-    m.top.PlaySessionId = m.LoadMetaDataTask.content[0].PlaySessionId
-    m.top.videoId = m.LoadMetaDataTask.content[0].id
-    m.top.container = m.LoadMetaDataTask.content[0].container
-    m.top.mediaSourceId = m.LoadMetaDataTask.content[0].mediaSourceId
-    m.top.fullSubtitleData = m.LoadMetaDataTask.content[0].fullSubtitleData
-    m.top.audioIndex = m.LoadMetaDataTask.content[0].audioIndex
-    m.top.transcodeParams = m.LoadMetaDataTask.content[0].transcodeparams
+    m.top.content = videoContent[0].content
+    m.top.PlaySessionId = videoContent[0].PlaySessionId
+    m.top.videoId = videoContent[0].id
+    m.top.container = videoContent[0].container
+    m.top.mediaSourceId = videoContent[0].mediaSourceId
+    m.top.fullSubtitleData = videoContent[0].fullSubtitleData
+    m.top.audioIndex = videoContent[0].audioIndex
+    m.top.transcodeParams = videoContent[0].transcodeparams
 
     if m.LoadMetaDataTask.isIntro
         m.top.enableTrickPlay = false

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -105,11 +105,6 @@ sub onVideoContentLoaded()
         return
     end if
 
-    if videoContent.count() = 0
-        showPlaybackErrorDialog()
-        return
-    end if
-
     m.top.content = videoContent[0].content
     m.top.PlaySessionId = videoContent[0].PlaySessionId
     m.top.videoId = videoContent[0].id

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -82,19 +82,14 @@ sub Main (args as dynamic) as void
 
     ' Check if we were sent content to play with the startup command (Deep Link)
     if isValidAndNotEmpty(args.mediaType) and isValidAndNotEmpty(args.contentId)
-        video = CreateVideoPlayerGroup(args.contentId)
 
-        if isValid(video)
-            sceneManager.callFunc("pushScene", video)
-        else
-            dialog = createObject("roSGNode", "Dialog")
-            dialog.id = "OKDialog"
-            dialog.title = tr("Not found")
-            dialog.message = tr("The requested content does not exist on the server")
-            dialog.buttons = [tr("OK")]
-            m.scene.dialog = dialog
-            m.scene.dialog.observeField("buttonSelected", m.port)
-        end if
+        deepLinkVideo = {
+            id: args.contentId,
+            type: "video"
+        }
+
+        m.global.queueManager.callFunc("push", deepLinkVideo)
+        m.global.queueManager.callFunc("playQueue")
     end if
 
     ' This is the core logic loop. Mostly for transitioning between scenes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Converts deep link content to use new global queue. This also adds the error dialog to a few more existing valid checks to tell the user the video is unplayable.