### PR TITLE
Update Live TV to provide smooth playback

### DIFF
--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -24,7 +24,9 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         "MaxStaticBitrate": "140000000",
         "SubtitleStreamIndex": currentView.selectedSubtitle,
         "MediaSourceId": currentItem.id,
-        "AudioStreamIndex": currentItem.selectedAudioStreamIndex
+        "AudioStreamIndex": currentItem.selectedAudioStreamIndex,
+        "enableDirectPlay": true,
+        "enableDirectStream": true
     }
 
     req = APIRequest(Substitute("Items/{0}/PlaybackInfo", id), params)

--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -121,7 +121,18 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     if meta.live
         video.content.live = true
         video.content.StreamFormat = "hls"
+        video.directPlaySupported = true
+        video.RequiresClosing = false
+        video.SupportsDirectStream = true
+        video.transcodeParams = {
+            "MediaSourceId": m.playbackInfo.MediaSources[0].Id,
+            "LiveStreamId": m.playbackInfo.MediaSources[0].LiveStreamId,
+            "PlaySessionId": video.PlaySessionId
+        }
+    else
+        video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
     end if
+
 
     video.container = getContainerType(meta)
 
@@ -131,18 +142,10 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     addSubtitlesToVideo(video, meta)
 
-    if meta.live
-        video.transcodeParams = {
-            "MediaSourceId": m.playbackInfo.MediaSources[0].Id,
-            "LiveStreamId": m.playbackInfo.MediaSources[0].LiveStreamId,
-            "PlaySessionId": video.PlaySessionId
-        }
-    end if
-
 
     ' 'TODO: allow user selection of subtitle track before playback initiated, for now set to no subtitles
 
-    video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
+    'video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
     fully_external = false
 
 
@@ -188,7 +191,6 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     if not fully_external
         video.content = authorize_request(video.content)
     end if
-
 end sub
 
 sub addVideoContentURL(video, mediaSourceId, audio_stream_idx, fully_external)

--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -117,9 +117,6 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     video.PlaySessionId = m.playbackInfo.PlaySessionId
-    video.container = getContainerType(meta)
-    print "meta info is " meta
-    print "media source is " meta.json.mediaSources[0].container
 
 
     if meta.live
@@ -135,26 +132,23 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
             video.SupportsDirectStream = true
             fully_external = true
             video.content.live = true
-            print "stream foramt set to hls"
         else if m.playbackInfo.MediaSources[0].container = "mpegts"
             video.directPlaySupported = false
             video.content.StreamFormat = "fMP4"
             video.SupportsDirectStream = true
             fully_external = false
             video.content.live = true
-            print "stream foramt set to ts"
         else
             fully_external = true
             video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
             video.content.StreamFormat = m.playbackInfo.MediaSources[0].container
-            print "stream is not hls or ts"
         end if
     else
         fully_external = false
-        video.directPlaySupported = false
-        print "stream is not live!"
+        video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
     end if
 
+    video.container = getContainerType(meta)
 
     if not isValid(m.playbackInfo.MediaSources[0])
         m.playbackInfo = meta.json
@@ -208,7 +202,6 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     if not fully_external
         video.content = authorize_request(video.content)
     end if
-    print "mediaSource" m.playbackInfo.MediaSources[0]
 end sub
 
 sub addVideoContentURL(video, mediaSourceId, audio_stream_idx, fully_external)

--- a/components/ItemGrid/LoadVideoContentTask.brs
+++ b/components/ItemGrid/LoadVideoContentTask.brs
@@ -139,9 +139,9 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
             fully_external = false
             video.content.live = true
         else
-            fully_external = true
+            fully_external = false
             video.directPlaySupported = m.playbackInfo.MediaSources[0].SupportsDirectPlay
-            video.content.StreamFormat = m.playbackInfo.MediaSources[0].container
+            video.content.StreamFormat = "hls"
         end if
     else
         fully_external = false

--- a/components/data/ChannelData.xml
+++ b/components/data/ChannelData.xml
@@ -2,6 +2,7 @@
 <component name="ChannelData" extends="JFContentItem">
   <interface>
     <field id="channelID" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
   </interface>
 </component>

--- a/components/liveTv/ProgramDetails.brs
+++ b/components/liveTv/ProgramDetails.brs
@@ -92,7 +92,7 @@ sub setupLabels()
     m.recordSeriesOutline.height = recordSeriesButtonBackground.height
 
     m.userCanRecord = m.global.session.user.settings["livetv.canrecord"]
-    if m.userCanRecord = "false"
+    if m.userCanRecord = false
         m.recordButton.visible = false
         m.recordSeriesButton.visible = false
     end if


### PR DESCRIPTION
Update LiveTV to provide smooth playback

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Consolidate Live.meta if statement and add media params to allow smooth playback of HLS streams.

## Issues
HLS stream sent to the server would constantly load and buffer and timeout which would push users back to the guide. 
