### PR TITLE
Add static analysis to build job

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -72,17 +72,6 @@ jobs:
         run: npm run ropm
       - name: Build app for production
         run: npm run build-prod
-      - name: Use Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Download the Static Channel Analysis CLI
-        run: |
-          curl -sSL "https://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip" -o sca-cmd.zip
-          unzip sca-cmd.zip
-      - name: Run Analysis 
-        run: ./sca-cmd/bin/sca-cmd ${{ github.workspace }}/build/staging --exit error
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: Jellyfin-Roku-v${{ env.newManVersion }}-${{ github.sha }}

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -72,6 +72,17 @@ jobs:
         run: npm run ropm
       - name: Build app for production
         run: npm run build-prod
+      - name: Use Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Download the Static Channel Analysis CLI
+        run: |
+          curl -sSL "https://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip" -o sca-cmd.zip
+          unzip sca-cmd.zip
+      - name: Run Analysis 
+        run: ./sca-cmd/bin/sca-cmd ${{ github.workspace }}/build/staging --exit error
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: Jellyfin-Roku-v${{ env.newManVersion }}-${{ github.sha }}

--- a/.github/workflows/roku-analysis.yml
+++ b/.github/workflows/roku-analysis.yml
@@ -2,6 +2,7 @@ name: roku-analysis
 
 on:
   pull_request:
+  push:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/roku-analysis.yml
+++ b/.github/workflows/roku-analysis.yml
@@ -1,0 +1,38 @@
+name: roku-analysis
+
+on:
+  pull_request:
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+      - name: NPM install
+        run: npm ci
+      - name: Install roku module dependencies
+        run: npm run ropm
+      - name: Build dev app
+        if: env.BRANCH_NAME != 'master'
+        run: npm run build
+      - name: Build app for production
+        if: env.BRANCH_NAME == 'master'
+        run: npm run build-prod
+      - name: Use Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Download the Static Channel Analysis CLI
+        run: |
+          curl -sSL "https://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip" -o sca-cmd.zip
+          unzip sca-cmd.zip
+      - name: Run Roku Static Analysis
+        run: ./sca-cmd/bin/sca-cmd ${{ github.workspace }}/build/staging --exit error


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Add static analysis to build job. This downloads  https://devtools.web.roku.com/#static-channel-analysis-tool and analyze the build.
I just added the tool to [Playlet](https://github.com/iBicha/playlet/blob/936eefeeb94b6667c9778b2bbe0a1c4e54cdb659/.github/workflows/release.yml#L45), I thought it might save me from unpleasant surprises when I try to publish.
Things to consider:
- I only added this to the build-prod job, you might be interested in other jobs (dev, at PR level, etc)
- I'm analyzing the staging folder, not the zipped artifact
- We're downloading from `https://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip` without a pinned version, let's hope that Roku folks are good at not breaking things

That being said, feel free to modify, merge, repurpose, or close this PR

## Issues
<!-- Tag any issues that this PR solves here. -->

N/A
