### PR TITLE
Fix to crash if bitrate limit is enabled and empty

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -1,3 +1,5 @@
+import "pkg:/source/utils/misc.brs"
+
 'Device Capabilities for Roku.
 'This will likely need further tweaking
 function getDeviceCapabilities() as object
@@ -368,9 +370,8 @@ end function
 function GetBitRateLimit(codec as string)
     if m.global.session.user.settings["playback.bitrate.maxlimited"] = true
         userSetLimit = m.global.session.user.settings["playback.bitrate.limit"]
-        userSetLimit *= 1000000
-
-        if userSetLimit > 0
+        if isValid(userSetLimit) and type(userSetLimit) = "Integer" and userSetLimit > 0
+            userSetLimit *= 1000000
             return {
                 "Condition": "LessThanEqual",
                 "Property": "VideoBitrate",


### PR DESCRIPTION
Discovered that if you enable Bit Rate Limit, but blank out the actual number (just empty dashes), the client crashes and there is no way for the user to fix it.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Defensive code around bit rate limit.
