### PR TITLE
Update settings page UI to create more space for long radio lists

### DIFF
--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -4,7 +4,6 @@ import "pkg:/source/roku_modules/log/LogMixin.brs"
 
 sub init()
     m.log = log.Logger("Settings")
-    m.top.overhangTitle = tr("Settings")
     m.top.optionsAvailable = false
 
     m.userLocation = []
@@ -12,7 +11,6 @@ sub init()
     m.settingsMenu = m.top.findNode("settingsMenu")
     m.settingDetail = m.top.findNode("settingDetail")
     m.settingDesc = m.top.findNode("settingDesc")
-    m.settingTitle = m.top.findNode("settingTitle")
     m.path = m.top.findNode("path")
 
     m.boolSetting = m.top.findNode("boolSetting")
@@ -72,7 +70,7 @@ sub LoadMenu(configSection)
     end if
 
     ' Set Path display
-    m.path.text = ""
+    m.path.text = tr("Settings")
     for each level in m.userLocation
         if level.title <> invalid then m.path.text += " / " + tr(level.title)
     end for
@@ -82,7 +80,7 @@ sub settingFocused()
 
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
     m.settingDesc.text = tr(selectedSetting.Description)
-    m.settingTitle.text = tr(selectedSetting.Title)
+    m.top.overhangTitle = tr(selectedSetting.Title)
 
     ' Hide Settings
     m.boolSetting.visible = false

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -7,32 +7,35 @@
     <LabelList
       translation="[120,250]"
       id="settingsMenu"
-      itemSize="[440,48]"
+      itemSize="[510,54]"
       vertFocusAnimationStyle="floatingFocus"
       focusBitmapBlendColor="#006fab"
       focusedColor="#ffffff"
-      itemSpacing="[0,5]" />
+      itemSpacing="[0,9]"
+      textVertAlign="center" />
 
     <Poster
-      translation="[710,250]" id="testRectangle" width="880" height="700" uri="pkg:/images/white.9.png"
+      translation="[710,230]" id="testRectangle" width="1210" height="830" uri="pkg:/images/white.9.png"
       blendColor="#3f3f3f" />
 
-    <LayoutGroup translation="[1150,275]" id="settingDetail" vertAlignment="top" horizAlignment="center" itemSpacings="[50]">
+    <LayoutGroup translation="[1278,270]" id="settingDetail" vertAlignment="top" horizAlignment="center" itemSpacings="[50]">
+      <Label id="settingDesc"
+        width="1065"
+        wrap="true"
+        horizAlign="center"
+        translation="[750,270]" />
 
-      <ScrollingLabel font="font:LargeSystemFont" id="settingTitle" maxWidth="750" />
-
-      <Label id="settingDesc" width="750" wrap="true" />
-
-      <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus">
-        <ContentNode role="content">
-          <ContentNode title="Disabled" />
-          <ContentNode title="Enabled" />
-        </ContentNode>
-      </RadioButtonList>
+      <RadioButtonList id="radioSetting" vertFocusAnimationStyle="floatingFocus" />
     </LayoutGroup>
 
-    <RadioButtonList id="radioSetting" translation="[900, 450]" inheritParentTransform="false" vertFocusAnimationStyle="floatingFocus" />
-    <intkeyboard_integerKeyboard translation="[900, 520]" id="integerSetting" maxLength="3" domain="numeric" visible="false" />
+    <RadioButtonList id="boolSetting" vertFocusAnimationStyle="floatingFocus" translation="[1034, 510]">
+      <ContentNode role="content">
+        <ContentNode title="Disabled" />
+        <ContentNode title="Enabled" />
+      </ContentNode>
+    </RadioButtonList>
+
+    <intkeyboard_integerKeyboard translation="[1034, 510]" id="integerSetting" maxLength="3" domain="numeric" visible="false" />
 
   </children>
 </component>


### PR DESCRIPTION
My only motivation for these changes were to create more room for long lists of settings like the one I just made with the new "Maximum Resolution" setting and this PR does the trick.

Another solution would have been to make the list of radio options loop around so we wouldn't need the full vertical space. I'm open to that solution instead of or in addition to this one. This was was just easier to implement for me at the time.

## Changes
- Move setting title from the right area to the overhang
- Move "Settings" from the overhang to the breadcrumb area
- Modify the grey rectangle background to stretch to the edge of the screen
  - At least it should. I'm testing with a TV that uses overscan so this might need tweaked

Before:
![PXL_20230912_233226298 MP](https://github.com/jellyfin/jellyfin-roku/assets/16514652/49ae15f1-e1b6-42e2-a0f9-e85524272ceb)

After:
![PXL_20230912_233144997 MP](https://github.com/jellyfin/jellyfin-roku/assets/16514652/25b35ae5-d4e1-4ddb-9e36-c40c17257570)

