### PR TITLE
Improve Quick Play support + Add support for Music Videos

### DIFF
--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -780,11 +780,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.loadItemsTask.control = "stop"
             return true
         end if
-    else if key = "play" or key = "OK"
+    else if key = "play"
         markupGrid = m.top.findNode("itemGrid")
         itemToPlay = markupGrid.content.getChild(markupGrid.itemFocused)
 
-        if itemToPlay <> invalid and (itemToPlay.type = "Movie" or itemToPlay.type = "Episode")
+        if itemToPlay <> invalid
             m.top.quickPlayNode = itemToPlay
             return true
         else if itemToPlay <> invalid and itemToPlay.type = "Photo"

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -734,6 +734,16 @@ sub onChannelFocused(msg)
     m.channelFocused = node.focusedChannel
 end sub
 
+'Returns Focused Item
+function getItemFocused()
+    if m.itemGrid.isinFocusChain() and isValid(m.itemGrid.itemFocused)
+        return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
+    else if m.genreList.isinFocusChain() and isValid(m.genreList.rowItemFocused)
+        return m.genreList.content.getChild(m.genreList.rowItemFocused[0]).getChild(m.genreList.rowItemFocused[1])
+    end if
+    return invalid
+end function
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
@@ -782,8 +792,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     else if key = "play"
         markupGrid = m.top.findNode("itemGrid")
-        itemToPlay = markupGrid.content.getChild(markupGrid.itemFocused)
-
+        itemToPlay = getItemFocused()
+        print "itemToPlay=", itemToPlay
         if itemToPlay <> invalid
             m.top.quickPlayNode = itemToPlay
             return true

--- a/components/ItemGrid/ItemGrid.brs
+++ b/components/ItemGrid/ItemGrid.brs
@@ -717,6 +717,7 @@ sub showTVGuide()
     m.tvGuide.filter = m.filter
     m.tvGuide.searchTerm = m.voiceBox.text
     m.top.appendChild(m.tvGuide)
+    m.scheduleGrid = m.top.findNode("scheduleGrid")
     m.tvGuide.lastFocus.setFocus(true)
 end sub
 
@@ -740,6 +741,8 @@ function getItemFocused()
         return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
     else if m.genreList.isinFocusChain() and isValid(m.genreList.rowItemFocused)
         return m.genreList.content.getChild(m.genreList.rowItemFocused[0]).getChild(m.genreList.rowItemFocused[1])
+    else if m.scheduleGrid.isinFocusChain() and isValid(m.scheduleGrid.itemFocused)
+        return m.scheduleGrid.content.getChild(m.scheduleGrid.itemFocused)
     end if
     return invalid
 end function
@@ -793,7 +796,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "play"
         markupGrid = m.top.findNode("itemGrid")
         itemToPlay = getItemFocused()
-        print "itemToPlay=", itemToPlay
+
         if itemToPlay <> invalid
             m.top.quickPlayNode = itemToPlay
             return true

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -707,7 +707,12 @@ end sub
 '
 'Returns Focused Item
 function getItemFocused()
-    return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
+    if m.itemGrid.isinFocusChain() and isValid(m.itemGrid.itemFocused)
+        return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
+    else if m.genreList.isinFocusChain() and isValid(m.genreList.rowItemFocused)
+        return m.genreList.content.getChild(m.genreList.rowItemFocused[0]).getChild(m.genreList.rowItemFocused[1])
+    end if
+    return invalid
 end function
 
 '

--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -869,11 +869,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.loadItemsTask.control = "stop"
             return true
         end if
-    else if key = "play" or key = "OK"
-
+    else if key = "play"
         itemToPlay = getItemFocused()
 
-        if itemToPlay <> invalid and (itemToPlay.type = "Movie" or itemToPlay.type = "Episode")
+        if itemToPlay <> invalid
             m.top.quickPlayNode = itemToPlay
             return true
         end if

--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -750,7 +750,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
             alpha.setFocus(true)
             return true
         end if
-
     else if key = "right" and m.Alpha.isinFocusChain()
         m.top.alphaActive = false
         m.Alpha.setFocus(false)
@@ -760,14 +759,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         m.genreList.setFocus(m.genreList.opacity = 1)
 
         return true
-
     else if key = "replay" and m.itemGrid.isinFocusChain()
         if m.resetGrid = true
             m.itemGrid.animateToItem = 0
         else
             m.itemGrid.jumpToItem = 0
         end if
-
     else if key = "replay" and m.genreList.isinFocusChain()
         if m.resetGrid = true
             m.genreList.animateToItem = 0
@@ -775,6 +772,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.genreList.jumpToItem = 0
         end if
         return true
+    else if key = "play"
+        itemToPlay = getItemFocused()
+        if itemToPlay <> invalid
+            m.top.quickPlayNode = itemToPlay
+            return true
+        end if
     end if
 
     if key = "replay"

--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -572,7 +572,12 @@ end sub
 '
 'Returns Focused Item
 function getItemFocused()
-    return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
+    if m.itemGrid.isinFocusChain() and isValid(m.itemGrid.itemFocused)
+        return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
+    else if m.genreList.isinFocusChain() and isValid(m.genreList.itemFocused)
+        return m.genreList.content.getChild(m.genreList.itemFocused)
+    end if
+    return invalid
 end function
 
 '

--- a/components/data/HomeData.brs
+++ b/components/data/HomeData.brs
@@ -31,7 +31,7 @@ sub setData()
             m.top.iconUrl = "pkg:/images/media_type_icons/folder_white.png"
         end if
 
-    else if datum.type = "Episode"
+    else if datum.type = "Episode" or datum.type = "MusicVideo"
         m.top.isWatched = datum.UserData.Played
 
         imgParams = {}
@@ -72,32 +72,7 @@ sub setData()
             m.top.widePosterUrl = ImageURL(datum.Id, "Backdrop", imgParams)
         end if
 
-    else if datum.type = "Movie"
-        m.top.isWatched = datum.UserData.Played
-
-        imgParams = {}
-        imgParams.Append({ "maxHeight": 261 })
-        imgParams.Append({ "maxWidth": 175 })
-
-        if datum.ImageTags.Primary <> invalid
-            param = { "Tag": datum.ImageTags.Primary }
-            imgParams.Append(param)
-        end if
-
-        m.top.posterURL = ImageURL(datum.id, "Primary", imgParams)
-
-        ' For wide image, use backdrop
-        imgParams["maxWidth"] = 464
-
-        if datum.ImageTags <> invalid and datum.imageTags.Thumb <> invalid
-            imgParams["Tag"] = datum.imageTags.Thumb
-            m.top.thumbnailUrl = ImageURL(datum.Id, "Thumb", imgParams)
-        else if datum.BackdropImageTags[0] <> invalid
-            imgParams["Tag"] = datum.BackdropImageTags[0]
-            m.top.thumbnailUrl = ImageURL(datum.id, "Backdrop", imgParams)
-        end if
-
-    else if datum.type = "Video"
+    else if datum.type = "Movie" or datum.type = "Video"
         m.top.isWatched = datum.UserData.Played
 
         imgParams = {}
@@ -126,12 +101,10 @@ sub setData()
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
         m.top.posterUrl = m.top.thumbnailURL
-
     else if datum.type = "TvChannel" or datum.type = "Channel"
         params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
         m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
         m.top.iconUrl = "pkg:/images/media_type_icons/live_tv_white.png"
     end if
-
 end sub

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -3,6 +3,7 @@ sub init()
     updateSize()
     m.top.rowFocusAnimationStyle = "fixedFocus"
     m.top.observeField("rowItemSelected", "onRowItemSelected")
+    m.top.observeField("rowItemFocused", "onRowItemFocused")
 
     ' Set up all Tasks
     m.LoadPeopleTask = CreateObject("roSGNode", "LoadItemsTask")
@@ -206,4 +207,8 @@ end sub
 
 sub onRowItemSelected()
     m.top.selectedItem = m.top.content.getChild(m.top.rowItemSelected[0]).getChild(m.top.rowItemSelected[1])
+end sub
+
+sub onRowItemFocused()
+    m.top.focusedItem = m.top.content.getChild(m.top.rowItemFocused[0]).getChild(m.top.rowItemFocused[1])
 end sub

--- a/components/extras/ExtrasRowList.xml
+++ b/components/extras/ExtrasRowList.xml
@@ -4,6 +4,7 @@
   <interface>
     <field id="type" type="string" />
     <field id="parentId" type="string" />
+    <field id="focusedItem" type="node" alwaysNotify="true" />
     <field id="selectedItem" type="node" alwaysNotify="true" />
     <function name="loadParts" />
     <function name="loadPersonVideos" />

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -30,6 +30,9 @@ end sub
 sub itemContentChanged()
     itemData = m.top.itemContent
     if itemData = invalid then return
+
+    print "itemData=", itemData
+    print "itemData.json=", itemData.json
     itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
 
     m.itemPoster.width = itemData.imageWidth
@@ -135,7 +138,7 @@ sub itemContentChanged()
         return
     end if
 
-    if itemData.type = "Movie"
+    if itemData.type = "Movie" or itemData.type = "MusicVideo"
         m.itemText.text = itemData.name
 
         if itemData.PlayedPercentage > 0

--- a/components/home/HomeItem.brs
+++ b/components/home/HomeItem.brs
@@ -31,8 +31,6 @@ sub itemContentChanged()
     itemData = m.top.itemContent
     if itemData = invalid then return
 
-    print "itemData=", itemData
-    print "itemData.json=", itemData.json
     itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
 
     m.itemPoster.width = itemData.imageWidth

--- a/components/home/HomeRows.brs
+++ b/components/home/HomeRows.brs
@@ -440,21 +440,20 @@ sub itemSelected()
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    handled = false
     if press
         if key = "play"
+            print "play was pressed from homerow"
             itemToPlay = m.top.content.getChild(m.top.rowItemFocused[0]).getChild(m.top.rowItemFocused[1])
-            if isValid(itemToPlay) and (itemToPlay.type = "Movie" or itemToPlay.type = "Episode")
+            if isValid(itemToPlay)
                 m.top.quickPlayNode = itemToPlay
             end if
-            handled = true
-        end if
-
-        if key = "replay"
+            return true
+        else if key = "replay"
             m.top.jumpToRowItem = [m.top.rowItemFocused[0], 0]
+            return true
         end if
     end if
-    return handled
+    return false
 end function
 
 function filterNodeArray(nodeArray as object, nodeKey as string, excludeArray as object) as object

--- a/components/home/HomeRows.xml
+++ b/components/home/HomeRows.xml
@@ -2,7 +2,7 @@
 <component name="HomeRows" extends="RowList">
   <interface>
     <field id="selectedItem" type="node" alwaysNotify="true" />
-    <field id="quickPlayNode" type="node" alwaysNotify="true" />
+    <field id="quickPlayNode" type="node" />
     <function name="updateHomeRows" />
     <function name="loadLibraries" />
   </interface>

--- a/components/home/LoadItemsTask.brs
+++ b/components/home/LoadItemsTask.brs
@@ -137,7 +137,8 @@ sub loadItems()
         if isValid(data) and isValid(data.Items)
             for each item in data.Items
                 ' Skip Books for now as we don't support it (issue #558)
-                if item.Type <> "Book"
+                ' also skip songs since there is limited space
+                if not (item.Type = "Book" or item.Type = "Audio")
                     tmp = CreateObject("roSGNode", "HomeData")
 
                     params = {}

--- a/components/manager/QueueManager.brs
+++ b/components/manager/QueueManager.brs
@@ -127,6 +127,11 @@ sub playQueue()
         return
     end if
 
+    if nextItemMediaType = "movie"
+        CreateVideoPlayerView()
+        return
+    end if
+
     if nextItemMediaType = "episode"
         CreateVideoPlayerView()
         return

--- a/components/manager/QueueManager.brs
+++ b/components/manager/QueueManager.brs
@@ -125,6 +125,11 @@ sub playQueue()
         return
     end if
 
+    if nextItemMediaType = "musicvideo"
+        CreateVideoPlayerView()
+        return
+    end if
+
     if nextItemMediaType = "video"
         CreateVideoPlayerView()
         return

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -383,6 +383,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
             audioOptionsClosed()
             return true
         end if
+    else if key = "play" and m.extrasGrid.hasFocus()
+        print "Play was pressed from the movie details extras slider"
+        if m.extrasGrid.focusedItem <> invalid
+            m.top.quickPlayNode = m.extrasGrid.focusedItem
+            return true
+        end if
     end if
     return false
 end function

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -50,5 +50,6 @@
     <field id="trailerAvailable" type="bool" onChange="trailerAvailableChanged" value="false" />
     <field id="selectedAudioStreamIndex" type="integer" />
     <field id="selectedVideoStreamId" type="string" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
   </interface>
 </component>

--- a/components/music/ArtistView.brs
+++ b/components/music/ArtistView.brs
@@ -314,11 +314,19 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = "play"
-        itemToPlay = m.albums.MusicArtistAlbumData.items[m.albums.itemFocused]
+        print "play button pressed from ArtistView"
+        itemToPlay = invalid
+
+        if isValid(m.albums) and m.albums.isInFocusChain()
+            itemToPlay = m.albums.MusicArtistAlbumData.items[m.albums.itemFocused]
+        else if isValid(m.appearsOn) and m.appearsOn.isInFocusChain()
+            itemToPlay = m.appearsOn.MusicArtistAlbumData.items[m.appearsOn.itemFocused]
+        end if
+
         if isValid(itemToPlay)
             m.top.quickPlayNode = itemToPlay
+            return true
         end if
-        return true
     end if
 
     return false

--- a/components/music/ArtistView.brs
+++ b/components/music/ArtistView.brs
@@ -313,5 +313,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
+    if key = "play"
+        itemToPlay = m.albums.MusicArtistAlbumData.items[m.albums.itemFocused]
+        if isValid(itemToPlay)
+            m.top.quickPlayNode = itemToPlay
+        end if
+        return true
+    end if
+
     return false
 end function

--- a/components/music/ArtistView.xml
+++ b/components/music/ArtistView.xml
@@ -54,5 +54,6 @@
     <field id="playArtistSelected" alias="play.selected" />
     <field id="instantMixSelected" alias="instantMix.selected" />
     <field id="selectedButtonIndex" type="integer" value="-1" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
   </interface>
 </component>

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -11,7 +11,7 @@
   </children>
   <interface>
     <field id="episodeSelected" alias="picker.itemSelected" />
-    <field id="quickPlayNode" type="node" alwaysNotify="true" />
+    <field id="quickPlayNode" type="node" />
     <field id="seasonData" type="assocarray" onChange="setSeasonLoading" />
     <field id="objects" alias="picker.objects" />
   </interface>

--- a/components/tvshows/TVShowDetails.brs
+++ b/components/tvshows/TVShowDetails.brs
@@ -11,6 +11,7 @@ sub init()
     m.getShuffleEpisodesTask = createObject("roSGNode", "getShuffleEpisodesTask")
     m.Shuffle = m.top.findNode("Shuffle")
     m.extrasSlider.visible = true
+    m.seasons = m.top.findNode("seasons")
 end sub
 
 sub itemContentChanged()
@@ -223,6 +224,20 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "up" and m.Shuffle.hasFocus()
         overview.setFocus(true)
         return true
+    else if key = "play" and m.seasons.hasFocus()
+        print "play was pressed from the seasons row"
+        if isValid(m.seasons.TVSeasonData) and isValid(m.seasons.TVSeasonData.Items)
+            itemFocused = m.seasons.rowItemFocused
+            m.top.quickPlayNode = m.seasons.TVSeasonData.Items[itemFocused[1]]
+            return true
+        end if
+    else if key = "play" and m.extrasSlider.isInFocusChain()
+        print "play was pressed from the extras grid"
+        extrasGrid = m.top.findNode("extrasGrid")
+        if extrasGrid.focusedItem <> invalid
+            m.top.quickPlayNode = extrasGrid.focusedItem
+            return true
+        end if
     end if
 
     return false

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -32,5 +32,6 @@
     <field id="itemContent" type="node" onChange="itemContentChanged" />
     <field id="seasonData" type="assocarray" alias="seasons.TVSeasonData" />
     <field id="seasonSelected" alias="seasons.rowItemSelected" alwaysNotify="true" />
+    <field id="quickPlayNode" type="node" alwaysNotify="true" />
   </interface>
 </component>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -129,24 +129,17 @@ sub Main (args as dynamic) as void
                     if isValid(itemNode.selectedAudioStreamIndex) and itemNode.selectedAudioStreamIndex > 0
                         audio_stream_idx = itemNode.selectedAudioStreamIndex
                     end if
-
                     itemNode.selectedAudioStreamIndex = audio_stream_idx
 
                     playbackPosition = 0
-
-                    ' Display playback options dialog
                     if isValid(itemNode.json) and isValid(itemNode.json.userdata) and isValid(itemNode.json.userdata.PlaybackPositionTicks)
                         playbackPosition = itemNode.json.userdata.PlaybackPositionTicks
                     end if
+                    itemNode.startingPoint = playbackPosition
 
-                    if playbackPosition > 0
-                        m.global.queueManager.callFunc("hold", itemNode)
-                        playbackOptionDialog(playbackPosition, itemNode.json)
-                    else
-                        m.global.queueManager.callFunc("clear")
-                        m.global.queueManager.callFunc("push", itemNode)
-                        m.global.queueManager.callFunc("playQueue")
-                    end if
+                    m.global.queueManager.callFunc("clear")
+                    m.global.queueManager.callFunc("push", itemNode)
+                    m.global.queueManager.callFunc("playQueue")
 
                     ' Prevent quick play node from double firing
                     reportingNode.quickPlayNode = invalid

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -644,6 +644,7 @@ sub Main (args as dynamic) as void
                 '   - "low" means that the general memory is below acceptable levels but not critical
                 '   - "critical" means that general memory are at dangerously low level and that the OS may force terminate the application
                 print "event.generalMemoryLevel = ", event.generalMemoryLevel
+                session.Update("memoreyLevel", event.generalMemoryLevel)
             else if isValid(event.audioCodecCapabilityChanged)
                 ' The audio codec capability has changed if true.
                 print "event.audioCodecCapabilityChanged = ", event.audioCodecCapabilityChanged

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -184,7 +184,7 @@ sub Main (args as dynamic) as void
             end if
             stopLoadingSpinner()
             elapsed = timeSpan.TotalMilliseconds() / 1000
-            print "Quick Play finished loading in " + elapsed.toStr() + " seconds.",
+            print "Quick Play finished loading in " + elapsed.toStr() + " seconds."
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow
             selectedItem = msg.getData()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -116,6 +116,7 @@ sub Main (args as dynamic) as void
                 group.setFocus(true)
             end if
         else if isNodeEvent(msg, "quickPlayNode")
+            startMediaLoadingSpinner()
             group = sceneManager.callFunc("getActiveScene")
             reportingNode = msg.getRoSGNode()
             itemNode = invalid
@@ -342,6 +343,7 @@ sub Main (args as dynamic) as void
                     end if
                 end if
             end if
+            stopLoadingSpinner()
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow
             selectedItem = msg.getData()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -189,6 +189,8 @@ sub Main (args as dynamic) as void
                         quickplay.person(itemNode)
                     else if itemType = "tvchannel"
                         quickplay.tvChannel(itemNode)
+                    else if itemType = "program"
+                        quickplay.program(itemNode)
                     end if
 
                     m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -177,6 +177,8 @@ sub Main (args as dynamic) as void
                         quickplay.playlist(itemNode)
                     else if itemType = "userview"
                         quickplay.userView(itemNode)
+                    else if itemType = "folder"
+                        quickplay.folder(itemNode)
                     end if
 
                     m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -127,8 +127,9 @@ sub Main (args as dynamic) as void
             if isValid(reportingNode)
                 itemNode = reportingNode.quickPlayNode
                 reportingNodeType = reportingNode.subtype()
-                ' prevent double fire on continue watching home row
-                if isValid(reportingNodeType) and reportingNodeType = "Home"
+                print "Quick Play reporting node type=", reportingNodeType
+                ' prevent double fire bug
+                if isValid(reportingNodeType) and (reportingNodeType = "Home" or reportingNodeType = "TVEpisodes")
                     reportingNode.quickPlayNode = invalid
                 end if
             end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -182,6 +182,8 @@ sub Main (args as dynamic) as void
                         quickplay.folder(itemNode)
                     else if itemType = "musicvideo"
                         quickplay.musicVideo(itemNode)
+                    else if itemType = "person"
+                        quickplay.person(itemNode)
                     end if
 
                     m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -134,6 +134,9 @@ sub Main (args as dynamic) as void
                 end if
             end if
             print "Quick Play started. itemNode=", itemNode
+            ' if itemNode.json <> invalid
+            '     print "itemNode.json=", itemNode.json
+            ' end if
             if isValid(itemNode) and isValid(itemNode.id) and itemNode.id <> ""
                 ' make sure there is a type and convert type to lowercase
                 itemType = invalid
@@ -184,6 +187,8 @@ sub Main (args as dynamic) as void
                         quickplay.musicVideo(itemNode)
                     else if itemType = "person"
                         quickplay.person(itemNode)
+                    else if itemType = "tvchannel"
+                        quickplay.tvChannel(itemNode)
                     end if
 
                     m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -179,6 +179,8 @@ sub Main (args as dynamic) as void
                         quickplay.userView(itemNode)
                     else if itemType = "folder"
                         quickplay.folder(itemNode)
+                    else if itemType = "musicvideo"
+                        quickplay.musicVideo(itemNode)
                     end if
 
                     m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -303,6 +303,7 @@ sub Main (args as dynamic) as void
                             end if
                         end for
                         if isValid(firstUnwatchedEpisodeIndex)
+                            ' add the first unwatched episode and the rest of the season to a playlist
                             for i = firstUnwatchedEpisodeIndex to unwatchedData.Items.count() - 1
                                 m.global.queueManager.callFunc("push", unwatchedData.Items[i])
                             end for
@@ -319,7 +320,7 @@ sub Main (args as dynamic) as void
                                 "Filters": "IsResumable",
                                 "EnableTotalRecordCount": false
                             })
-                            print "resumeitems continueData=", continueData
+
                             if isValid(continueData) and isValid(continueData.Items) and continueData.Items.count() > 0
                                 ' play the resumable episode
                                 for each item in continueData.Items
@@ -341,6 +342,22 @@ sub Main (args as dynamic) as void
                             end if
                         end if
                     end if
+                else if itemType = "playlist"
+                    m.global.queueManager.callFunc("clear")
+                    print "attempting to quickplay a playlist"
+                    ' get playlist items
+                    myPlaylist = api.playlists.GetItems(itemNode.id, {
+                        "userId": m.global.session.user.id
+                    })
+                    if isValid(myPlaylist) and isValid(myPlaylist.Items) and myPlaylist.Items.count() > 0
+                        myPlaylistItems = shuffleArray(myPlaylist.Items)
+                        ' add each item to the queue
+                        for each item in myPlaylistItems
+                            m.global.queueManager.callFunc("push", item)
+                        end for
+                        m.global.queueManager.callFunc("playQueue")
+                    end if
+
                 end if
             end if
             stopLoadingSpinner()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -211,7 +211,8 @@ sub Main (args as dynamic) as void
                     if isValid(data) and isValid(data.Items) and data.Items.count() > 0
                         ' there are videos inside
                         print "found videos inside boxset"
-                        for each item in data.Items
+                        dataItems = shuffleArray(data.items)
+                        for each item in dataItems
                             m.global.queueManager.callFunc("push", item)
                         end for
                         m.global.queueManager.callFunc("playQueue")

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -118,9 +118,30 @@ sub Main (args as dynamic) as void
         else if isNodeEvent(msg, "quickPlayNode")
             group = sceneManager.callFunc("getActiveScene")
             reportingNode = msg.getRoSGNode()
-            itemNode = reportingNode.quickPlayNode
+            itemNode = invalid
+            if isValid(reportingNode)
+                itemNode = reportingNode.quickPlayNode
+                reportingNodeType = reportingNode.subtype()
+                ' prevent double fire on continue watching home row
+                if isValid(reportingNodeType) and reportingNodeType = "Home"
+                    reportingNode.quickPlayNode = invalid
+                end if
+            end if
             if isValid(itemNode) and isValid(itemNode.id) and itemNode.id <> ""
-                if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
+                print "quickPlayNode=", itemNode
+                itemType = invalid
+                if isValid(itemNode.type)
+                    itemType = Lcase(itemNode.type)
+                end if
+                ' grab type from json if needed
+                if not isValid(itemType) or itemType = ""
+                    if isValid(itemNode.json) and isValid(itemNode.json.type)
+                        itemType = Lcase(itemNode.json.type)
+                    end if
+                end if
+                print "quickPlayNode type=", itemType
+                if itemType = "episode" or itemType = "movie" or itemType = "video"
+                    ' attempt to play video file. resume if possible
                     if isValid(itemNode.selectedVideoStreamId)
                         itemNode.id = itemNode.selectedVideoStreamId
                     end if
@@ -141,12 +162,182 @@ sub Main (args as dynamic) as void
                     m.global.queueManager.callFunc("push", itemNode)
                     m.global.queueManager.callFunc("playQueue")
 
-                    ' Prevent quick play node from double firing
-                    reportingNode.quickPlayNode = invalid
-
                     if LCase(group.subtype()) = "tvepisodes"
                         if isValid(group.lastFocus)
                             group.lastFocus.setFocus(true)
+                        end if
+                    end if
+                else if itemType = "audio"
+                    ' attempt to play audio file
+                    m.global.queueManager.callFunc("clear")
+                    m.global.queueManager.callFunc("push", itemNode)
+                    m.global.queueManager.callFunc("playQueue")
+                else if itemType = "musicalbum"
+                    ' attempt to play the entire album starting with track 1
+                    m.global.queueManager.callFunc("clear")
+                    ' convert album to list of songs
+                    albumSongs = MusicSongList(itemNode.id)
+                    ' add each song to the queue
+                    for each song in albumSongs.items
+                        song.type = "Audio"
+                        m.global.queueManager.callFunc("push", song)
+                    end for
+                    ' play queue
+                    m.global.queueManager.callFunc("playQueue")
+                else if itemType = "musicartist"
+                    ' attempt to shuffle play all songs by artist
+                    m.global.queueManager.callFunc("clear")
+
+                    data = GetSongsByArtist(itemNode.id, { "sortBy": "Random" })
+
+                    if isValid(data)
+                        for each item in data.items
+                            m.global.queueManager.callFunc("push", item)
+                        end for
+
+                        m.global.queueManager.callFunc("playQueue")
+                    end if
+                else if itemType = "boxset"
+                    ' attempt to play all movies in the boxset
+                    ' play them in order of release
+                    m.global.queueManager.callFunc("clear")
+
+                    data = api.items.GetByQuery({
+                        "userid": m.global.session.user.id,
+                        "parentid": itemNode.id,
+                        "EnableTotalRecordCount": false
+                    })
+                    if isValid(data) and isValid(data.Items) and data.Items.count() > 0
+                        ' there are videos inside
+                        print "found videos inside boxset"
+                        for each item in data.Items
+                            m.global.queueManager.callFunc("push", item)
+                        end for
+                        m.global.queueManager.callFunc("playQueue")
+                    end if
+                else if itemType = "series"
+                    ' attempt to play first unwatched episode
+                    m.global.queueManager.callFunc("clear")
+
+                    data = api.shows.GetNextUp({
+                        "seriesId": itemNode.id,
+                        "recursive": true,
+                        "SortBy": "DatePlayed",
+                        "SortOrder": "Descending",
+                        "ImageTypeLimit": 1,
+                        "UserId": m.global.session.user.id,
+                        "EnableRewatching": false,
+                        "DisableFirstEpisode": false,
+                        "EnableTotalRecordCount": false
+                    })
+                    if isValid(data) and isValid(data.Items) and data.Items.count() > 0
+                        ' there are unwatched episodes
+                        for each item in data.Items
+                            m.global.queueManager.callFunc("push", item)
+                        end for
+                        m.global.queueManager.callFunc("playQueue")
+                    else
+                        ' next up check was empty
+                        ' check for a resumable episode
+                        data = api.users.GetResumeItemsByQuery(m.global.session.user.id, {
+                            "parentId": itemNode.id,
+                            "userid": m.global.session.user.id,
+                            "SortBy": "DatePlayed",
+                            "recursive": true,
+                            "SortOrder": "Descending",
+                            "Filters": "IsResumable",
+                            "EnableTotalRecordCount": false
+                        })
+                        print "resumeitems data=", data
+                        if isValid(data) and isValid(data.Items) and data.Items.count() > 0
+                            ' play the resumable episode
+                            for each item in data.Items
+                                if isValid(item.UserData) and isValid(item.UserData.PlaybackPositionTicks)
+                                    item.startingPoint = item.userdata.PlaybackPositionTicks
+                                end if
+                                m.global.queueManager.callFunc("push", item)
+                            end for
+                            m.global.queueManager.callFunc("playQueue")
+                        else
+                            ' shuffle all episodes
+                            data = api.shows.GetEpisodes(itemNode.id, {
+                                "userid": m.global.session.user.id,
+                                "SortBy": "Random",
+                                "EnableTotalRecordCount": false
+                            })
+
+                            if isValid(data) and isValid(data.Items) and data.Items.count() > 0
+                                ' add all episodes found to a playlist
+                                for each item in data.Items
+                                    m.global.queueManager.callFunc("push", item)
+                                end for
+                                m.global.queueManager.callFunc("playQueue")
+                            end if
+                        end if
+                    end if
+                else if itemType = "collectionfolder"
+                    ' play depends on the kind of files inside the collectionfolder
+                else if itemType = "season"
+                    ' play first unwatched episode
+                    m.global.queueManager.callFunc("clear")
+
+                    unwatchedData = api.shows.GetEpisodes(itemNode.json.SeriesId, {
+                        "seasonId": itemNode.id,
+                        "userid": m.global.session.user.id,
+                        "EnableTotalRecordCount": false
+                    })
+
+                    if isValid(unwatchedData) and isValid(unwatchedData.Items)
+                        ' find the first unwatched episode
+                        firstUnwatchedEpisodeIndex = invalid
+                        for each item in unwatchedData.Items
+                            if isValid(item.UserData)
+                                if isValid(item.UserData.Played) and item.UserData.Played = false
+                                    firstUnwatchedEpisodeIndex = item.IndexNumber - 1
+                                    if isValid(item.UserData.PlaybackPositionTicks)
+                                        item.startingPoint = item.UserData.PlaybackPositionTicks
+                                    end if
+                                    exit for
+                                end if
+                            end if
+                        end for
+                        if isValid(firstUnwatchedEpisodeIndex)
+                            for i = firstUnwatchedEpisodeIndex to unwatchedData.Items.count() - 1
+                                m.global.queueManager.callFunc("push", unwatchedData.Items[i])
+                            end for
+
+                            m.global.queueManager.callFunc("playQueue")
+                        else
+                            ' try to find a "continue watching" episode
+                            continueData = api.users.GetResumeItemsByQuery(m.global.session.user.id, {
+                                "parentId": itemNode.id,
+                                "userid": m.global.session.user.id,
+                                "SortBy": "DatePlayed",
+                                "recursive": true,
+                                "SortOrder": "Descending",
+                                "Filters": "IsResumable",
+                                "EnableTotalRecordCount": false
+                            })
+                            print "resumeitems continueData=", continueData
+                            if isValid(continueData) and isValid(continueData.Items) and continueData.Items.count() > 0
+                                ' play the resumable episode
+                                for each item in continueData.Items
+                                    if isValid(item.UserData) and isValid(item.UserData.PlaybackPositionTicks)
+                                        item.startingPoint = item.userdata.PlaybackPositionTicks
+                                    end if
+                                    m.global.queueManager.callFunc("push", item)
+                                end for
+                                m.global.queueManager.callFunc("playQueue")
+                            else
+                                ' play the whole season in order
+                                if isValid(unwatchedData) and isValid(unwatchedData.Items) and unwatchedData.Items.count() > 0
+                                    ' add all episodes found to a playlist
+                                    for each item in unwatchedData.Items
+                                        m.global.queueManager.callFunc("push", item)
+                                    end for
+                                    m.global.queueManager.callFunc("playQueue")
+                                end if
+                            end if
                         end if
                     end if
                 end if

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -290,6 +290,8 @@ sub Main (args as dynamic) as void
                     end if
                 else if selectedItemType = "MusicAlbum"
                     group = CreateAlbumView(selectedItem.json)
+                else if selectedItemType = "MusicVideo"
+                    group = CreateMovieDetailsGroup(selectedItem)
                 else if selectedItemType = "Playlist"
                     group = CreatePlaylistView(selectedItem.json)
                 else if selectedItemType = "Audio"
@@ -428,6 +430,8 @@ sub Main (args as dynamic) as void
                 group = CreateArtistView(node.json)
             else if node.type = "MusicAlbum"
                 group = CreateAlbumView(node.json)
+            else if node.type = "MusicVideo"
+                group = CreateMovieDetailsGroup(node)
             else if node.type = "Audio"
                 m.global.queueManager.callFunc("clear")
                 m.global.queueManager.callFunc("resetShuffle")

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -565,6 +565,7 @@ function CreateMovieDetailsGroup(movie as object) as dynamic
     end if
     ' start building MovieDetails view
     group = CreateObject("roSGNode", "MovieDetails")
+    group.observeField("quickPlayNode", m.port)
     group.overhangTitle = movie.title
     group.optionsAvailable = false
     group.trailerAvailable = false
@@ -618,6 +619,7 @@ function CreateSeriesDetailsGroup(seriesID as string) as dynamic
     group.seasonData = seasonData
     ' watch for button presses
     group.observeField("seasonSelected", m.port)
+    group.observeField("quickPlayNode", m.port)
     ' setup and load series extras
     extras = group.findNode("extrasGrid")
     extras.observeField("selectedItem", m.port)
@@ -670,6 +672,7 @@ function CreateArtistView(artist as object) as dynamic
         group.observeField("appearsOnSelected", m.port)
     end if
 
+    group.observeField("quickPlayNode", m.port)
     m.global.sceneManager.callFunc("pushScene", group)
 
     return group
@@ -806,6 +809,7 @@ function CreateMusicLibraryView(libraryItem as object) as dynamic
     group.parentItem = libraryItem
     group.optionsAvailable = true
     group.observeField("selectedItem", m.port)
+    group.observeField("quickPlayNode", m.port)
     return group
 end function
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -782,6 +782,7 @@ function CreateItemGrid(libraryItem as object) as dynamic
     group.parentItem = libraryItem
     group.optionsAvailable = true
     group.observeField("selectedItem", m.port)
+    group.observeField("quickPlayNode", m.port)
     return group
 end function
 
@@ -793,6 +794,7 @@ function CreateMovieLibraryView(libraryItem as object) as dynamic
     group.parentItem = libraryItem
     group.optionsAvailable = true
     group.observeField("selectedItem", m.port)
+    group.observeField("quickPlayNode", m.port)
     return group
 end function
 

--- a/source/api/Items.brs
+++ b/source/api/Items.brs
@@ -223,15 +223,20 @@ function AppearsOnList(id as string)
 end function
 
 ' Get list of songs belonging to an artist
-function GetSongsByArtist(id as string)
+function GetSongsByArtist(id as string, params = {} as object)
     url = Substitute("Users/{0}/Items", m.global.session.user.id)
-    resp = APIRequest(url, {
+    paramArray = {
         "AlbumArtistIds": id,
         "includeitemtypes": "Audio",
         "sortBy": "SortName",
         "Recursive": true
-    })
+    }
+    ' overwrite defaults with the params provided
+    for each param in params
+        paramArray.AddReplace(param, params[param])
+    end for
 
+    resp = APIRequest(url, paramArray)
     data = getJson(resp)
     results = []
 
@@ -408,7 +413,7 @@ function TVSeasons(id as string) as dynamic
     results = []
     for each item in data.Items
         imgParams = { "AddPlayedIndicator": item.UserData.Played }
-        tmp = CreateObject("roSGNode", "TVEpisodeData")
+        tmp = CreateObject("roSGNode", "TVSeasonData")
         tmp.image = PosterImage(item.id, imgParams)
         tmp.json = item
         results.push(tmp)

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1200,8 +1200,8 @@ namespace api
         end function
 
         ' Gets the original items of a playlist.
-        function GetItems(id as string, params = {} as object)
-            req = APIRequest(Substitute("/playlists/{0}/items", id), params)
+        function GetItems(playlistID as string, params = {} as object)
+            req = APIRequest(Substitute("/playlists/{0}/items", playlistID), params)
             return getJson(req)
         end function
 

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -392,3 +392,13 @@ function arrayHasValue(arr as object, value as dynamic) as boolean
     end for
     return false
 end function
+
+' Takes an array of data, shuffles the order, then returns the array
+' uses the Fisher-Yates shuffling algorithm
+function shuffleArray(array as object) as object
+    for i = array.count() - 1 to 1 step -1
+        j = Rnd(i + 1) - 1
+        t = array[i] : array[i] = array[j] : array[j] = t
+    end for
+    return array
+end function

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -78,6 +78,7 @@ namespace quickplay
             "parentId": itemNode.id,
             "imageTypeLimit": 1,
             "sortBy": "SortName",
+            "limit": 2000,
             "enableUserData": false,
             "EnableTotalRecordCount": false
         })
@@ -99,6 +100,7 @@ namespace quickplay
             "artistIds": itemNode.id,
             "includeItemTypes": "Audio",
             "sortBy": "Album",
+            "limit": 2000,
             "imageTypeLimit": 1,
             "Recursive": true,
             "enableUserData": false,
@@ -124,6 +126,7 @@ namespace quickplay
         data = api.items.GetByQuery({
             "userid": m.global.session.user.id,
             "parentid": itemNode.id,
+            "limit": 2000,
             "EnableTotalRecordCount": false
         })
         if isValid(data) and isValidAndNotEmpty(data.Items)
@@ -181,6 +184,7 @@ namespace quickplay
                 data = api.shows.GetEpisodes(itemNode.id, {
                     "userid": m.global.session.user.id,
                     "SortBy": "Random",
+                    "limit": 2000,
                     "EnableTotalRecordCount": false
                 })
 
@@ -196,10 +200,13 @@ namespace quickplay
     ' Shuffle play all watched episodes
     sub multipleSeries(itemNodes as object)
         if isValidAndNotEmpty(itemNodes)
+            numTotal = 0
+            numLimit = 2000
             for each tvshow in itemNodes
                 ' grab all watched episodes for each series
                 showData = api.shows.GetEpisodes(tvshow.id, {
                     "userId": m.global.session.user.id,
+                    "SortBy": "Random",
                     "imageTypeLimit": 0,
                     "EnableTotalRecordCount": false,
                     "enableImages": false
@@ -214,6 +221,13 @@ namespace quickplay
                             end if
                         end if
                     end for
+
+                    ' keep track of how many items we've seen
+                    numTotal = numTotal + showData.items.count()
+                    if numTotal >= numLimit
+                        ' stop grabbing more items if we hit our limit
+                        exit for
+                    end if
                 end if
             end for
             if m.global.queueManager.callFunc("getCount") > 1
@@ -231,6 +245,7 @@ namespace quickplay
         unwatchedData = api.shows.GetEpisodes(itemNode.json.SeriesId, {
             "seasonId": itemNode.id,
             "userid": m.global.session.user.id,
+            "limit": 2000,
             "EnableTotalRecordCount": false
         })
 
@@ -292,7 +307,8 @@ namespace quickplay
         if not isValid(itemNode) or not isValid(itemNode.id) then return
         ' get playlist items
         myPlaylist = api.playlists.GetItems(itemNode.id, {
-            "userId": m.global.session.user.id
+            "userId": m.global.session.user.id,
+            "limit": 2000
         })
 
         if isValid(myPlaylist) and isValidAndNotEmpty(myPlaylist.Items)
@@ -311,6 +327,7 @@ namespace quickplay
             "includeItemTypes": ["Episode", "Movie", "Video"],
             "videoTypes": "VideoFile",
             "sortBy": "Random",
+            "limit": 2000,
             "imageTypeLimit": 1,
             "Recursive": true,
             "enableUserData": false,
@@ -318,8 +335,6 @@ namespace quickplay
         }
         ' modify api query based on folder type
         folderType = Lcase(itemNode.json.type)
-
-        ' modify qpi query based on folder type
         if folderType = "studio"
             paramArray["studioIds"] = itemNode.id
         else if folderType = "genre"
@@ -331,7 +346,7 @@ namespace quickplay
         else
             paramArray["parentId"] = itemNode.id
         end if
-        ' loof for tv series in stead of video files
+        ' look for tv series instead of video files
         if isValid(itemNode.json.SeriesCount) and itemNode.json.SeriesCount > 0
             paramArray["includeItemTypes"] = "Series"
             paramArray.Delete("videoTypes")
@@ -370,7 +385,8 @@ namespace quickplay
         if collectionType = "movies"
             ' get randomized list of movies inside
             data = api.users.GetItemsByQuery(m.global.session.user.id, {
-                "parentId": itemNode.id
+                "parentId": itemNode.id,
+                "limit": 2000
             })
 
             if isValid(data) and isValidAndNotEmpty(data.items)
@@ -395,6 +411,7 @@ namespace quickplay
                 "includeItemTypes": "Audio",
                 "sortBy": "Album",
                 "Recursive": true,
+                "limit": 2000,
                 "imageTypeLimit": 1,
                 "enableUserData": false,
                 "EnableTotalRecordCount": false
@@ -410,6 +427,7 @@ namespace quickplay
             ' get list of all boxsets inside
             boxsetData = api.users.GetItemsByQuery(m.global.session.user.id, {
                 "parentId": itemNode.id,
+                "limit": 2000,
                 "imageTypeLimit": 0,
                 "enableUserData": false,
                 "EnableTotalRecordCount": false,
@@ -438,6 +456,7 @@ namespace quickplay
             ' get list of tv shows inside
             tvshowsData = api.users.GetItemsByQuery(m.global.session.user.id, {
                 "parentId": itemNode.id,
+                "sortBy": "Random",
                 "imageTypeLimit": 0,
                 "enableUserData": false,
                 "EnableTotalRecordCount": false,
@@ -456,6 +475,7 @@ namespace quickplay
                 "includeItemTypes": "MusicVideo",
                 "sortBy": "Random",
                 "Recursive": true,
+                "limit": 2000,
                 "imageTypeLimit": 1,
                 "enableUserData": false,
                 "EnableTotalRecordCount": false
@@ -501,7 +521,8 @@ namespace quickplay
                 print "myPlaylist=", myPlaylist
                 playlistItems = api.playlists.GetItems(myPlaylist.id, {
                     "userId": m.global.session.user.id,
-                    "EnableTotalRecordCount": false
+                    "EnableTotalRecordCount": false,
+                    "limit": 2000
                 })
                 ' validate api results
                 if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -365,6 +365,9 @@ namespace quickplay
             paramArray["studioIds"] = itemNode.id
         else if folderType = "genre"
             paramArray["genreIds"] = itemNode.id
+            if isValid(itemNode.json.MovieCount) and itemNode.json.MovieCount > 0
+                paramArray["includeItemTypes"] = "Movie"
+            end if
         else if folderType = "musicgenre"
             paramArray["genreIds"] = itemNode.id
             paramArray.delete("videoTypes")

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -61,6 +61,13 @@ namespace quickplay
         m.global.queueManager.callFunc("push", itemNode)
     end sub
 
+    ' A single music video file.
+    sub musicVideo(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) or not isValid(itemNode.json) then return
+
+        m.global.queueManager.callFunc("push", itemNode)
+    end sub
+
     ' A music album.
     ' Play the entire album starting with track 1.
     sub album(itemNode as object)
@@ -417,6 +424,25 @@ namespace quickplay
                     end if
                 end for
                 m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        else if collectionType = "musicvideos"
+            ' get randomized list of videos inside
+            data = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "includeItemTypes": "MusicVideo",
+                "sortBy": "Random",
+                "Recursive": true,
+                "imageTypeLimit": 1,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false
+            })
+            print "data=", data
+            if isValid(data) and isValidAndNotEmpty(data.items)
+                ' add each item to the queue
+                pushToQueue(data.Items)
+                if data.items.count() > 1
+                    m.global.queueManager.callFunc("toggleShuffle")
+                end if
             end if
             ' else if collectionType = "homevideos" ' also used for a "Photo" library
         else

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -103,7 +103,7 @@ namespace quickplay
             pushToQueue(artistSongs.items)
 
             ' don't show shuffle icon for 1 song
-            if artistSongs.items > 1
+            if artistSongs.items.count() > 1
                 m.global.queueManager.callFunc("toggleShuffle")
             end if
         end if
@@ -265,6 +265,44 @@ namespace quickplay
         end if
     end sub
 
+    ' Quick Play A folder.
+    ' Shuffle play all items found
+    sub folder(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+        print "itemNode.json=", itemNode.json
+
+        paramArray = {
+            "includeItemTypes": ["Audio", "Episode", "Movie", "Video"],
+            "videoTypes": "VideoFile",
+            "sortBy": "Random",
+            "imageTypeLimit": 1,
+            "Recursive": true,
+            "enableUserData": false,
+            "EnableTotalRecordCount": false
+        }
+        ' modify api query based on folder type
+        folderType = Lcase(itemNode.json.type)
+        if folderType = "studio"
+            paramArray["studioIds"] = itemNode.id
+        else if folderType = "genre"
+            paramArray["genreIds"] = itemNode.id
+        else
+            paramArray["parentId"] = itemNode.id
+        end if
+        ' get folder items
+        folderData = api.users.GetItemsByQuery(m.global.session.user.id, paramArray)
+        print "folderData=", folderData
+
+        if isValid(folderData) and isValidAndNotEmpty(folderData.items)
+            pushToQueue(folderData.items)
+
+            ' don't show shuffle icon for 1 item
+            if folderData.items.count() > 1
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        end if
+    end sub
+
     ' Quick Play A CollectionFolder.
     ' Shuffle play the items inside
     ' with some differences based on collectionType.
@@ -308,7 +346,9 @@ namespace quickplay
             print "songsData=", songsData
             if isValid(songsData) and isValidAndNotEmpty(songsData.items)
                 pushToQueue(songsData.Items)
-                m.global.queueManager.callFunc("toggleShuffle")
+                if songsData.Items.count() > 1
+                    m.global.queueManager.callFunc("toggleShuffle")
+                end if
             end if
         else if collectionType = "boxsets"
             ' get list of all boxsets inside
@@ -415,7 +455,7 @@ namespace quickplay
                         m.global.queueManager.callFunc("push", item)
                     end for
                     ' don't show shuffle icon for 1 item
-                    if playlistItems.items > 1
+                    if playlistItems.items.count() > 1
                         m.global.queueManager.callFunc("toggleShuffle")
                     end if
                 end if

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -192,6 +192,36 @@ namespace quickplay
         end if
     end sub
 
+    ' More than one TV Show Series.
+    ' Shuffle play all watched episodes
+    sub multipleSeries(itemNodes as object)
+        if isValidAndNotEmpty(itemNodes)
+            for each tvshow in itemNodes
+                ' grab all watched episodes for each series
+                showData = api.shows.GetEpisodes(tvshow.id, {
+                    "userId": m.global.session.user.id,
+                    "imageTypeLimit": 0,
+                    "EnableTotalRecordCount": false,
+                    "enableImages": false
+                })
+
+                if isValid(showData) and isValidAndNotEmpty(showData.items)
+                    ' add all played episodes to queue
+                    for each episode in showData.items
+                        if isValid(episode.userdata) and isValid(episode.userdata.Played)
+                            if episode.userdata.Played
+                                m.global.queueManager.callFunc("push", episode)
+                            end if
+                        end if
+                    end for
+                end if
+            end for
+            if m.global.queueManager.callFunc("getCount") > 1
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        end if
+    end sub
+
     ' A TV Show Season.
     ' Play the first unwatched episode.
     ' If none, play the whole season starting with episode 1.
@@ -276,7 +306,6 @@ namespace quickplay
     ' Shuffle play all items found
     sub folder(itemNode as object)
         if not isValid(itemNode) or not isValid(itemNode.id) then return
-        print "itemNode.json=", itemNode.json
 
         paramArray = {
             "includeItemTypes": ["Episode", "Movie", "Video"],
@@ -289,6 +318,8 @@ namespace quickplay
         }
         ' modify api query based on folder type
         folderType = Lcase(itemNode.json.type)
+
+        ' modify qpi query based on folder type
         if folderType = "studio"
             paramArray["studioIds"] = itemNode.id
         else if folderType = "genre"
@@ -300,16 +331,28 @@ namespace quickplay
         else
             paramArray["parentId"] = itemNode.id
         end if
+        ' loof for tv series in stead of video files
+        if isValid(itemNode.json.SeriesCount) and itemNode.json.SeriesCount > 0
+            paramArray["includeItemTypes"] = "Series"
+            paramArray.Delete("videoTypes")
+        end if
         ' get folder items
         folderData = api.users.GetItemsByQuery(m.global.session.user.id, paramArray)
         print "folderData=", folderData
 
         if isValid(folderData) and isValidAndNotEmpty(folderData.items)
-            pushToQueue(folderData.items)
-
-            ' don't show shuffle icon for 1 item
-            if folderData.items.count() > 1
-                m.global.queueManager.callFunc("toggleShuffle")
+            if isValid(itemNode.json.SeriesCount) and itemNode.json.SeriesCount > 0
+                if itemNode.json.SeriesCount = 1
+                    quickplay.series(folderData.items[0])
+                else
+                    quickplay.multipleSeries(folderData.items)
+                end if
+            else
+                pushToQueue(folderData.items)
+                ' don't show shuffle icon for 1 item
+                if folderData.items.count() > 1
+                    m.global.queueManager.callFunc("toggleShuffle")
+                end if
             end if
         end if
     end sub
@@ -340,7 +383,9 @@ namespace quickplay
                         end if
                     end if
                 end for
-                m.global.queueManager.callFunc("toggleShuffle")
+                if m.global.queueManager.callFunc("getCount") > 1
+                    m.global.queueManager.callFunc("toggleShuffle")
+                end if
             end if
         else if collectionType = "music"
             ' get all audio files under this collection
@@ -402,28 +447,7 @@ namespace quickplay
             print "tvshowsData=", tvshowsData
 
             if isValid(tvshowsData) and isValidAndNotEmpty(tvshowsData.items)
-                for each tvshow in tvshowsData.items
-                    ' grab all watched episodes for each series
-                    showData = api.shows.GetEpisodes(tvshow.id, {
-                        "userId": m.global.session.user.id,
-                        "imageTypeLimit": 0,
-                        "EnableTotalRecordCount": false,
-                        "enableImages": false
-                    })
-
-                    if isValid(showData) and isValidAndNotEmpty(showData.items)
-                        ' add all played episodes to queue
-                        for each episode in showData.items
-                            if isValid(episode.userdata) and isValid(episode.userdata.Played)
-                                if episode.userdata.Played
-                                    m.global.queueManager.callFunc("push", episode)
-                                end if
-                            end if
-                        end for
-
-                    end if
-                end for
-                m.global.queueManager.callFunc("toggleShuffle")
+                quickplay.multipleSeries(tvshowsData.items)
             end if
         else if collectionType = "musicvideos"
             ' get randomized list of videos inside

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -300,6 +300,46 @@ namespace quickplay
         end if
     end sub
 
+    ' Quick Play A Person.
+    ' Shuffle play all videos found
+    sub person(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+        ' get movies and videos by the person
+        personMovies = api.users.GetItemsByQuery(m.global.session.user.id, {
+            "personIds": itemNode.id,
+            "includeItemTypes": "Movie,Video",
+            "excludeItemTypes": "Season,Series",
+            "recursive": true,
+            "limit": 2000
+        })
+        print "personMovies=", personMovies
+
+        if isValid(personMovies) and isValidAndNotEmpty(personMovies.Items)
+            ' add each item to the queue
+            pushToQueue(personMovies.Items)
+        end if
+
+        ' get watched episodes by the person
+        personEpisodes = api.users.GetItemsByQuery(m.global.session.user.id, {
+            "personIds": itemNode.id,
+            "includeItemTypes": "Episode",
+            "isPlayed": true,
+            "excludeItemTypes": "Season,Series",
+            "recursive": true,
+            "limit": 2000
+        })
+        print "personEpisodes=", personEpisodes
+
+        if isValid(personEpisodes) and isValidAndNotEmpty(personEpisodes.Items)
+            ' add each item to the queue
+            pushToQueue(personEpisodes.Items)
+        end if
+
+        if m.global.queueManager.callFunc("getCount") > 1
+            m.global.queueManager.callFunc("toggleShuffle")
+        end if
+    end sub
+
     ' Quick Play A Playlist.
     ' Play the first unwatched episode.
     ' If none, play the whole season starting with episode 1.
@@ -314,7 +354,9 @@ namespace quickplay
         if isValid(myPlaylist) and isValidAndNotEmpty(myPlaylist.Items)
             ' add each item to the queue
             pushToQueue(myPlaylist.Items)
-            m.global.queueManager.callFunc("toggleShuffle")
+            if m.global.queueManager.callFunc("getCount") > 1
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
         end if
     end sub
 
@@ -404,7 +446,7 @@ namespace quickplay
                 end if
             end if
         else if collectionType = "music"
-            ' get all audio files under this collection
+            ' get audio files from under this collection
             ' sort songs by album then artist
             songsData = api.users.GetItemsByQuery(m.global.session.user.id, {
                 "parentId": itemNode.id,

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -2,30 +2,16 @@
 namespace quickplay
 
     ' Takes an array of items and adds to global queue.
-    ' Stop loading items if memory level becomes low
-    sub pushToQueue(queueArray as object, limitValue = 200 as integer)
+    ' Also shuffles the playlist if asked
+    sub pushToQueue(queueArray as object, shufflePlay = false as boolean)
         if isValidAndNotEmpty(queueArray)
-            itemCount = queueArray.count()
-            if limitValue >= itemCount
-                ' load everything
-                for each item in queueArray
-                    m.global.queueManager.callFunc("push", item)
-                end for
-            else
-                newLimit = limitValue
-                for i = 0 to itemCount - 1
-                    m.global.queueManager.callFunc("push", queueArray[i])
-
-                    if i = newLimit
-                        ' hit the item limit. check memory level
-                        newLimit = newLimit + limitValue
-                        print "m.global.session.memoryLevel=", m.global.session.memoryLevel
-                        if m.global.session.memoryLevel = "low" or m.global.session.memoryLevel = "critical"
-                            print "Memory is low. Stop loading items in the playlist..."
-                            exit for
-                        end if
-                    end if
-                end for
+            ' load everything
+            for each item in queueArray
+                m.global.queueManager.callFunc("push", item)
+            end for
+            ' shuffle the playlist if asked
+            if shufflePlay and m.global.queueManager.callFunc("getCount") > 1
+                m.global.queueManager.callFunc("toggleShuffle")
             end if
         end if
     end sub
@@ -83,10 +69,7 @@ namespace quickplay
             "EnableTotalRecordCount": false
         })
         if isValid(albumSongs) and isValidAndNotEmpty(albumSongs.items)
-            ' add every song to the queue
-            for each song in albumSongs.items
-                m.global.queueManager.callFunc("push", song)
-            end for
+            quickplay.pushToQueue(albumSongs.items)
         end if
     end sub
 
@@ -109,17 +92,12 @@ namespace quickplay
         print "artistSongs=", artistSongs
 
         if isValid(artistSongs) and isValidAndNotEmpty(artistSongs.items)
-            pushToQueue(artistSongs.items)
-
-            ' don't show shuffle icon for 1 song
-            if artistSongs.items.count() > 1
-                m.global.queueManager.callFunc("toggleShuffle")
-            end if
+            quickplay.pushToQueue(artistSongs.items, true)
         end if
     end sub
 
     ' A boxset.
-    ' Shuffle play all items inside.
+    ' Play all items inside.
     sub boxset(itemNode as object)
         if not isValid(itemNode) or not isValid(itemNode.id) then return
 
@@ -130,8 +108,7 @@ namespace quickplay
             "EnableTotalRecordCount": false
         })
         if isValid(data) and isValidAndNotEmpty(data.Items)
-            ' there are videos inside
-            pushToQueue(data.items)
+            quickplay.pushToQueue(data.items)
         end if
     end sub
 
@@ -155,9 +132,7 @@ namespace quickplay
 
         if isValid(data) and isValidAndNotEmpty(data.Items)
             ' there are unwatched episodes
-            for each item in data.Items
-                m.global.queueManager.callFunc("push", item)
-            end for
+            m.global.queueManager.callFunc("push", data.Items[0])
         else
             ' next up check was empty
             ' check for a resumable episode
@@ -173,12 +148,10 @@ namespace quickplay
             print "resumeitems data=", data
             if isValid(data) and isValidAndNotEmpty(data.Items)
                 ' play the resumable episode
-                for each item in data.Items
-                    if isValid(item.UserData) and isValid(item.UserData.PlaybackPositionTicks)
-                        item.startingPoint = item.userdata.PlaybackPositionTicks
-                    end if
-                    m.global.queueManager.callFunc("push", item)
-                end for
+                if isValid(data.Items[0].UserData) and isValid(data.Items[0].UserData.PlaybackPositionTicks)
+                    data.Items[0].startingPoint = data.Items[0].userdata.PlaybackPositionTicks
+                end if
+                m.global.queueManager.callFunc("push", data.Items[0])
             else
                 ' shuffle all episodes
                 data = api.shows.GetEpisodes(itemNode.id, {
@@ -190,7 +163,7 @@ namespace quickplay
 
                 if isValid(data) and isValidAndNotEmpty(data.Items)
                     ' add all episodes found to a playlist
-                    pushToQueue(data.Items)
+                    quickplay.pushToQueue(data.Items)
                 end if
             end if
         end if
@@ -213,14 +186,16 @@ namespace quickplay
                 })
 
                 if isValid(showData) and isValidAndNotEmpty(showData.items)
+                    playedEpisodes = []
                     ' add all played episodes to queue
                     for each episode in showData.items
                         if isValid(episode.userdata) and isValid(episode.userdata.Played)
                             if episode.userdata.Played
-                                m.global.queueManager.callFunc("push", episode)
+                                playedEpisodes.push(episode)
                             end if
                         end if
                     end for
+                    quickplay.pushToQueue(playedEpisodes)
 
                     ' keep track of how many items we've seen
                     numTotal = numTotal + showData.items.count()
@@ -316,7 +291,7 @@ namespace quickplay
 
         if isValid(personMovies) and isValidAndNotEmpty(personMovies.Items)
             ' add each item to the queue
-            pushToQueue(personMovies.Items)
+            quickplay.pushToQueue(personMovies.Items)
         end if
 
         ' get watched episodes by the person
@@ -332,7 +307,7 @@ namespace quickplay
 
         if isValid(personEpisodes) and isValidAndNotEmpty(personEpisodes.Items)
             ' add each item to the queue
-            pushToQueue(personEpisodes.Items)
+            quickplay.pushToQueue(personEpisodes.Items)
         end if
 
         if m.global.queueManager.callFunc("getCount") > 1
@@ -353,7 +328,7 @@ namespace quickplay
 
         if isValid(myPlaylist) and isValidAndNotEmpty(myPlaylist.Items)
             ' add each item to the queue
-            pushToQueue(myPlaylist.Items)
+            quickplay.pushToQueue(myPlaylist.Items)
             if m.global.queueManager.callFunc("getCount") > 1
                 m.global.queueManager.callFunc("toggleShuffle")
             end if
@@ -405,11 +380,7 @@ namespace quickplay
                     quickplay.multipleSeries(folderData.items)
                 end if
             else
-                pushToQueue(folderData.items)
-                ' don't show shuffle icon for 1 item
-                if folderData.items.count() > 1
-                    m.global.queueManager.callFunc("toggleShuffle")
-                end if
+                quickplay.pushToQueue(folderData.items, true)
             end if
         end if
     end sub
@@ -428,22 +399,22 @@ namespace quickplay
             ' get randomized list of movies inside
             data = api.users.GetItemsByQuery(m.global.session.user.id, {
                 "parentId": itemNode.id,
+                "sortBy": "Random",
                 "limit": 2000
             })
 
             if isValid(data) and isValidAndNotEmpty(data.items)
+                movieList = []
                 ' add each item to the queue
                 for each item in data.Items
                     ' only add movies we're not currently watching
                     if isValid(item.userdata) and isValid(item.userdata.PlaybackPositionTicks)
                         if item.userdata.PlaybackPositionTicks = 0
-                            m.global.queueManager.callFunc("push", item)
+                            movieList.push(item)
                         end if
                     end if
                 end for
-                if m.global.queueManager.callFunc("getCount") > 1
-                    m.global.queueManager.callFunc("toggleShuffle")
-                end if
+                quickplay.pushToQueue(movieList)
             end if
         else if collectionType = "music"
             ' get audio files from under this collection
@@ -460,10 +431,7 @@ namespace quickplay
             })
             print "songsData=", songsData
             if isValid(songsData) and isValidAndNotEmpty(songsData.items)
-                pushToQueue(songsData.Items)
-                if songsData.Items.count() > 1
-                    m.global.queueManager.callFunc("toggleShuffle")
-                end if
+                quickplay.pushToQueue(songsData.Items, true)
             end if
         else if collectionType = "boxsets"
             ' get list of all boxsets inside
@@ -491,7 +459,7 @@ namespace quickplay
 
                 if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
                     ' add all boxset items to queue
-                    pushToQueue(boxsetData.Items)
+                    quickplay.pushToQueue(boxsetData.Items)
                 end if
             end if
         else if collectionType = "tvshows"
@@ -524,11 +492,7 @@ namespace quickplay
             })
             print "data=", data
             if isValid(data) and isValidAndNotEmpty(data.items)
-                ' add each item to the queue
-                pushToQueue(data.Items)
-                if data.items.count() > 1
-                    m.global.queueManager.callFunc("toggleShuffle")
-                end if
+                quickplay.pushToQueue(data.Items)
             end if
             ' else if collectionType = "homevideos" ' also used for a "Photo" library
         else
@@ -568,13 +532,7 @@ namespace quickplay
                 })
                 ' validate api results
                 if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)
-                    for each item in playlistItems.items
-                        m.global.queueManager.callFunc("push", item)
-                    end for
-                    ' don't show shuffle icon for 1 item
-                    if playlistItems.items.count() > 1
-                        m.global.queueManager.callFunc("toggleShuffle")
-                    end if
+                    quickplay.pushToQueue(playlistItems.items, true)
                 end if
             end if
         else

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -483,7 +483,7 @@ namespace quickplay
                     quickplay.pushToQueue(boxsetData.Items)
                 end if
             end if
-        else if collectionType = "tvshows"
+        else if collectionType = "tvshows" or collectionType = "collectionfolder"
             ' get list of tv shows inside
             tvshowsData = api.users.GetItemsByQuery(m.global.session.user.id, {
                 "parentId": itemNode.id,

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -315,6 +315,15 @@ namespace quickplay
         end if
     end sub
 
+    ' Quick Play A TVChannel
+    sub tvChannel(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        stopLoadingSpinner()
+        group = CreateVideoPlayerGroup(itemNode.id)
+        m.global.sceneManager.callFunc("pushScene", group)
+    end sub
+
     ' Quick Play A Playlist.
     ' Play the first unwatched episode.
     ' If none, play the whole season starting with episode 1.
@@ -534,6 +543,27 @@ namespace quickplay
                 if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)
                     quickplay.pushToQueue(playlistItems.items, true)
                 end if
+            end if
+        else if collectionType = "livetv"
+            ' get list of all tv channels
+            channelData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "includeItemTypes": "TVChannel",
+                "sortBy": "Random",
+                "Recursive": true,
+                "imageTypeLimit": 0,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false,
+                "enableImages": false
+            })
+            print "channelData=", channelData
+
+            if isValid(channelData) and isValidAndNotEmpty(channelData.items)
+                ' pick a random channel
+                arrayIndex = Rnd(channelData.items.count()) - 1
+                myChannel = channelData.items[arrayIndex]
+                print "myChannel=", myChannel
+                ' play channel
+                quickplay.tvChannel(myChannel)
             end if
         else
             print "Quick Play CollectionFolder WARNING: Unknown collection type"

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -324,6 +324,15 @@ namespace quickplay
         m.global.sceneManager.callFunc("pushScene", group)
     end sub
 
+    ' Quick Play A Live Program
+    sub program(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.json) or not isValid(itemNode.json.ChannelId) then return
+
+        stopLoadingSpinner()
+        group = CreateVideoPlayerGroup(itemNode.json.ChannelId)
+        m.global.sceneManager.callFunc("pushScene", group)
+    end sub
+
     ' Quick Play A Playlist.
     ' Play the first unwatched episode.
     ' If none, play the whole season starting with episode 1.

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -1,0 +1,407 @@
+' All of the Quick Play logic seperated by media type
+namespace quickplay
+
+    ' A single video file.
+    sub video(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) or not isValid(itemNode.json) then return
+
+        ' attempt to play video file. resume if possible
+        if isValid(itemNode.selectedVideoStreamId)
+            itemNode.id = itemNode.selectedVideoStreamId
+        end if
+
+        audio_stream_idx = 0
+        if isValid(itemNode.selectedAudioStreamIndex) and itemNode.selectedAudioStreamIndex > 0
+            audio_stream_idx = itemNode.selectedAudioStreamIndex
+        end if
+        itemNode.selectedAudioStreamIndex = audio_stream_idx
+
+        playbackPosition = 0
+        if isValid(itemNode.json.userdata) and isValid(itemNode.json.userdata.PlaybackPositionTicks)
+            playbackPosition = itemNode.json.userdata.PlaybackPositionTicks
+        end if
+        itemNode.startingPoint = playbackPosition
+
+        m.global.queueManager.callFunc("push", itemNode)
+    end sub
+
+    ' A single audio file.
+    sub audio(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        m.global.queueManager.callFunc("push", itemNode)
+    end sub
+
+    ' A music album.
+    ' Play the entire album starting with track 1.
+    sub album(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        ' grab list of songs in the album
+        albumSongs = api.users.GetItemsByQuery(m.global.session.user.id, {
+            "parentId": itemNode.id,
+            "imageTypeLimit": 1,
+            "sortBy": "SortName",
+            "enableUserData": false,
+            "EnableTotalRecordCount": false
+        })
+        if isValid(albumSongs) and isValidAndNotEmpty(albumSongs.items)
+            ' add every song to the queue
+            for each song in albumSongs.items
+                m.global.queueManager.callFunc("push", song)
+            end for
+        end if
+    end sub
+
+    ' A music artist.
+    ' Shuffle play all songs by artist.
+    sub artist(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        ' get all songs by artist
+        artistSongs = api.users.GetItemsByQuery(m.global.session.user.id, {
+            "artistIds": itemNode.id,
+            "includeItemTypes": "Audio",
+            "sortBy": "Album",
+            "imageTypeLimit": 1,
+            "Recursive": true,
+            "enableUserData": false,
+            "EnableTotalRecordCount": false
+        })
+        print "artistSongs=", artistSongs
+
+        if isValid(artistSongs) and isValidAndNotEmpty(artistSongs.items)
+            for each artistSong in artistSongs.items
+                m.global.queueManager.callFunc("push", artistSong)
+            end for
+        end if
+
+        m.global.queueManager.callFunc("toggleShuffle")
+    end sub
+
+    ' A boxset.
+    ' Shuffle play all items inside.
+    sub boxset(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        data = api.items.GetByQuery({
+            "userid": m.global.session.user.id,
+            "parentid": itemNode.id,
+            "EnableTotalRecordCount": false
+        })
+        if isValid(data) and isValidAndNotEmpty(data.Items)
+            ' there are videos inside
+            for each item in data.items
+                m.global.queueManager.callFunc("push", item)
+            end for
+        end if
+    end sub
+
+    ' A TV Show Series.
+    ' Play the first unwatched episode.
+    ' If none, shuffle play the whole series.
+    sub series(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        data = api.shows.GetNextUp({
+            "seriesId": itemNode.id,
+            "recursive": true,
+            "SortBy": "DatePlayed",
+            "SortOrder": "Descending",
+            "ImageTypeLimit": 1,
+            "UserId": m.global.session.user.id,
+            "EnableRewatching": false,
+            "DisableFirstEpisode": false,
+            "EnableTotalRecordCount": false
+        })
+
+        if isValid(data) and isValidAndNotEmpty(data.Items)
+            ' there are unwatched episodes
+            for each item in data.Items
+                m.global.queueManager.callFunc("push", item)
+            end for
+        else
+            ' next up check was empty
+            ' check for a resumable episode
+            data = api.users.GetResumeItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "userid": m.global.session.user.id,
+                "SortBy": "DatePlayed",
+                "recursive": true,
+                "SortOrder": "Descending",
+                "Filters": "IsResumable",
+                "EnableTotalRecordCount": false
+            })
+            print "resumeitems data=", data
+            if isValid(data) and isValidAndNotEmpty(data.Items)
+                ' play the resumable episode
+                for each item in data.Items
+                    if isValid(item.UserData) and isValid(item.UserData.PlaybackPositionTicks)
+                        item.startingPoint = item.userdata.PlaybackPositionTicks
+                    end if
+                    m.global.queueManager.callFunc("push", item)
+                end for
+            else
+                ' shuffle all episodes
+                data = api.shows.GetEpisodes(itemNode.id, {
+                    "userid": m.global.session.user.id,
+                    "SortBy": "Random",
+                    "EnableTotalRecordCount": false
+                })
+
+                if isValid(data) and isValidAndNotEmpty(data.Items)
+                    ' add all episodes found to a playlist
+                    for each item in data.Items
+                        m.global.queueManager.callFunc("push", item)
+                    end for
+                end if
+            end if
+        end if
+    end sub
+
+    ' A TV Show Season.
+    ' Play the first unwatched episode.
+    ' If none, play the whole season starting with episode 1.
+    sub season(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+
+        unwatchedData = api.shows.GetEpisodes(itemNode.json.SeriesId, {
+            "seasonId": itemNode.id,
+            "userid": m.global.session.user.id,
+            "EnableTotalRecordCount": false
+        })
+
+        if isValid(unwatchedData) and isValidAndNotEmpty(unwatchedData.Items)
+            ' find the first unwatched episode
+            firstUnwatchedEpisodeIndex = invalid
+            for each item in unwatchedData.Items
+                if isValid(item.UserData)
+                    if isValid(item.UserData.Played) and item.UserData.Played = false
+                        firstUnwatchedEpisodeIndex = item.IndexNumber - 1
+                        if isValid(item.UserData.PlaybackPositionTicks)
+                            item.startingPoint = item.UserData.PlaybackPositionTicks
+                        end if
+                        exit for
+                    end if
+                end if
+            end for
+
+            if isValid(firstUnwatchedEpisodeIndex)
+                ' add the first unwatched episode and the rest of the season to a playlist
+                for i = firstUnwatchedEpisodeIndex to unwatchedData.Items.count() - 1
+                    m.global.queueManager.callFunc("push", unwatchedData.Items[i])
+                end for
+            else
+                ' try to find a "continue watching" episode
+                continueData = api.users.GetResumeItemsByQuery(m.global.session.user.id, {
+                    "parentId": itemNode.id,
+                    "userid": m.global.session.user.id,
+                    "SortBy": "DatePlayed",
+                    "recursive": true,
+                    "SortOrder": "Descending",
+                    "Filters": "IsResumable",
+                    "EnableTotalRecordCount": false
+                })
+
+                if isValid(continueData) and isValidAndNotEmpty(continueData.Items)
+                    ' play the resumable episode
+                    for each item in continueData.Items
+                        if isValid(item.UserData) and isValid(item.UserData.PlaybackPositionTicks)
+                            item.startingPoint = item.userdata.PlaybackPositionTicks
+                        end if
+                        m.global.queueManager.callFunc("push", item)
+                    end for
+                else
+                    ' play the whole season in order
+                    if isValid(unwatchedData) and isValidAndNotEmpty(unwatchedData.Items)
+                        ' add all episodes found to a playlist
+                        for each item in unwatchedData.Items
+                            m.global.queueManager.callFunc("push", item)
+                        end for
+                    end if
+                end if
+            end if
+        end if
+    end sub
+
+    ' Quick Play A Playlist.
+    ' Play the first unwatched episode.
+    ' If none, play the whole season starting with episode 1.
+    sub playlist(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+        ' get playlist items
+        myPlaylist = api.playlists.GetItems(itemNode.id, {
+            "userId": m.global.session.user.id
+        })
+
+        if isValid(myPlaylist) and isValidAndNotEmpty(myPlaylist.Items)
+            ' add each item to the queue
+            for each item in myPlaylist.Items
+                m.global.queueManager.callFunc("push", item)
+            end for
+            m.global.queueManager.callFunc("toggleShuffle")
+        end if
+    end sub
+
+    ' Quick Play A CollectionFolder.
+    ' Shuffle play the items inside
+    ' with some differences based on collectionType.
+    sub collectionFolder(itemNode as object)
+        if not isValid(itemNode) or not isValid(itemNode.id) then return
+        ' play depends on the kind of files inside the collectionfolder
+        print "attempting to quickplay a collection folder"
+        collectionType = LCase(itemNode.collectionType)
+        print "collectionType=", collectionType
+
+        if collectionType = "movies"
+            ' get randomized list of movies inside
+            data = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id
+            })
+
+            if isValid(data) and isValidAndNotEmpty(data.items)
+                ' add each item to the queue
+                for each item in data.Items
+                    ' only add movies we're not currently watching
+                    if isValid(item.userdata) and isValid(item.userdata.PlaybackPositionTicks)
+                        if item.userdata.PlaybackPositionTicks = 0
+                            m.global.queueManager.callFunc("push", item)
+                        end if
+                    end if
+                end for
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        else if collectionType = "music"
+            ' get all audio files under this collection
+            ' sort songs by album then artist
+            songsData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "includeItemTypes": "Audio",
+                "sortBy": "Album",
+                "Recursive": true,
+                "imageTypeLimit": 1,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false
+            })
+            print "songsData=", songsData
+            if isValid(songsData) and isValidAndNotEmpty(songsData.items)
+                for each song in songsData.Items
+                    m.global.queueManager.callFunc("push", song)
+                end for
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        else if collectionType = "boxsets"
+            ' get list of all boxsets inside
+            boxsetData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "imageTypeLimit": 0,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false,
+                "enableImages": false
+            })
+
+            print "boxsetData=", boxsetData
+
+            if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
+                ' pick a random boxset
+                arrayIndex = Rnd(boxsetData.items.count()) - 1
+                myBoxset = boxsetData.items[arrayIndex]
+                ' grab list of items from boxset
+                print "myBoxset=", myBoxset
+                boxsetData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                    "parentId": myBoxset.id,
+                    "EnableTotalRecordCount": false
+                })
+
+                if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
+                    ' add all boxset items to queue
+                    for each item in boxsetData.items
+                        m.global.queueManager.callFunc("push", item)
+                    end for
+                end if
+            end if
+        else if collectionType = "tvshows"
+            ' get list of tv shows inside
+            tvshowsData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "imageTypeLimit": 0,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false,
+                "enableImages": false
+            })
+
+            print "tvshowsData=", tvshowsData
+
+            if isValid(tvshowsData) and isValidAndNotEmpty(tvshowsData.items)
+                for each tvshow in tvshowsData.items
+                    ' grab all watched episodes for each series
+                    showData = api.shows.GetEpisodes(tvshow.id, {
+                        "userId": m.global.session.user.id,
+                        "imageTypeLimit": 0,
+                        "EnableTotalRecordCount": false,
+                        "enableImages": false
+                    })
+
+                    if isValid(showData) and isValidAndNotEmpty(showData.items)
+                        ' add all played episodes to queue
+                        for each episode in showData.items
+                            if isValid(episode.userdata) and isValid(episode.userdata.Played)
+                                if episode.userdata.Played
+                                    m.global.queueManager.callFunc("push", episode)
+                                end if
+                            end if
+                        end for
+
+                    end if
+                end for
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+            ' else if collectionType = "homevideos" ' also used for a "Photo" library
+        else
+            print "Quick Play WARNING: Unknown collection type"
+        end if
+    end sub
+
+    ' Quick Play A UserView.
+    ' Play logic depends on "collectionType".
+    sub userView(itemNode as object)
+        ' play depends on the kind of files inside the collectionfolder
+        collectionType = LCase(itemNode.collectionType)
+        print "collectionType=", collectionType
+
+        if collectionType = "playlists"
+            ' get list of all playlists inside
+            playlistData = api.users.GetItemsByQuery(m.global.session.user.id, {
+                "parentId": itemNode.id,
+                "imageTypeLimit": 0,
+                "enableUserData": false,
+                "EnableTotalRecordCount": false,
+                "enableImages": false
+            })
+
+            print "playlistData=", playlistData
+
+            if isValid(playlistData) and isValidAndNotEmpty(playlistData.items)
+                ' pick a random playlist
+                arrayIndex = Rnd(playlistData.items.count()) - 1
+                myPlaylist = playlistData.items[arrayIndex]
+                ' grab list of items from playlist
+                print "myPlaylist=", myPlaylist
+                playlistItems = api.playlists.GetItems(myPlaylist.id, {
+                    "userId": m.global.session.user.id,
+                    "EnableTotalRecordCount": false
+                })
+                ' validate api results
+                if isValid(playlistItems) and isValidAndNotEmpty(playlistItems.items)
+                    for each item in playlistItems.items
+                        m.global.queueManager.callFunc("push", item)
+                    end for
+                end if
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        else
+            print "Quick Play CollectionFolder WARNING: Unknown collection type"
+        end if
+    end sub
+
+end namespace

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -272,7 +272,7 @@ namespace quickplay
         print "itemNode.json=", itemNode.json
 
         paramArray = {
-            "includeItemTypes": ["Audio", "Episode", "Movie", "Video"],
+            "includeItemTypes": ["Episode", "Movie", "Video"],
             "videoTypes": "VideoFile",
             "sortBy": "Random",
             "imageTypeLimit": 1,
@@ -286,6 +286,10 @@ namespace quickplay
             paramArray["studioIds"] = itemNode.id
         else if folderType = "genre"
             paramArray["genreIds"] = itemNode.id
+        else if folderType = "musicgenre"
+            paramArray["genreIds"] = itemNode.id
+            paramArray.delete("videoTypes")
+            paramArray["includeItemTypes"] = "Audio"
         else
             paramArray["parentId"] = itemNode.id
         end if

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -1,6 +1,35 @@
 ' All of the Quick Play logic seperated by media type
 namespace quickplay
 
+    ' Takes an array of items and adds to global queue.
+    ' Stop loading items if memory level becomes low
+    sub pushToQueue(queueArray as object, limitValue = 200 as integer)
+        if isValidAndNotEmpty(queueArray)
+            itemCount = queueArray.count()
+            if limitValue >= itemCount
+                ' load everything
+                for each item in queueArray
+                    m.global.queueManager.callFunc("push", item)
+                end for
+            else
+                newLimit = limitValue
+                for i = 0 to itemCount - 1
+                    m.global.queueManager.callFunc("push", queueArray[i])
+
+                    if i = newLimit
+                        ' hit the item limit. check memory level
+                        newLimit = newLimit + limitValue
+                        print "m.global.session.memoryLevel=", m.global.session.memoryLevel
+                        if m.global.session.memoryLevel = "low" or m.global.session.memoryLevel = "critical"
+                            print "Memory is low. Stop loading items in the playlist..."
+                            exit for
+                        end if
+                    end if
+                end for
+            end if
+        end if
+    end sub
+
     ' A single video file.
     sub video(itemNode as object)
         if not isValid(itemNode) or not isValid(itemNode.id) or not isValid(itemNode.json) then return
@@ -71,12 +100,13 @@ namespace quickplay
         print "artistSongs=", artistSongs
 
         if isValid(artistSongs) and isValidAndNotEmpty(artistSongs.items)
-            for each artistSong in artistSongs.items
-                m.global.queueManager.callFunc("push", artistSong)
-            end for
-        end if
+            pushToQueue(artistSongs.items)
 
-        m.global.queueManager.callFunc("toggleShuffle")
+            ' don't show shuffle icon for 1 song
+            if artistSongs.items > 1
+                m.global.queueManager.callFunc("toggleShuffle")
+            end if
+        end if
     end sub
 
     ' A boxset.
@@ -91,9 +121,7 @@ namespace quickplay
         })
         if isValid(data) and isValidAndNotEmpty(data.Items)
             ' there are videos inside
-            for each item in data.items
-                m.global.queueManager.callFunc("push", item)
-            end for
+            pushToQueue(data.items)
         end if
     end sub
 
@@ -151,9 +179,7 @@ namespace quickplay
 
                 if isValid(data) and isValidAndNotEmpty(data.Items)
                     ' add all episodes found to a playlist
-                    for each item in data.Items
-                        m.global.queueManager.callFunc("push", item)
-                    end for
+                    pushToQueue(data.Items)
                 end if
             end if
         end if
@@ -215,9 +241,7 @@ namespace quickplay
                     ' play the whole season in order
                     if isValid(unwatchedData) and isValidAndNotEmpty(unwatchedData.Items)
                         ' add all episodes found to a playlist
-                        for each item in unwatchedData.Items
-                            m.global.queueManager.callFunc("push", item)
-                        end for
+                        pushToQueue(unwatchedData.Items)
                     end if
                 end if
             end if
@@ -236,9 +260,7 @@ namespace quickplay
 
         if isValid(myPlaylist) and isValidAndNotEmpty(myPlaylist.Items)
             ' add each item to the queue
-            for each item in myPlaylist.Items
-                m.global.queueManager.callFunc("push", item)
-            end for
+            pushToQueue(myPlaylist.Items)
             m.global.queueManager.callFunc("toggleShuffle")
         end if
     end sub
@@ -285,9 +307,7 @@ namespace quickplay
             })
             print "songsData=", songsData
             if isValid(songsData) and isValidAndNotEmpty(songsData.items)
-                for each song in songsData.Items
-                    m.global.queueManager.callFunc("push", song)
-                end for
+                pushToQueue(songsData.Items)
                 m.global.queueManager.callFunc("toggleShuffle")
             end if
         else if collectionType = "boxsets"
@@ -315,9 +335,7 @@ namespace quickplay
 
                 if isValid(boxsetData) and isValidAndNotEmpty(boxsetData.items)
                     ' add all boxset items to queue
-                    for each item in boxsetData.items
-                        m.global.queueManager.callFunc("push", item)
-                    end for
+                    pushToQueue(boxsetData.Items)
                 end if
             end if
         else if collectionType = "tvshows"
@@ -396,8 +414,11 @@ namespace quickplay
                     for each item in playlistItems.items
                         m.global.queueManager.callFunc("push", item)
                     end for
+                    ' don't show shuffle icon for 1 item
+                    if playlistItems.items > 1
+                        m.global.queueManager.callFunc("toggleShuffle")
+                    end if
                 end if
-                m.global.queueManager.callFunc("toggleShuffle")
             end if
         else
             print "Quick Play CollectionFolder WARNING: Unknown collection type"

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -7,6 +7,7 @@ namespace session
     sub Init()
         m.global.addFields({
             session: {
+                "memoryLevel": "normal",
                 server: {},
                 user: {
                     Configuration: {},


### PR DESCRIPTION
Expand Quick Play support for everything (tested on my server) except photos

~~NOTE: Some queries take a little while to load (like shuffling a large series or shuffling an artist with a lot of songs) and since there is no loading spinner it may seem as if the app is unresponsive.~~

## Changes
- BoxSet support added
  - Shuffle play all the items in the collection
  - Works from home screen and library view when viewing collections
- Series support added
  - Play the first unwatched episode
    - If all episodes are watched, shuffle play all episodes
  - Works from the home screen and TV library view
- Season support added
  - Play the first unwatched episode
    - If all episodes are watched, play the whole season starting from episode 1
  - Works from the home screen and series detail view
- Album support added
  - Play the whole album starting from track 1
  - Works from the home screen, music library view(when viewing albums), and music artist detail view
- Music artist support added
  - Shuffle all songs by found by the selected artist
  - Works from the home screen and music library view
- "More Like This" support
  - Enable support for Quick Play on the "More Like This" row found on the "Extras" slider
  - Works on the movie detail view and the series detail view
- Playlist support added
  - Shuffle play all items inside of playlist
  - Tested with a playlist full of songs and one with movies
  - Works on the home screen(favorites), and on the "Playlists" library view
- Remove individual songs from the favorites row on the home screen.
- Show loading spinner
- Add support for "Appears on" row when viewing music artist
- Fix music logic so that all songs are played when quick playing an artist or music library
  - Number of songs in playlist now matches the number of songs listed in the "Artist (Presentation)" view
- Optimize api quieries
  - To shuffle play all 1366 of the songs in my music library now takes ~3.8 seconds
- Add "collectionFolder" support
  - Supports `movies`, `tvshows`, `boxsets`, and `music` collection types
    - movies: shuffle play all movies found in collection
    - tvshows: shuffle play all watched episodes in collection
    - boxsets: pick a random boxset inside and play all the items inside
    - music: shuffle play all audio files in collection
  - Works from the "My Media" and favorite rows on the home page and also the main grid view
- Add "UserView "support
  - Supports `playlists` collection type
  - Picks a random playlist inside and shuffle plays it
  - Works from the "My Media" and favorite rows on the home page and also the main grid view
- Move quick play logic out of main and into it's own file under a namespace of `quickplay`


## Issues
Fixes #1138
Fixes #1139
Fixes #1399
