### PR TITLE
Add function to load default subtitles according to user settings on the global player

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -43,7 +43,6 @@ sub loadItems()
 
     ' Determine selected subtitles before video loads based on user configuration
     m.top.selectedSubtitleIndex = defaultSubtitleTrackFromVid(m.top.itemId)
-    print m.top.selectedSubtitleIndex
     id = m.top.itemId
     mediaSourceId = invalid
     audio_stream_idx = m.top.selectedAudioStreamIndex
@@ -377,13 +376,11 @@ end function
 '     This allows forcing text subs, since roku requires transcoding of non-text subs
 ' returns the server-side track index for the appriate subtitle
 function defaultSubtitleTrack(sorted_subtitles, require_text = false) as integer
-    print m.user.Configuration.SubtitleMode
     if m.user.Configuration.SubtitleMode = "None"
         return -1 ' No subtitles desired: select none
     end if
 
     for each item in sorted_subtitles
-        print "FORCED?: ", item.isForced
         ' Only auto-select subtitle if language matches preference
         languageMatch = (m.user.Configuration.SubtitleLanguagePreference = item.Track.Language) or (m.user.Configuration.SubtitleLanguagePreference = "")
         ' Ensure textuality of subtitle matches preferenced passed as arg

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -4,7 +4,7 @@
   <interface>
     <field id="itemId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
-    <field id="selectedSubtitleIndex" type="integer" value="-2" />
+    <field id="selectedSubtitleIndex" type="integer" value="-1" />
     <field id="isIntro" type="boolean" />
     <field id="startIndex" type="integer" value="0" />
     <field id="itemType" type="string" value="" />

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -4,7 +4,7 @@
   <interface>
     <field id="itemId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
-    <field id="selectedSubtitleIndex" type="integer" value="-1" />
+    <field id="selectedSubtitleIndex" type="integer" value="-2" />
     <field id="isIntro" type="boolean" />
     <field id="startIndex" type="integer" value="0" />
     <field id="itemType" type="string" value="" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Modified video player to mimic behavior of jellyfin web player, where subtitles load immediately when the video is loaded, according to user settings. Returns old functionality without modifications.
Sets "selected" flag on load for purposes of subtitle selection window.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #850