### PR TITLE
Test audio codecs for max audio channels supported

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -511,7 +511,7 @@ function getDeviceProfile() as object
         ]
     })
     ' test each codec to see how many channels are supported
-    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "aac", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
+    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
     audioChannels = [8, 6, 2] ' highest first
     for each audioCodec in audioCodecs
         for each audioChannel in audioChannels

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -490,7 +490,7 @@ function getDeviceProfile() as object
         audioChannels = [8, 6, 2] ' highest first
         for each audioCodec in audioCodecs
             for each audioChannel in audioChannels
-                if di.CanDecodeAudio({ Codec: audioCodec, ChCnt: audioChannel }).Result
+                if di.CanDecodeAudio({ Codec: audioCodec, ChCnt: audioChannel, Container: audioCodec }).Result
                     deviceProfile.CodecProfiles.push({
                         "Type": "Audio",
                         "Codec": audioCodec,


### PR DESCRIPTION
Possible fix for opus 5.1 files direct playing when they shouldn't.

If we know the device supports surround sound, test each audio codec to see how many channels are supported. Otherwise just limit all codecs to 2 channels.
