### PR TITLE
Respect transcoding user policy

### DIFF
--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -798,27 +798,27 @@ function getDeviceProfile() as object
     end if
 
     ' respect user policy in regards to transcoding permission
-    enableVideoTranscoding = m.global.session.user.policy.EnableVideoPlaybackTranscoding
-    enableAudioTranscoding = m.global.session.user.policy.EnableAudioPlaybackTranscoding
+    enableVideoTranscoding = Lcase(m.global.session.user.policy.EnableVideoPlaybackTranscoding)
+    enableAudioTranscoding = Lcase(m.global.session.user.policy.EnableAudioPlaybackTranscoding)
 
-    if enableVideoTranscoding <> invalid and enableAudioTranscoding <> invalid
-        if enableVideoTranscoding = false and enableAudioTranscoding = false
+    if isValid(enableVideoTranscoding) and isValid(enableAudioTranscoding)
+        if not enableVideoTranscoding and not enableAudioTranscoding
             ' no transcoding allowed
             deviceProfile.TranscodingProfiles = []
-        else if enableVideoTranscoding = false and enableAudioTranscoding = true
+        else if not enableVideoTranscoding and enableAudioTranscoding
             ' no video transcoding allowed
             newProfile = []
             for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
-                if deviceProfile.TranscodingProfiles[i].Type <> "Video"
+                if deviceProfile.TranscodingProfiles[i].Type <> "video"
                     newProfile.push(deviceProfile.TranscodingProfiles[i])
                 end if
             end for
             deviceProfile.TranscodingProfiles = newProfile
-        else if enableVideoTranscoding = true and enableAudioTranscoding = false
+        else if enableVideoTranscoding and not enableAudioTranscoding
             ' no audio transcoding allowed
             newProfile = []
             for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
-                if deviceProfile.TranscodingProfiles[i].Type <> "Audio"
+                if deviceProfile.TranscodingProfiles[i].Type <> "audio"
                     newProfile.push(deviceProfile.TranscodingProfiles[i])
                 end if
             end for

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -797,9 +797,33 @@ function getDeviceProfile() as object
         deviceProfile.CodecProfiles.push(codecProfileArray)
     end if
 
-    enableTranscoding = m.global.session.user.policy.EnableVideoPlaybackTranscoding
-    if enableTranscoding <> invalid and enableTranscoding = false
-        deviceProfile.TranscodingProfiles = []
+    ' respect user policy in regards to transcoding permission
+    enableVideoTranscoding = m.global.session.user.policy.EnableVideoPlaybackTranscoding
+    enableAudioTranscoding = m.global.session.user.policy.EnableAudioPlaybackTranscoding
+
+    if enableVideoTranscoding <> invalid and enableAudioTranscoding <> invalid
+        if enableVideoTranscoding = false and enableAudioTranscoding = false
+            ' no transcoding allowed
+            deviceProfile.TranscodingProfiles = []
+        else if enableVideoTranscoding = false and enableAudioTranscoding = true
+            ' no video transcoding allowed
+            newProfile = []
+            for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
+                if deviceProfile.TranscodingProfiles[i].Type <> "Video"
+                    newProfile.push(deviceProfile.TranscodingProfiles[i])
+                end if
+            end for
+            deviceProfile.TranscodingProfiles = newProfile
+        else if enableVideoTranscoding = true and enableAudioTranscoding = false
+            ' no audio transcoding allowed
+            newProfile = []
+            for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
+                if deviceProfile.TranscodingProfiles[i].Type <> "Audio"
+                    newProfile.push(deviceProfile.TranscodingProfiles[i])
+                end if
+            end for
+            deviceProfile.TranscodingProfiles = newProfile
+        end if
     end if
 
     return deviceProfile

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -798,8 +798,8 @@ function getDeviceProfile() as object
     end if
 
     ' respect user policy in regards to transcoding permission
-    enableVideoTranscoding = Lcase(m.global.session.user.policy.EnableVideoPlaybackTranscoding)
-    enableAudioTranscoding = Lcase(m.global.session.user.policy.EnableAudioPlaybackTranscoding)
+    enableVideoTranscoding = m.global.session.user.policy.EnableVideoPlaybackTranscoding
+    enableAudioTranscoding = m.global.session.user.policy.EnableAudioPlaybackTranscoding
 
     if isValid(enableVideoTranscoding) and isValid(enableAudioTranscoding)
         if not enableVideoTranscoding and not enableAudioTranscoding
@@ -809,7 +809,7 @@ function getDeviceProfile() as object
             ' no video transcoding allowed
             newProfile = []
             for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
-                if deviceProfile.TranscodingProfiles[i].Type <> "video"
+                if Lcase(deviceProfile.TranscodingProfiles[i].Type) <> "video"
                     newProfile.push(deviceProfile.TranscodingProfiles[i])
                 end if
             end for
@@ -818,7 +818,7 @@ function getDeviceProfile() as object
             ' no audio transcoding allowed
             newProfile = []
             for i = 0 to deviceProfile.TranscodingProfiles.count() - 1
-                if deviceProfile.TranscodingProfiles[i].Type <> "audio"
+                if Lcase(deviceProfile.TranscodingProfiles[i].Type) <> "audio"
                     newProfile.push(deviceProfile.TranscodingProfiles[i])
                 end if
             end for

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -797,6 +797,11 @@ function getDeviceProfile() as object
         deviceProfile.CodecProfiles.push(codecProfileArray)
     end if
 
+    enableTranscoding = m.global.session.user.policy.EnableVideoPlaybackTranscoding
+    if enableTranscoding <> invalid and enableTranscoding = false
+        deviceProfile.TranscodingProfiles = []
+    end if
+
     return deviceProfile
 end function
 


### PR DESCRIPTION
These settings are accessed from the admin dashboard in the web client. Select "Users" then select a user to see the options.

![user-policy](https://github.com/jellyfin/jellyfin-roku/assets/16514652/f4ded68c-e6b5-4f43-8dda-9a02e472c0e9)

## Changes
- Remove audio entries in the transcodingprofiles array if audio transcoding is disabled
- Remove video entries in the transcodingprofiles array if video transcoding is disabled

## Issues
Fixes https://github.com/jellyfin/jellyfin-roku/discussions/1382
