### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @jellyfin/roku


### PR DESCRIPTION
This file tells github to automatically request reviews for new PRs based on who "owns" the files that were modified. I have it setup so that the whole roku team owns all files; every new PR will ask for a review from the `jellyfin/roku` team. Note that this will *not* request reviews for draft PRs.

Inspired by the web client repo. [link to their file](https://github.com/jellyfin/jellyfin-web/blob/master/.github/CODEOWNERS) for reference.
[github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

## Changes
- Add `.github/CODEOWNERS` file
