### PR TITLE
Update TVListDetails.brs

### DIFF
--- a/components/tvshows/TVListDetails.brs
+++ b/components/tvshows/TVListDetails.brs
@@ -96,7 +96,7 @@ sub itemContentChanged()
     m.videoCodec.visible = false
     if isValid(itemData.MediaSources)
         for i = 0 to itemData.MediaSources.Count() - 1
-            if item.selectedVideoStreamId = itemData.MediaSources[i].id
+            if item.selectedVideoStreamId = itemData.MediaSources[i].id and isValid(itemData.MediaSources[i].MediaStreams[0])
                 m.videoCodec.text = tr("Video") + ": " + itemData.MediaSources[i].MediaStreams[0].DisplayTitle
                 SetupAudioDisplay(itemData.MediaSources[i].MediaStreams, item.selectedAudioStreamIndex)
                 exit for


### PR DESCRIPTION
Add IsValid Check to make sure app does not crash in event MediaStreams returns invalid for some reason.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Add IsValid check to line #L99
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
App wpuld crash when MediaStreams returned invalid. Not sure why/how that would be returned but in some cases it does. 

