### PR TITLE
Use task node to post deviceprofile + post deviceprofile when exiting the settings screen

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -375,7 +375,6 @@ end function
 ' Return the Post Task to it's default state
 sub postFinished()
     m.postTask.unobserveField("responseCode")
-    ' Empty the Post Task data to its default state
     m.postTask.apiUrl = ""
     m.postTask.arrayData = {}
     m.postTask.stringData = ""

--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -403,12 +403,9 @@ function postProfile() as boolean
     return true
 end function
 
-' Return the Post Task to it's default state
+' Post Task is finished
 sub postFinished()
     m.postTask.unobserveField("responseCode")
-    m.postTask.apiUrl = ""
-    m.postTask.arrayData = {}
-    m.postTask.stringData = ""
-    m.postTask.responseCode = 0
+    m.postTask.callFunc("emptyPostTask")
     m.postTask.observeField("responseCode", "postFinished")
 end sub

--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -366,7 +366,38 @@ end function
 
 ' Send Device Profile information to server
 function postProfile() as boolean
-    m.postTask.arrayData = getDeviceCapabilities()
+    profile = getDeviceCapabilities()
+    print "profile =", profile
+    print "profile.DeviceProfile =", profile.DeviceProfile
+    print "profile.DeviceProfile.CodecProfiles ="
+    for each prof in profile.DeviceProfile.CodecProfiles
+        print prof
+        for each cond in prof.Conditions
+            print cond
+        end for
+    end for
+    print "profile.DeviceProfile.ContainerProfiles =", profile.DeviceProfile.ContainerProfiles
+    print "profile.DeviceProfile.DirectPlayProfiles ="
+    for each prof in profile.DeviceProfile.DirectPlayProfiles
+        print prof
+    end for
+    print "profile.DeviceProfile.SubtitleProfiles ="
+    for each prof in profile.DeviceProfile.SubtitleProfiles
+        print prof
+    end for
+    print "profile.DeviceProfile.TranscodingProfiles ="
+    for each prof in profile.DeviceProfile.TranscodingProfiles
+        print prof
+        if isValid(prof.Conditions)
+            for each condition in prof.Conditions
+                print condition
+            end for
+        end if
+    end for
+    print "profile.PlayableMediaTypes =", profile.PlayableMediaTypes
+    print "profile.SupportedCommands =", profile.SupportedCommands
+
+    m.postTask.arrayData = profile
     m.postTask.apiUrl = "/Sessions/Capabilities/Full"
     m.postTask.control = "RUN"
     return true

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -14,6 +14,7 @@
     <function name="dismissDialog" />
     <function name="isDialogOpen" />
     <function name="optionDialog" />
+    <function name="postProfile" />
     <field id="currentUser" type="string" onChange="updateUser" />
     <field id="returnData" type="assocarray" />
     <field id="dataReturned" type="boolean" />

--- a/components/tasks/PostTask.bs
+++ b/components/tasks/PostTask.bs
@@ -7,17 +7,17 @@ end sub
 sub postItems()
     if m.top.apiUrl <> ""
         if m.top.arrayData.count() > 0 and m.top.stringData = ""
-            print "PostTask Started - " + m.top.apiUrl, m.top.arrayData
+            print "PostTask Started - Posting array to " + m.top.apiUrl
             req = APIRequest(m.top.apiUrl)
             req.SetRequest("POST")
-            httpResponse = jsonPostTask(req, FormatJson(m.top.arrayData))
+            httpResponse = asyncPost(req, FormatJson(m.top.arrayData))
             m.top.responseCode = httpResponse
             print "PostTask Finished. " + m.top.apiUrl + " Response = " + httpResponse.toStr()
         else if m.top.arrayData.count() = 0 and m.top.stringData <> ""
-            print "PostTask Started - " + m.top.apiUrl + " Data= " + m.top.stringData
+            print "PostTask Started - Posting string(" + m.top.stringData + ") to " + m.top.apiUrl
             req = APIRequest(m.top.apiUrl)
             req.SetRequest("POST")
-            httpResponse = jsonPostTask(req, m.top.stringData)
+            httpResponse = asyncPost(req, m.top.stringData)
             m.top.responseCode = httpResponse
             print "PostTask Finished. " + m.top.apiUrl + " Response = " + httpResponse.toStr()
         else
@@ -29,11 +29,46 @@ sub postItems()
 end sub
 
 ' Post data and wait for response code
-function jsonPostTask(req, data = "" as string) as integer
+function asyncPost(req, data = "" as string) as integer
+    ' response code 0 means there was an error
+    respCode = 0
+
     req.setMessagePort(CreateObject("roMessagePort"))
     req.AddHeader("Content-Type", "application/json")
-    resp = req.PostFromString(data)
+    req.AsyncPostFromString(data)
+    ' wait up to m.top.timeoutSeconds for a response
+    ' NOTE: wait() uses milliseconds - multiply by 1000 to convert
+    resp = wait(m.top.timeoutSeconds * 1000, req.GetMessagePort())
 
-    return resp
+    respString = resp.GetString()
+    if respString <> invalid and respString <> ""
+        m.top.responseBody = ParseJson(respString)
+        print "m.top.responseBody=", m.top.responseBody
+    end if
+
+    respCode = resp.GetResponseCode()
+    if respCode < 0
+        ' there was an unexpected error
+        m.top.failureReason = resp.GetFailureReason()
+    else if respCode >= 200 and respCode < 300
+        ' save response headers if they're available
+        m.top.responseHeaders = resp.GetResponseHeaders()
+    end if
+
+    return respCode
 end function
 
+' Revert PostTask to default state
+sub emptyPostTask()
+    ' These should match the defaults set in PostTask.xml
+    m.top.apiUrl = ""
+    m.top.timeoutSeconds = 30
+
+    m.top.arrayData = {}
+    m.top.stringData = ""
+
+    m.top.responseCode = invalid
+    m.top.responseBody = {}
+    m.top.responseHeaders = {}
+    m.top.failureReason = ""
+end sub

--- a/components/tasks/PostTask.bs
+++ b/components/tasks/PostTask.bs
@@ -1,0 +1,39 @@
+import "pkg:/source/api/baserequest.brs"
+
+sub init()
+    m.top.functionName = "postItems"
+end sub
+
+sub postItems()
+    if m.top.apiUrl <> ""
+        if m.top.arrayData.count() > 0 and m.top.stringData = ""
+            print "PostTask Started - " + m.top.apiUrl, m.top.arrayData
+            req = APIRequest(m.top.apiUrl)
+            req.SetRequest("POST")
+            httpResponse = jsonPostTask(req, FormatJson(m.top.arrayData))
+            m.top.responseCode = httpResponse
+            print "PostTask Finished. " + m.top.apiUrl + " Response = " + httpResponse.toStr()
+        else if m.top.arrayData.count() = 0 and m.top.stringData <> ""
+            print "PostTask Started - " + m.top.apiUrl + " Data= " + m.top.stringData
+            req = APIRequest(m.top.apiUrl)
+            req.SetRequest("POST")
+            httpResponse = jsonPostTask(req, m.top.stringData)
+            m.top.responseCode = httpResponse
+            print "PostTask Finished. " + m.top.apiUrl + " Response = " + httpResponse.toStr()
+        else
+            print "ERROR processing data for PostTask"
+        end if
+    else
+        print "ERROR in PostTask. Invalid API URL provided"
+    end if
+end sub
+
+' Post data and wait for response code
+function jsonPostTask(req, data = "" as string) as integer
+    req.setMessagePort(CreateObject("roMessagePort"))
+    req.AddHeader("Content-Type", "application/json")
+    resp = req.PostFromString(data)
+
+    return resp
+end function
+

--- a/components/tasks/PostTask.xml
+++ b/components/tasks/PostTask.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<component name="PostTask" extends="Task">
+    <interface>
+        <field id="arrayData" type="assocarray" value="{}" />
+        <field id="stringData" type="string" value="" />
+        <field id="apiUrl" type="string" />
+
+        <field id="responseCode" type="integer" value="0" />
+    </interface>
+</component>

--- a/components/tasks/PostTask.xml
+++ b/components/tasks/PostTask.xml
@@ -2,10 +2,17 @@
 
 <component name="PostTask" extends="Task">
     <interface>
+        <field id="apiUrl" type="string" />
+        <field id="timeoutSeconds" type="integer" value="30" />
+
         <field id="arrayData" type="assocarray" value="{}" />
         <field id="stringData" type="string" value="" />
-        <field id="apiUrl" type="string" />
 
-        <field id="responseCode" type="integer" value="0" />
+        <field id="responseCode" type="integer" />
+        <field id="responseBody" type="assocarray" value="{}" />
+        <field id="responseHeaders" type="assocarray" value="{}" />
+        <field id="failureReason" type="string" value="" />
+
+        <function name="emptyPostTask" />
     </interface>
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -32,7 +32,7 @@ sub Main (args as dynamic) as void
     ' First thing to do is validate the ability to use the API
     if not LoginFlow() then return
     ' tell jellyfin server about device capabilities
-    PostDeviceProfile()
+    m.global.sceneManager.callFunc("postProfile")
     ' remove previous scenes from the stack
     sceneManager.callFunc("clearScenes")
 
@@ -621,12 +621,12 @@ sub Main (args as dynamic) as void
                 ' The audio codec capability has changed if true.
                 print "event.audioCodecCapabilityChanged = ", event.audioCodecCapabilityChanged
 
-                PostDeviceProfile()
+                m.global.sceneManager.callFunc("postProfile")
             else if isValid(event.videoCodecCapabilityChanged)
                 ' The video codec capability has changed if true.
                 print "event.videoCodecCapabilityChanged = ", event.videoCodecCapabilityChanged
 
-                PostDeviceProfile()
+                m.global.sceneManager.callFunc("postProfile")
             else if isValid(event.appFocus)
                 ' It is set to False when the System Overlay (such as the confirm partner button HUD or the caption control overlay) takes focus and True when the channel regains focus
                 print "event.appFocus = ", event.appFocus

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -17,14 +17,6 @@ function getDeviceCapabilities() as object
     }
 end function
 
-' Send Device Profile information to server
-sub PostDeviceProfile()
-    body = getDeviceCapabilities()
-    req = APIRequest("/Sessions/Capabilities/Full")
-    req.SetRequest("POST")
-    postJson(req, FormatJson(body))
-end sub
-
 function getDeviceProfile() as object
     playMpeg2 = m.global.session.user.settings["playback.mpeg2"]
     playAv1 = m.global.session.user.settings["playback.av1"]


### PR DESCRIPTION
Some user settings affect the device profile. This pr ensures that the server always has an updated device proflie from the roku device and also moves the post call off of the main render thread.

## Changes
- Create generic task node for posting data (async)
  - Post timeout is customizable - defaults to 30s
  - Response body, header, and failure reason are saved
  - Expose `emptyPostTask` function to restore task to default state
- Use new post task when posting device profile to prevent blocking the render thread
  - Task is saved to scenemanager so that it can be reused anywhere else in the app
- Update scenemanger to post device profile when exiting the settings screen

