### PR TITLE
Copy custom subtitle functionality into new Global Queue Player

### DIFF
--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -54,7 +54,7 @@ sub init()
     m.top.trickPlayBar.filledBarBlendColor = m.global.constants.colors.blue
 end sub
 
-' Custom Caption Function
+' Only setup captain items if captions are allowed
 sub onAllowCaptionsChange()
     if not m.top.allowCaptions then return
 
@@ -66,20 +66,22 @@ sub onAllowCaptionsChange()
     m.top.observeField("subtitleTrack", "loadCaption")
     m.top.observeField("globalCaptionMode", "toggleCaption")
 
-    if get_user_setting("playback.subs.custom") = "false"
-        m.top.suppressCaptions = false
-    else
+    if m.global.session.user.settings["playback.subs.custom"]
         m.top.suppressCaptions = true
         toggleCaption()
+    else
+        m.top.suppressCaptions = false
     end if
 end sub
 
+' Set caption url to server subtitle track
 sub loadCaption()
     if m.top.suppressCaptions
         m.captionTask.url = m.top.subtitleTrack
     end if
 end sub
 
+' Toggles visibility of custom subtitles and sets captionTask's player state
 sub toggleCaption()
     m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
     if LCase(m.top.globalCaptionMode) = "on"
@@ -90,11 +92,13 @@ sub toggleCaption()
     end if
 end sub
 
+' Removes old subtitle lines and adds new subtitle lines
 sub updateCaption()
     m.captionGroup.removeChildrenIndex(m.captionGroup.getChildCount(), 0)
     m.captionGroup.appendChildren(m.captionTask.currentCaption)
 end sub
 
+' Event handler for when selectedSubtitle changes
 sub onSubtitleChange()
     ' Save the current video position
     m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -23,6 +23,7 @@
     <field id="mediaSourceId" type="string" />
     <field id="fullSubtitleData" type="array" />
     <field id="audioIndex" type="integer" />
+    <field id="allowCaptions" type="boolean" value="false" />
   </interface>
 
   <children>

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -7,7 +7,6 @@
     <field id="PlaySessionId" type="string" />
     <field id="Subtitles" type="array" />
     <field id="SelectedSubtitle" type="integer" value="-1" alwaysNotify="true" />
-    <field id="captionMode" type="string" />
     <field id="container" type="string" />
     <field id="directPlaySupported" type="boolean" />
     <field id="systemOverlay" type="boolean" value="false" />
@@ -27,6 +26,7 @@
   </interface>
 
   <children>
+    <Group id="captionGroup" translation="[960,1020]" />
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
 

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -197,24 +197,15 @@ sub Main (args as dynamic) as void
 
                     selectedItem.selectedAudioStreamIndex = audio_stream_idx
 
-                    ' If we are playing a playlist, always start at the beginning
-                    if m.global.queueManager.callFunc("getCount") > 1
-                        selectedItem.startingPoint = 0
+                    ' Display playback options dialog
+                    if selectedItem.json.userdata.PlaybackPositionTicks > 0
+                        m.global.queueManager.callFunc("hold", selectedItem)
+                        playbackOptionDialog(selectedItem.json.userdata.PlaybackPositionTicks, selectedItem.json)
+                    else
                         m.global.queueManager.callFunc("clear")
                         m.global.queueManager.callFunc("push", selectedItem)
                         m.global.queueManager.callFunc("playQueue")
-                    else
-                        ' Display playback options dialog
-                        if selectedItem.json.userdata.PlaybackPositionTicks > 0
-                            m.global.queueManager.callFunc("hold", selectedItem)
-                            playbackOptionDialog(selectedItem.json.userdata.PlaybackPositionTicks, selectedItem.json)
-                        else
-                            m.global.queueManager.callFunc("clear")
-                            m.global.queueManager.callFunc("push", selectedItem)
-                            m.global.queueManager.callFunc("playQueue")
-                        end if
                     end if
-
 
                 else if selectedItemType = "Series"
                     group = CreateSeriesDetailsGroup(selectedItem.json.id)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
I copied the custom subtitle functionality and the crashing fix #1133 from the old VideoPlayer into the new Global Queue Player. This allows CJK subtitles to work with the new video player used across the client except f

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #1162. Though we're fixing it in a different order than I originally thought months ago, but that's ok. Now the issue will be fixed prior to us using global queue player in other areas.