### PR TITLE
proof of concept - infer server url proto and port

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -189,7 +189,7 @@ function CreateServerGroup()
                 dialog.title = tr("Connecting to Server")
                 m.scene.dialog = dialog
 
-                serverUrl = determine_server_url(screen.serverUrl)
+                serverUrl = inferServerUrl(screen.serverUrl)
                 'If this is a different server from what we know, reset username/password setting
                 if isValid(serverUrl)
                     if get_setting("server") <> serverUrl

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -184,48 +184,54 @@ function CreateServerGroup()
         else if type(msg) = "roSGNodeEvent"
             node = msg.getNode()
             if node = "submit"
-                serverUrl = standardize_jellyfin_url(screen.serverUrl)
-                'If this is a different server from what we know, reset username/password setting
-                if get_setting("server") <> serverUrl
-                    set_setting("username", "")
-                    set_setting("password", "")
-                end if
-                set_setting("server", serverUrl)
                 ' Show Connecting to Server spinner
                 dialog = createObject("roSGNode", "ProgressDialog")
                 dialog.title = tr("Connecting to Server")
                 m.scene.dialog = dialog
 
-                m.serverInfoResult = ServerInfo()
-
-                dialog.close = true
-
-                if m.serverInfoResult = invalid
-                    ' Maybe don't unset setting, but offer as a prompt
-                    ' Server not found, is it online? New values / Retry
-                    print "Server not found, is it online? New values / Retry"
-                    screen.errorMessage = tr("Server not found, is it online?")
-                    SignOut(false)
-                else if m.serverInfoResult.Error <> invalid and m.serverInfoResult.Error
-                    ' If server redirected received, update the URL
-                    if m.serverInfoResult.UpdatedUrl <> invalid
-                        serverUrl = m.serverInfoResult.UpdatedUrl
-                        set_setting("server", serverUrl)
+                serverUrl = determine_server_url(screen.serverUrl)
+                'If this is a different server from what we know, reset username/password setting
+                if isValid(serverUrl)
+                    if get_setting("server") <> serverUrl
+                        set_setting("username", "")
+                        set_setting("password", "")
                     end if
-                    ' Display Error Message to user
-                    message = tr("Error: ")
-                    if m.serverInfoResult.ErrorCode <> invalid
-                        message = message + "[" + m.serverInfoResult.ErrorCode.toStr() + "] "
-                    end if
-                    screen.errorMessage = message + tr(m.serverInfoResult.ErrorMessage)
-                    SignOut(false)
-                else
-                    screen.visible = false
-                    if m.serverInfoResult.serverName <> invalid
-                        return m.serverInfoResult.ServerName + " (Saved)"
+                    set_setting("server", serverUrl)
+
+                    m.serverInfoResult = ServerInfo()
+
+                    dialog.close = true
+
+                    if m.serverInfoResult = invalid
+                        ' Maybe don't unset setting, but offer as a prompt
+                        ' Server not found, is it online? New values / Retry
+                        print "Server not found, is it online? New values / Retry"
+                        screen.errorMessage = tr("Server not found, is it online?")
+                        SignOut(false)
+                    else if m.serverInfoResult.Error <> invalid and m.serverInfoResult.Error
+                        ' If server redirected received, update the URL
+                        if m.serverInfoResult.UpdatedUrl <> invalid
+                            serverUrl = m.serverInfoResult.UpdatedUrl
+                            set_setting("server", serverUrl)
+                        end if
+                        ' Display Error Message to user
+                        message = tr("Error: ")
+                        if m.serverInfoResult.ErrorCode <> invalid
+                            message = message + "[" + m.serverInfoResult.ErrorCode.toStr() + "] "
+                        end if
+                        screen.errorMessage = message + tr(m.serverInfoResult.ErrorMessage)
+                        SignOut(false)
                     else
-                        return "Saved"
+                        screen.visible = false
+                        if m.serverInfoResult.serverName <> invalid
+                            return m.serverInfoResult.ServerName + " (Saved)"
+                        else
+                            return "Saved"
+                        end if
                     end if
+                else
+                    dialog.close = true
+                    screen.errorMessage = tr("Server not found, is it online?")
                 end if
             else if node = "delete_saved"
                 serverPicker = screen.findNode("serverPicker")

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -200,12 +200,10 @@ function determine_server_url(url as string)
 end function
 
 function url_candidates(input as string)
-    urlRegex = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
-    input_url = urlRegex.Match(input)
-    ' proto $1, host $2, port $3, the-rest $4
+    input_url = parseUrl(input)
     if input_url[2] = invalid
         ' a proto wasn't declared
-        input_url = urlRegex.Match("none://" + input)
+        input_url = parseUrl("none://" + input)
     end if
     proto = input_url[1]
     host = input_url[2]
@@ -287,6 +285,18 @@ function isValidAndNotEmpty(input as dynamic) as boolean
         print "Called isValidAndNotEmpty() with invalid type: ", inputType
         return false
     end if
+end function
+
+function parseUrl(url as string) as object
+    ' proto $1, host $2, port $3, the-rest $4
+    rgx = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
+    return rgx.Match(url)
+end function
+
+function isLocalhost(url as string) as boolean
+    ' https://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses
+    rgx = CreateObject("roRegex", "^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$", "i")
+    return rgx.isMatch(url)
 end function
 
 ' Rounds number to nearest integer

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -177,7 +177,6 @@ function determine_server_url(url as string)
     end for
     handled = 0
     timeout = CreateObject("roTimespan")
-    timeout.Mark()
     while timeout.totalseconds() < 15
         resp = wait(0, port)
         if type(resp) = "roUrlEvent"

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -162,17 +162,20 @@ function option_dialog(options, message = "", defaultSelection = 0) as integer
     return show_dialog(message, options, defaultSelection)
 end function
 
-function determine_server_url(url as string)
+function inferServerUrl(url as string)
     port = CreateObject("roMessagePort")
     hosts = CreateObject("roAssociativeArray")
     reqs = []
-    candidates = url_candidates(url)
+    candidates = urlCandidates(url)
     for each endpoint in candidates
         req = CreateObject("roUrlTransfer")
         reqs.push(req) ' keep in scope outside of loop, else -10001
         req.seturl(endpoint + "/system/info/public")
         req.setMessagePort(port)
         hosts.addreplace(req.getidentity().ToStr(), endpoint)
+        if endpoint.Left(8) = "https://"
+            req.setCertificatesFile("common:/certs/ca-bundle.crt")
+        end if
         req.AsyncGetToString()
     end for
     handled = 0
@@ -199,7 +202,7 @@ function determine_server_url(url as string)
     return invalid
 end function
 
-function url_candidates(input as string)
+function urlCandidates(input as string)
     input_url = parseUrl(input)
     if input_url[2] = invalid
         ' a proto wasn't declared

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -203,14 +203,14 @@ function inferServerUrl(url as string)
 end function
 
 function urlCandidates(input as string)
-    input_url = parseUrl(input)
-    if input_url[2] = invalid
+    url = parseUrl(input)
+    if url[2] = invalid
         ' a proto wasn't declared
-        input_url = parseUrl("none://" + input)
+        url = parseUrl("none://" + input)
     end if
-    proto = input_url[1]
-    host = input_url[2]
-    port = input_url[3]
+    proto = url[1]
+    host = url[2]
+    port = url[3]
     print ""
     print "THE PROTO"
     print proto

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -139,7 +139,7 @@ function show_dialog(message as string, options = [], defaultSelection = 0) as i
     end if
 
     dialog.visible = true
-    m.scene.pushChild(dialog)
+    m.scene.appendChild(dialog)
     dialog.setFocus(true)
 
     port = CreateObject("roMessagePort")
@@ -410,7 +410,7 @@ sub startLoadingSpinner()
     m.spinner = createObject("roSGNode", "Spinner")
     m.spinner.translation = "[900, 450]"
     m.spinner.visible = true
-    m.scene.pushChild(m.spinner)
+    m.scene.appendChild(m.spinner)
 end sub
 
 sub startMediaLoadingSpinner()


### PR DESCRIPTION
Allow the user to enter much less information, since entering info on the roku suxxx.
Users can now enter just the host, proto://host, or host:port, and we will check http and https at 80, 8096, 443, and 8920 appropriately.
This draft version is over commented and prints, for your reading pleasure.
Please comment.
Once we are in agreement I will remove the excessive comments and print statements.
doesn't really address #366 but its a giant leap forward.
