### PR TITLE
Audio transcode fixes

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -23,8 +23,8 @@ sub PostDeviceProfile()
 end sub
 
 function getDeviceProfile() as object
-    playMpeg2 = get_user_setting("playback.mpeg2") = "true"
-    playAv1 = get_user_setting("playback.av1") = "true"
+    playMpeg2 = m.global.session.user.settings["playback.mpeg2"]
+    playAv1 = m.global.session.user.settings["playback.av1"]
 
     'Check if 5.1 Audio Output connected
     maxAudioChannels = 2
@@ -287,7 +287,7 @@ function GetDirectPlayProfiles() as object
     mkvAudio = "mp3,pcm,lpcm,wav"
     audio = "mp3,pcm,lpcm,wav"
 
-    playMpeg2 = get_user_setting("playback.mpeg2") = "true"
+    playMpeg2 = m.global.session.user.settings["playback.mpeg2"]
 
     di = CreateObject("roDeviceInfo")
 
@@ -306,7 +306,7 @@ function GetDirectPlayProfiles() as object
         mkvVideo = mkvVideo + ",mpeg2video"
     end if
 
-    if get_user_setting("playback.mpeg4") = "true"
+    if m.global.session.user.settings["playback.mpeg4"] = true
         mp4Video = mp4Video + ",mpeg4"
     end if
 
@@ -383,8 +383,8 @@ function GetDirectPlayProfiles() as object
 end function
 
 function GetBitRateLimit(codec as string)
-    if get_user_setting("playback.bitrate.maxlimited") = "true"
-        userSetLimit = get_user_setting("playback.bitrate.limit").ToInt()
+    if m.global.session.user.settings["playback.bitrate.maxlimited"] = true
+        userSetLimit = m.global.session.user.settings["playback.bitrate.limit"]
         userSetLimit *= 1000000
 
         if userSetLimit > 0


### PR DESCRIPTION
Fix AAC being chosen over AC3 for TS HLS transcode streams, Added MKV HLS to support E-AC3 for transcode.

Change on line 60 reverses aac and ac3 order preferring ac3. Changes on line 136-146 adds restricted mkv transcode profile, allowing multiple audio formats results in aac always being chosen, seems to be a server issue.