### PR TITLE
Update settings.json to fix double-entry of "Disable Community Rating for Episodes"

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1031,8 +1031,8 @@
             <translation>Enable Limit</translation>
         </message>
         <message>
-            <source>Enable or disable  the 'Maximum Bitrate' setting.</source>
-            <translation>Enable or disable  the 'Maximum Bitrate' setting.</translation>
+            <source>Enable or disable the 'Maximum Bitrate' setting.</source>
+            <translation>Enable or disable the 'Maximum Bitrate' setting.</translation>
         </message>
         <message>
             <source>Bitrate Limit</source>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -9,7 +9,7 @@
                 "children": [
                     {
                         "title": "Enable Limit",
-                        "description": "Enable or disable  the 'Maximum Bitrate' setting.",
+                        "description": "Enable or disable the 'Maximum Bitrate' setting.",
                         "settingName": "playback.bitrate.maxlimited",
                         "type": "bool",
                         "default": "true"
@@ -133,13 +133,6 @@
                         "title": "Use Splashscreen as Home Background",
                         "description": "Use generated splashscreen image as Jellyfin's home background. Jellyfin will need to be closed and reopened for change to take effect.",
                         "settingName": "ui.home.splashBackground",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
-                        "title": "Disable Community Rating for Episodes",
-                        "description": "If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.",
-                        "settingName": "ui.tvshows.disableCommunityRating",
                         "type": "bool",
                         "default": "false"
                     }


### PR DESCRIPTION
Removing double entry of "Disable Community Rating for Episodes". I kept the one under TV Shows vs the general User Interface as it relates to TV shows

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
Fixes #1291
