### PR TITLE
Update roku-log to latest version and fix compile error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {
+        "@rokucommunity/bslib": "0.1.1",
         "bgv": "npm:button-group-vert@1.0.2",
         "brighterscript-formatter": "1.6.29",
         "intKeyboard": "npm:integer-keyboard@1.0.12",
@@ -19,7 +20,6 @@
       "devDependencies": {
         "@rokucommunity/bslint": "0.8.6",
         "brighterscript": "0.65.0",
-        "bslib": "npm:@rokucommunity/bslib@0.1.1",
         "jshint": "2.13.6",
         "markdownlint-cli2": "0.7.1",
         "rimraf": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "bgv": "npm:button-group-vert@1.0.2",
         "brighterscript-formatter": "1.6.29",
         "intKeyboard": "npm:integer-keyboard@1.0.12",
-        "log": "npm:roku-log@0.9.3",
+        "log": "npm:roku-log@0.11.1",
         "sob": "npm:slide-out-button@1.0.1"
       },
       "devDependencies": {
@@ -705,12 +705,6 @@
       "dependencies": {
         "base64-js": "^1.1.2"
       }
-    },
-    "node_modules/bslib": {
-      "name": "@rokucommunity/bslib",
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
-      "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -2228,11 +2222,11 @@
     },
     "node_modules/log": {
       "name": "roku-log",
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/roku-log/-/roku-log-0.9.3.tgz",
-      "integrity": "sha512-YzvtSCdmZJeimyZZ/C5Y7tdw6vpNMrZV90pg8EPn3vLAtRjtxN3dOt73s48BVOx2W00M0BEGmeaECObS2RdIqg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/roku-log/-/roku-log-0.11.1.tgz",
+      "integrity": "sha512-ezowFIgthbFhM6iNQwfQT/oARhYNvwetgCaeMyN7deq1JwdUpe3Mzzvhqs9/2+ogtRF7sKVtnfmNKAWx4W2rOw==",
       "dependencies": {
-        "bslib": "npm:@rokucommunity/bslib@^0.1.1"
+        "@rokucommunity/bslib": "^0.1.1"
       }
     },
     "node_modules/log-driver": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint-json": "jshint --extra-ext .json --verbose --exclude node_modules ./",
     "lint-markdown": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
     "lint-spelling": "spellchecker -d dictionary.txt --files \"**/*.md\" \"**/.*/**/*.md\" \"!node_modules/**/*.md\"",
-    "postinstall": "npx ropm copy",
+    "postinstall": "npm run ropm",
+    "ropm": "ropm copy && node scripts/ropm-hook.js",
     "validate": "npx bsc --copy-to-staging=false --create-package=false"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.6",
   "description": "Roku app for Jellyfin media server",
   "dependencies": {
+    "@rokucommunity/bslib": "0.1.1",
     "bgv": "npm:button-group-vert@1.0.2",
     "brighterscript-formatter": "1.6.29",
     "intKeyboard": "npm:integer-keyboard@1.0.12",
@@ -12,7 +13,6 @@
   "devDependencies": {
     "@rokucommunity/bslint": "0.8.6",
     "brighterscript": "0.65.0",
-    "bslib": "npm:@rokucommunity/bslib@0.1.1",
     "jshint": "2.13.6",
     "markdownlint-cli2": "0.7.1",
     "rimraf": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bgv": "npm:button-group-vert@1.0.2",
     "brighterscript-formatter": "1.6.29",
     "intKeyboard": "npm:integer-keyboard@1.0.12",
-    "log": "npm:roku-log@0.9.3",
+    "log": "npm:roku-log@0.11.1",
     "sob": "npm:slide-out-button@1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "check-formatting": "npx bsfmt --check",
     "format": "npx bsfmt --write",
     "lint": "bslint",
-    "lint-json": "jshint --extra-ext .json --verbose --exclude node_modules ./",
+    "lint-json": "jshint --extra-ext .json --verbose --exclude node_modules,scripts ./",
     "lint-markdown": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
     "lint-spelling": "spellchecker -d dictionary.txt --files \"**/*.md\" \"**/.*/**/*.md\" \"!node_modules/**/*.md\"",
     "postinstall": "npm run ropm",

--- a/scripts/ropm-hook.js
+++ b/scripts/ropm-hook.js
@@ -27,11 +27,11 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-let componentsDir = path.join(__dirname, '..', 'src', 'components', 'roku_modules');
+let componentsDir = path.join(__dirname, '..', 'components', 'roku_modules');
 
 parseFolder(componentsDir);
 
-let sourceDir = path.join(__dirname, '..', 'src', 'source', 'roku_modules');
+let sourceDir = path.join(__dirname, '..', 'source', 'roku_modules');
 parseFolder(sourceDir);
 
 function parseFolder(sourceDir) {

--- a/scripts/ropm-hook.js
+++ b/scripts/ropm-hook.js
@@ -1,0 +1,59 @@
+// MIT License
+
+// Copyright (c) 2019 George Cook
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable github/array-foreach */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs-extra');
+const path = require('path');
+
+let componentsDir = path.join(__dirname, '..', 'src', 'components', 'roku_modules');
+
+parseFolder(componentsDir);
+
+let sourceDir = path.join(__dirname, '..', 'src', 'source', 'roku_modules');
+parseFolder(sourceDir);
+
+function parseFolder(sourceDir) {
+    try {
+        fs.readdirSync(sourceDir).forEach(file => {
+            let filePath = path.join(sourceDir, file);
+            let fileStats = fs.statSync(filePath);
+            if (fileStats.isDirectory()) {
+                parseFolder(filePath);
+            } else if (filePath.endsWith('.xml')) {
+                let text = fs.readFileSync(filePath, 'utf8');
+                let r = /\/roku_modules\/undefined\/bslib\.brs/gim;
+                text = text.replace(r, '/roku_modules/rokucommunity_bslib/bslib.brs');
+                r = /\/roku_modules\/bslib\/bslib\.brs/gim;
+                text = text.replace(r, '/roku_modules/rokucommunity_bslib/bslib.brs');
+                r = /\/roku_modules\/undefined/gim;
+                text = text.replace(r, '/roku_modules/maestro');
+                fs.writeFileSync(filePath, text);
+                // console.log('fixed', filePath);
+            }
+        });
+    } catch (e) {
+        console.log(e);
+    }
+}


### PR DESCRIPTION
The compile error is fixed by using a script provided by @georgejecook to manually update any paths that have "undefined" in them which is what was causing the compile error.

## Changes
- Install js script to be ran whenever we run `npm run ropm`
- Change `postinstall` to run `npm run ropm` instead of calling `ropm copy` directly
- Update roku-log to latest version `0.11.1`
- Move `bslib` from devdependencies to dependencies so that paths are predictable and compatible with js script
- Stop using alias for bslib dependency

## Issues
Fixes issue mentioned in #1249
