### PR TITLE
Small update to login flow if saved serverurl has no connection at startup

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -5,7 +5,11 @@ function LoginFlow(startOver = false as boolean)
     serverUrl = get_setting("server")
     if isValid(serverUrl)
         print "Previous server connection saved to registry"
-        session.server.UpdateURL(serverUrl)
+        startOver = not session.server.UpdateURL(serverUrl)
+        if startOver
+            print "Could not connect to previously saved server."
+            session.server.Delete()
+        end if
     else
         startOver = true
         print "No previous server connection saved to registry"

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -8,7 +8,6 @@ function LoginFlow(startOver = false as boolean)
         startOver = not session.server.UpdateURL(serverUrl)
         if startOver
             print "Could not connect to previously saved server."
-            session.server.Delete()
         end if
     else
         startOver = true

--- a/source/api/userauth.brs
+++ b/source/api/userauth.brs
@@ -90,13 +90,15 @@ function ServerInfo()
         ' set the server to new location and try again
         if right(headers.location, 19) = "/System/Info/Public"
             set_setting("server", left(headers.location, len(headers.location) - 19))
-            session.server.UpdateURL(left(headers.location, len(headers.location) - 19))
-            info = ServerInfo()
-            if info.Error
-                info.UpdatedUrl = left(headers.location, len(headers.location) - 19)
-                info.ErrorMessage = info.ErrorMessage + " (Note: Server redirected us to " + info.UpdatedUrl + ")"
+            isConnected = session.server.UpdateURL(left(headers.location, len(headers.location) - 19))
+            if isConnected
+                info = ServerInfo()
+                if info.Error
+                    info.UpdatedUrl = left(headers.location, len(headers.location) - 19)
+                    info.ErrorMessage = info.ErrorMessage + " (Note: Server redirected us to " + info.UpdatedUrl + ")"
+                end if
+                return info
             end if
-            return info
         end if
     end if
 

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -64,7 +64,13 @@ namespace session
             ' validate parameters
             if value = "" then return false
             session.server.Update("url", value)
-            return session.server.Populate()
+
+            success = session.server.Populate()
+            if not success
+                session.server.Delete()
+            end if
+
+            return success
         end function
 
         ' Use the saved server url to populate the global server session array (m.global.session.server)

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -59,21 +59,23 @@ namespace session
         end sub
 
         ' Add or update the jellyfin server URL from the global server session array (m.global.session.server)
-        sub UpdateURL(value as string)
+        ' Returns a boolean based on if a connection to the Jellyfin server was made
+        function UpdateURL(value as string) as boolean
             ' validate parameters
-            if value = "" then return
+            if value = "" then return false
             session.server.Update("url", value)
-            session.server.Populate()
-        end sub
+            return session.server.Populate()
+        end function
 
         ' Use the saved server url to populate the global server session array (m.global.session.server)
-        sub Populate()
+        ' Returns a boolean based on if a connection to the Jellyfin server was made
+        function Populate() as boolean
             ' validate server url
-            if m.global.session.server.url = invalid or m.global.session.server.url = "" then return
+            if m.global.session.server.url = invalid or m.global.session.server.url = "" then return false
             ' get server info using API
             myServerInfo = ServerInfo()
             ' validate data returned from API
-            if myServerInfo.id = invalid then return
+            if myServerInfo.id = invalid then return false
             ' make copy of global server session
             tmpSessionServer = m.global.session.server
             ' update the temp array
@@ -93,7 +95,8 @@ namespace session
             tmpSessionServer.AddReplace("isLocalHTTPS", isLocalServerHTTPS)
             ' update global server session using the temp array
             session.Update("server", tmpSessionServer)
-        end sub
+            return true
+        end function
     end namespace
 
     namespace user


### PR DESCRIPTION
Small update to login flow at startup when a server is saved to the registry but is no longer online. UX is still not ideal since there is no spinner or anything and we just stare at a blank screen for 15 seconds or so but this is better than it is now.

## Changes
- Updates `session.server.UpdateURL()` to return a boolean based on if a  connection could be made to the server URL
- Update login flow if saved server is found in registry but connection couldn't be made
  - Log that the `serverURL` couldn't be connected to
  - Update `startOver` var

## Context
This may be a regression from the new global session var but I didn't check

