### PR TITLE
Update api.sessions.get() + add tanscoding info for Direct Streaming

### DIFF
--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -35,8 +35,7 @@ end function
 ' Returns an array of playback info to be displayed during playback.
 ' In the future, with a custom playback info view, we can return an associated array.
 sub getPlaybackInfoTask()
-    params = { "deviceId": m.global.device.id }
-    sessions = api.sessions.Get(params)
+    sessions = api.sessions.Get()
 
     m.playbackInfo = ItemPostPlaybackInfo(m.top.videoID)
 

--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -35,7 +35,8 @@ end function
 ' Returns an array of playback info to be displayed during playback.
 ' In the future, with a custom playback info view, we can return an associated array.
 sub getPlaybackInfoTask()
-    sessions = api.sessions.Get()
+    params = { "deviceId": m.global.device.id }
+    sessions = api.sessions.Get(params)
 
     m.playbackInfo = ItemPostPlaybackInfo(m.top.videoID)
 
@@ -88,6 +89,11 @@ function GetTranscodingStats(deviceSession)
             data = "<b>• " + tr("Audio Channels") + ":</b> " + Str(audioChannels)
             sessionStats.data.push(data)
         end if
+    else
+        sessionStats.data.push("<header>" + tr("Direct playing") + "</header>")
+        bitrate = "<b>• " + tr("Total Bitrate") + ":</b> " + getDisplayBitrate(totalBitrate)
+        sessionStats.data.push(bitrate)
+        sessionStats.data.push("<b>" + tr("The source file is entirely compatible with this client, and the session is receiving the file without modifications.") + "</b>")
     end if
 
     if havePlaybackInfo()

--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -91,8 +91,6 @@ function GetTranscodingStats(deviceSession)
         end if
     else
         sessionStats.data.push("<header>" + tr("Direct playing") + "</header>")
-        bitrate = "<b>• " + tr("Total Bitrate") + ":</b> " + getDisplayBitrate(totalBitrate)
-        sessionStats.data.push(bitrate)
         sessionStats.data.push("<b>" + tr("The source file is entirely compatible with this client, and the session is receiving the file without modifications.") + "</b>")
     end if
 

--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -90,7 +90,7 @@ function GetTranscodingStats(deviceSession)
         end if
     else
         sessionStats.data.push("<header>" + tr("Direct playing") + "</header>")
-        sessionStats.data.push("<b>" + tr("The source file is entirely compatible with this client, and the session is receiving the file without modifications.") + "</b>")
+        sessionStats.data.push("<b>" + tr("The source file is entirely compatible with this client and the session is receiving the file without modifications.") + "</b>")
     end if
 
     if havePlaybackInfo()

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1114,6 +1114,10 @@
             <translation>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+		<message>
+			<source>Direct playing</source>
+			<translation>Direct playing</translation>
+		</message>
         <message>
             <source>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</source>
             <translation>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</translation>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1119,8 +1119,8 @@
 			<translation>Direct playing</translation>
 		</message>
         <message>
-            <source>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</source>
-            <translation>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</translation>
+            <source>The source file is entirely compatible with this client and the session is receiving the file without modifications.</source>
+            <translation>The source file is entirely compatible with this client and the session is receiving the file without modifications.</translation>
             <extracomment>Direct play info box text in GetPlaybackInfoTask.brs</extracomment>
         </message>
     </context>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1114,5 +1114,10 @@
             <translation>Set how many seconds before the end of an episode the Next Episode button should appear. Set to 0 to disable.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+        <message>
+            <source>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</source>
+            <translation>The source file is entirely compatible with this client, and the session is receiving the file without modifications.</translation>
+            <extracomment>Direct play info box text in GetPlaybackInfoTask.brs</extracomment>
+        </message>
     </context>
 </TS>

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1374,7 +1374,7 @@ namespace api
         end function
 
         ' Gets a list of sessions.
-        function Get(params = {} as object)
+        function Get(params = {"deviceId": m.global.device.id} as object)
             req = APIRequest("/sessions", params)
             return getJson(req)
         end function

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1374,7 +1374,7 @@ namespace api
         end function
 
         ' Gets a list of sessions.
-        function Get(params = {"deviceId": m.global.device.id} as object)
+        function Get(params = { "deviceId": m.global.device.id } as object)
             req = APIRequest("/sessions", params)
             return getJson(req)
         end function


### PR DESCRIPTION
Add Device ID filter the the Get sessions API Call. This allows us to get the correct device playback if multiple devices are active at once. 

Also add Tanscoding info for Direct Streaming. This will show if there is no transcodingInfo from the deviceSession. This is more inline with the web server activity info box.



## Issues
Device session was only quering the first active device. This filters the query to get the device ID
