### PR TITLE
Fix early exit from settings screen

### DIFF
--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -203,7 +203,7 @@ end sub
 
 ' Returns true if any of the data entry forms are in focus
 function isFormInFocus() as boolean
-    if m.settingDetail.focusedChild <> invalid or m.radioSetting.hasFocus() or m.boolSetting.hasFocus() or m.integerSetting.hasFocus()
+    if isValid(m.settingDetail.focusedChild) or m.radioSetting.hasFocus() or m.boolSetting.hasFocus() or m.integerSetting.hasFocus()
         return true
     end if
     return false
@@ -215,7 +215,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if (key = "back" or key = "left") and m.settingsMenu.focusedChild <> invalid and m.userLocation.Count() > 1
         LoadMenu({})
         return true
-    else if (key = "back" or key = "left") and isFormInFocus() = true
+    else if (key = "back" or key = "left") and isFormInFocus()
         m.settingsMenu.setFocus(true)
         return true
     end if

--- a/components/settings/settings.brs
+++ b/components/settings/settings.brs
@@ -1,7 +1,6 @@
 import "pkg:/source/utils/config.brs"
 import "pkg:/source/utils/misc.brs"
 import "pkg:/source/roku_modules/log/LogMixin.brs"
-import "pkg:/source/api/sdk.bs"
 
 sub init()
     m.log = log.Logger("Settings")
@@ -202,16 +201,21 @@ sub radioSettingChanged()
     set_user_setting(selectedSetting.settingName, m.radioSetting.content.getChild(m.radioSetting.checkedItem).id)
 end sub
 
+' Returns true if any of the data entry forms are in focus
+function isFormInFocus() as boolean
+    if m.settingDetail.focusedChild <> invalid or m.radioSetting.hasFocus() or m.boolSetting.hasFocus() or m.integerSetting.hasFocus()
+        return true
+    end if
+    return false
+end function
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
     if (key = "back" or key = "left") and m.settingsMenu.focusedChild <> invalid and m.userLocation.Count() > 1
         LoadMenu({})
         return true
-    else if (key = "back" or key = "left") and m.settingDetail.focusedChild <> invalid
-        m.settingsMenu.setFocus(true)
-        return true
-    else if (key = "back" or key = "left") and m.radioSetting.hasFocus()
+    else if (key = "back" or key = "left") and isFormInFocus() = true
         m.settingsMenu.setFocus(true)
         return true
     end if


### PR DESCRIPTION
While focused on the setting data form, hitting back or left would almost always exit the screen instead of navigating the settings tree as it should. This PR fixes that
## Changes
- Fix early exit from settings screen

Fixes #1454
