### PR TITLE
Fix crash when viewing Live TV

### DIFF
--- a/components/liveTv/ProgramDetails.brs
+++ b/components/liveTv/ProgramDetails.brs
@@ -92,7 +92,7 @@ sub setupLabels()
     m.recordSeriesOutline.height = recordSeriesButtonBackground.height
 
     m.userCanRecord = m.global.session.user.settings["livetv.canrecord"]
-    if m.userCanRecord = "false"
+    if m.userCanRecord = false
         m.recordButton.visible = false
         m.recordSeriesButton.visible = false
     end if


### PR DESCRIPTION
Follow up to #1316 

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix crash.
