### PR TITLE
Fix compile error with build zips

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -20,7 +20,7 @@ jobs:
       - name: NPM install
         run: npm ci
       - name: Install roku module dependencies
-        run: npx ropm install
+        run: npm run ropm
       - name: Build app
         run: npm run build
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -69,7 +69,7 @@ jobs:
       - name: NPM install
         run: npm ci
       - name: Install roku module dependencies
-        run: npx ropm install
+        run: npm run ropm
       - name: Build app for production
         run: npm run build-prod
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3


### PR DESCRIPTION
Update build workflows so that our ropm script is ran after installing ropm dependencies. Fixes the current issue with compile errors with build zips.

## Changes
- Change ropm install command from `npx ropm install` to `npm run ropm`


