### PR TITLE
Add function to load default subtitles according to user settings on the global player

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -10,7 +10,9 @@ import "pkg:/source/utils/deviceCapabilities.brs"
 sub init()
     m.user = AboutMe()
     m.top.functionName = "loadItems"
-    m.top.selectedSubtitleIndex = -2
+    currentItem = m.global.queueManager.callFunc("getCurrentItem")
+    m.top.selectedSubtitleIndex = defaultSubtitleTrackFromVid(currentItem.id)
+
 end sub
 
 sub loadItems()
@@ -141,25 +143,8 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, subtitl
     end if
 
 
-    ' 'TODO: allow user selection of subtitle track before playback initiated, for now set to no subtitles
-
-    ' Determine selected subtitles before video loads based on user configuration.
-    ' Will only run once on first load, as -2 index does not exist.
-    if m.top.selectedSubtitleIndex = -2
-        currentItem = m.global.queueManager.callFunc("getCurrentItem")
-        if isValid(currentItem) and isValid(currentItem.json)
-            m.top.selectedSubtitleIndex = defaultSubtitleTrackFromVid(m.top.itemId)
-            subtitle_idx = m.top.selectedSubtitleIndex
-            ' Add initial check for which subtitle has the selected flag
-            for i = 0 to video.fullSubtitleData.Count() - 1
-                if video.fullSubtitleData[i].index = subtitle_idx
-                    video.fullSubtitleData[i].selected = true
-                end if
-            end for
-            ' Reload playback info now that subtitle is loaded
-            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
-        end if
-    end if
+    ' 'TODO: allow user selection of subtitle track before playback initiated, for manual subtitle selection
+    ' Now uses behavior of JF video players, uses user subtitle settings
 
     video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
     fully_external = false

--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -50,16 +50,15 @@ sub loadItems()
     subtitle_idx = m.top.selectedSubtitleIndex
     forceTranscoding = false
 
-    m.top.content = [LoadItems_VideoPlayer(id, subtitle_idx, mediaSourceId, audio_stream_idx, forceTranscoding)]
+    m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, subtitle_idx, forceTranscoding)]
 end sub
 
-function LoadItems_VideoPlayer(id as string, subtitle_idx, mediaSourceId = invalid as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean) as dynamic
-
+function LoadItems_VideoPlayer(id as string, mediaSourceId = invalid as dynamic, audio_stream_idx = 1 as integer, subtitle_idx = -1 as integer, forceTranscoding = false as boolean) as dynamic
     video = {}
     video.id = id
     video.content = createObject("RoSGNode", "ContentNode")
 
-    LoadItems_AddVideoContent(video, mediaSourceId, subtitle_idx, audio_stream_idx, forceTranscoding)
+    LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx, subtitle_idx, forceTranscoding)
 
     if video.content = invalid
         return invalid
@@ -68,8 +67,7 @@ function LoadItems_VideoPlayer(id as string, subtitle_idx, mediaSourceId = inval
     return video
 end function
 
-sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, subtitle_idx, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean)
-
+sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, subtitle_idx = -1 as integer, forceTranscoding = false as boolean)
     meta = ItemMetaData(video.id)
 
     if not isValid(meta)

--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -43,7 +43,6 @@ sub loadItems()
 
     ' Determine selected subtitles before video loads based on user configuration
     m.top.selectedSubtitleIndex = defaultSubtitleTrackFromVid(m.top.itemId)
-    print m.top.selectedSubtitleIndex
     id = m.top.itemId
     mediaSourceId = invalid
     audio_stream_idx = m.top.selectedAudioStreamIndex
@@ -377,13 +376,11 @@ end function
 '     This allows forcing text subs, since roku requires transcoding of non-text subs
 ' returns the server-side track index for the appriate subtitle
 function defaultSubtitleTrack(sorted_subtitles, require_text = false) as integer
-    print m.user.Configuration.SubtitleMode
     if m.user.Configuration.SubtitleMode = "None"
         return -1 ' No subtitles desired: select none
     end if
 
     for each item in sorted_subtitles
-        print "FORCED?: ", item.isForced
         ' Only auto-select subtitle if language matches preference
         languageMatch = (m.user.Configuration.SubtitleLanguagePreference = item.Track.Language) or (m.user.Configuration.SubtitleLanguagePreference = "")
         ' Ensure textuality of subtitle matches preferenced passed as arg

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -4,7 +4,7 @@
   <interface>
     <field id="itemId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
-    <field id="selectedSubtitleIndex" type="integer" value="-2" />
+    <field id="selectedSubtitleIndex" type="integer" value="-1" />
     <field id="isIntro" type="boolean" />
     <field id="startIndex" type="integer" value="0" />
     <field id="itemType" type="string" value="" />

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -4,7 +4,7 @@
   <interface>
     <field id="itemId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
-    <field id="selectedSubtitleIndex" type="integer" value="-1" />
+    <field id="selectedSubtitleIndex" type="integer" value="-2" />
     <field id="isIntro" type="boolean" />
     <field id="startIndex" type="integer" value="0" />
     <field id="itemType" type="string" value="" />

--- a/components/manager/ViewCreator.brs
+++ b/components/manager/ViewCreator.brs
@@ -46,6 +46,13 @@ sub onSelectSubtitlePressed()
         }]
     }
 
+    ' Recheck which subtitle is selected, needed for first load
+    for each item in m.view.fullSubtitleData
+        if item.selected = true
+            m.view.selectedSubtitle = item.index
+        end if
+    end for
+
     for each item in m.view.fullSubtitleData
         item.type = "subtitleselection"
 
@@ -96,6 +103,7 @@ sub processSubtitleSelection()
         if m.view.selectedSubtitle = m.selectedSubtitle.index then return
     end if
 
+    print
     ' The playbackData is now outdated and must be refreshed
     m.playbackData = invalid
 

--- a/components/manager/ViewCreator.brs
+++ b/components/manager/ViewCreator.brs
@@ -103,7 +103,6 @@ sub processSubtitleSelection()
         if m.view.selectedSubtitle = m.selectedSubtitle.index then return
     end if
 
-    print
     ' The playbackData is now outdated and must be refreshed
     m.playbackData = invalid
 

--- a/components/manager/ViewCreator.brs
+++ b/components/manager/ViewCreator.brs
@@ -46,16 +46,8 @@ sub onSelectSubtitlePressed()
         }]
     }
 
-    ' Recheck which subtitle is selected, needed for first load
-    for each item in m.view.fullSubtitleData
-        if item.selected = true
-            m.view.selectedSubtitle = item.index
-        end if
-    end for
-
     for each item in m.view.fullSubtitleData
         item.type = "subtitleselection"
-
         if m.view.selectedSubtitle <> -1
             ' Subtitle is a track within the file
             if item.index = m.view.selectedSubtitle

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -16,6 +16,7 @@ sub init()
     m.LoadMetaDataTask.selectedAudioStreamIndex = m.currentItem.selectedAudioStreamIndex
     m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
     m.LoadMetaDataTask.control = "RUN"
+    m.top.selectedSubtitle = m.LoadMetaDataTask.selectedSubtitleIndex
 
     m.playbackTimer = m.top.findNode("playbackTimer")
     m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
@@ -113,12 +114,6 @@ sub onVideoContentLoaded()
     m.top.audioIndex = videoContent[0].audioIndex
     m.top.transcodeParams = videoContent[0].transcodeparams
 
-    for i = 0 to videoContent[0].fullSubtitleData.Count() - 1
-        if videoContent[0].fullSubtitleData[i].selected = true
-            videoContent[0].fullSubtitleData[i].selected = false
-            m.top.selectedSubtitle = videoContent[0].fullSubtitleData[i].index
-        end if
-    end for
     if m.LoadMetaDataTask.isIntro
         m.top.enableTrickPlay = false
     end if

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -113,6 +113,12 @@ sub onVideoContentLoaded()
     m.top.audioIndex = videoContent[0].audioIndex
     m.top.transcodeParams = videoContent[0].transcodeparams
 
+    for i = 0 to videoContent[0].fullSubtitleData.Count() - 1
+        if videoContent[0].fullSubtitleData[i].selected = true
+            videoContent[0].fullSubtitleData[i].selected = false
+            m.top.selectedSubtitle = videoContent[0].fullSubtitleData[i].index
+        end if
+    end for
     if m.LoadMetaDataTask.isIntro
         m.top.enableTrickPlay = false
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Modified video player to mimic behavior of jellyfin web player, where subtitles load immediately when the video is loaded, according to user settings. Returns old functionality mentioned in #850.
Sets selectedSubtitleIndex to default subtitle.
Apologies for the duplicated PR, thought this would take longer.
Might also help with #1259, as this might remove some of the dependency on the system settings for captions

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #850
