### PR TITLE
Fix movie options getting cut off

### DIFF
--- a/components/movies/MovieOptions.xml
+++ b/components/movies/MovieOptions.xml
@@ -7,8 +7,8 @@
       <LayoutGroup horizAlignment="center" translation="[860,50]" itemSpacings="[50]">
         <JFButtons id="buttons" />
         <Group>
-          <RadiobuttonList id="videoMenu" itemspacing="[0,10]" opacity="1" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" />
-          <RadiobuttonList id="audioMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" />
+          <RadiobuttonList id="videoMenu" itemspacing="[0,10]" opacity="1" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8" />
+          <RadiobuttonList id="audioMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8" />
         </Group>
       </LayoutGroup>
     </Group>


### PR DESCRIPTION
## Changes

Currently, the video/audio movie options menu has two problems with items getting cut off.

### 1. Text truncation

The narrow width of the centered list causes each item's text to be truncated too early, so some items may appear indistinguishable from each other when the differing text is the last part of the string. For example, "DD 5.1 - Dolby Digital - English" and "DD 5.1 - Dolby Digital - French" might both show up as "DD 5.1 - Dolby Di ...".

This change solves the first problem by widening the list to fill the background card, allowing for 3x longer text strings before truncation:

![screenshot of a very long audio track name after change](https://github.com/jellyfin/jellyfin-roku/assets/1693960/d307441e-56cb-419d-bac6-77f646077648)

### 2. List length

If a movie has too many audio or video options, some items will be pushed off the bottom of the screen so they cannot be viewed at all.

This is solved by specifying the number of list items to show on the screen as 8, after which the list will scroll. Previously, this number was not specified, so it was showing up to the [default of 12 items](https://developer.roku.com/docs/references/scenegraph/list-and-grid-nodes/labellist.md#fields).