### PR TITLE
Fix crash when viewing Photo Slideshow or Photo Random

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -137,7 +137,7 @@ sub loadInitialItems()
     if m.sortField = invalid then m.sortField = "SortName"
     if m.filter = invalid then m.filter = "All"
 
-    if sortAscendingStr = invalid or sortAscendingStr = "true"
+    if sortAscendingStr = invalid or sortAscendingStr = true
         m.sortAscending = true
     else
         m.sortAscending = false

--- a/components/photos/PhotoDetails.brs
+++ b/components/photos/PhotoDetails.brs
@@ -34,7 +34,7 @@ sub onPhotoLoaded()
         photo = m.top.findNode("photo")
         photo.uri = m.LoadLibrariesTask.results
 
-        if m.slideshow = "true" or m.random = "true"
+        if m.slideshow = true or m.random = true
             ' user has requested either a slideshow or random...
             m.slideshowTimer.control = "start"
         end if
@@ -47,12 +47,12 @@ end sub
 sub nextSlide()
     m.slideshowTimer.control = "stop"
 
-    if m.slideshow = "true"
+    if m.slideshow = true
         if isValidToContinue(m.top.itemIndex + 1)
             m.top.itemIndex++
             m.slideshowTimer.control = "start"
         end if
-    else if m.random = "true"
+    else if m.random = true
         index = rnd(m.top.items.content.getChildCount() - 1)
         if isValidToContinue(index)
             m.top.itemIndex = index
@@ -100,7 +100,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.textBackground.opacity = 0
                 m.showStatusAnimation.control = "start"
             end if
-            m.slideshow = "true"
+            m.slideshow = true
             m.statusTimer.control = "start"
             m.slideshowTimer.control = "start"
         end if


### PR DESCRIPTION
Fixes crash on code that got missed when we changed over from storing bools as strings to bools (i.e. "true" is now true).

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
= "true" and = "false" are now = true and = false.

## Fixes
Crash when viewing photos and opting for either Slideshow or Random.