### PR TITLE
Fix direct play of the AV1 codec

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -526,16 +526,6 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>AV1</source>
-            <translation>AV1</translation>
-            <extracomment>Name of a setting - should we try to direct play experimental av1 codec</extracomment>
-        </message>
-        <message>
-            <source>** EXPERIMENTAL** Support Direct Play of AV1 content if this Roku device supports it.</source>
-            <translation>** EXPERIMENTAL** Support Direct Play of AV1 content if this Roku device supports it.</translation>
-            <extracomment>Description of a setting - should we try to direct play experimental av1 codec</extracomment>
-        </message>
-        <message>
             <source>Enabled</source>
             <translation>Enabled</translation>
         </message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -133,13 +133,6 @@
                 "description": "Enable or disable Direct Play support for certain codecs.",
                 "children": [
                     {
-                        "title": "AV1",
-                        "description": "** EXPERIMENTAL** Support Direct Play of AV1 content if this Roku device supports it.",
-                        "settingName": "playback.av1",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
                         "title": "MPEG-2",
                         "description": "Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.",
                         "settingName": "playback.mpeg2",

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -379,8 +379,7 @@ function getDeviceProfile() as object
         "IsRequired": true
     }
     '
-    ' add mp3 directly to transcoding profile.
-    ' for music i think?
+    ' add mp3 to TranscodingProfile for music
     deviceProfile.TranscodingProfiles.push({
         "Container": "mp3",
         "Type": "Audio",
@@ -397,30 +396,6 @@ function getDeviceProfile() as object
         "Protocol": "http",
         "MaxAudioChannels": maxAudioChannels
     })
-
-    ' setup container arrays
-    tsArray = {
-        "Container": "ts",
-        "Context": "Streaming",
-        "Protocol": "hls",
-        "Type": "Video",
-        "AudioCodec": tsAudioCodecs,
-        "VideoCodec": tsVideoCodecs,
-        "MaxAudioChannels": maxAudioChannels,
-        "MinSegments": 1,
-        "BreakOnNonKeyFrames": false
-    }
-    mp4Array = {
-        "Container": "mp4",
-        "Context": "Streaming",
-        "Protocol": "hls",
-        "Type": "Video",
-        "AudioCodec": mp4AudioCodecs,
-        "VideoCodec": mp4VideoCodecs,
-        "MaxAudioChannels": maxAudioChannels,
-        "MinSegments": 1,
-        "BreakOnNonKeyFrames": false
-    }
 
     ' set preferred audio codec for transcoding
     if isValid(surroundSoundCodec)
@@ -474,6 +449,29 @@ function getDeviceProfile() as object
             "MaxAudioChannels": "2"
         })
     end if
+
+    tsArray = {
+        "Container": "ts",
+        "Context": "Streaming",
+        "Protocol": "hls",
+        "Type": "Video",
+        "AudioCodec": tsAudioCodecs,
+        "VideoCodec": tsVideoCodecs,
+        "MaxAudioChannels": maxAudioChannels,
+        "MinSegments": 1,
+        "BreakOnNonKeyFrames": false
+    }
+    mp4Array = {
+        "Container": "mp4",
+        "Context": "Streaming",
+        "Protocol": "hls",
+        "Type": "Video",
+        "AudioCodec": mp4AudioCodecs,
+        "VideoCodec": mp4VideoCodecs,
+        "MaxAudioChannels": maxAudioChannels,
+        "MinSegments": 1,
+        "BreakOnNonKeyFrames": false
+    }
 
     ' apply max res to transcoding profile
     if maxResSetting <> "off"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -396,59 +396,24 @@ function getDeviceProfile() as object
         "Protocol": "http",
         "MaxAudioChannels": maxAudioChannels
     })
-
-    ' set preferred audio codec for transcoding
-    if isValid(surroundSoundCodec)
-        ' use preferred surround sound codec
-        deviceProfile.TranscodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Streaming",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-        deviceProfile.TranscodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Static",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-
-        ' put preferred surround sound codec in the front of AudioCodec strings
-        if tsArray.AudioCodec = ""
-            tsArray.AudioCodec = surroundSoundCodec
-        else
-            tsArray.AudioCodec = surroundSoundCodec + "," + tsArray.AudioCodec
-        end if
-
-        if mp4Array.AudioCodec = ""
-            mp4Array.AudioCodec = surroundSoundCodec
-        else
-            mp4Array.AudioCodec = surroundSoundCodec + "," + mp4Array.AudioCodec
-        end if
-    else
-        ' add aac for stereo audio.
-        ' stereo aac is supported on all devices
-        deviceProfile.TranscodingProfiles.push({
-            "Container": "ts",
-            "Type": "Audio",
-            "AudioCodec": "aac",
-            "Context": "Streaming",
-            "Protocol": "http",
-            "MaxAudioChannels": "2"
-        })
-        deviceProfile.TranscodingProfiles.push({
-            "Container": "ts",
-            "Type": "Audio",
-            "AudioCodec": "aac",
-            "Context": "Static",
-            "Protocol": "http",
-            "MaxAudioChannels": "2"
-        })
-    end if
+    ' add aac to TranscodingProfile for stereo audio
+    ' NOTE: multichannel aac is not supported. only decode to stereo on some devices
+    deviceProfile.TranscodingProfiles.push({
+        "Container": "ts",
+        "Type": "Audio",
+        "AudioCodec": "aac",
+        "Context": "Streaming",
+        "Protocol": "http",
+        "MaxAudioChannels": "2"
+    })
+    deviceProfile.TranscodingProfiles.push({
+        "Container": "ts",
+        "Type": "Audio",
+        "AudioCodec": "aac",
+        "Context": "Static",
+        "Protocol": "http",
+        "MaxAudioChannels": "2"
+    })
 
     tsArray = {
         "Container": "ts",
@@ -477,6 +442,40 @@ function getDeviceProfile() as object
     if maxResSetting <> "off"
         tsArray.Conditions = [maxVideoHeightArray, maxVideoWidthArray]
         mp4Array.Conditions = [maxVideoHeightArray, maxVideoWidthArray]
+    end if
+
+    ' surround sound
+    if surroundSoundCodec <> invalid
+        ' add preferred surround sound codec to TranscodingProfile
+        deviceProfile.TranscodingProfiles.push({
+            "Container": surroundSoundCodec,
+            "Type": "Audio",
+            "AudioCodec": surroundSoundCodec,
+            "Context": "Streaming",
+            "Protocol": "http",
+            "MaxAudioChannels": maxAudioChannels
+        })
+        deviceProfile.TranscodingProfiles.push({
+            "Container": surroundSoundCodec,
+            "Type": "Audio",
+            "AudioCodec": surroundSoundCodec,
+            "Context": "Static",
+            "Protocol": "http",
+            "MaxAudioChannels": maxAudioChannels
+        })
+
+        ' put codec in front of AudioCodec string
+        if tsArray.AudioCodec = ""
+            tsArray.AudioCodec = surroundSoundCodec
+        else
+            tsArray.AudioCodec = surroundSoundCodec + "," + tsArray.AudioCodec
+        end if
+
+        if mp4Array.AudioCodec = ""
+            mp4Array.AudioCodec = surroundSoundCodec
+        else
+            mp4Array.AudioCodec = surroundSoundCodec + "," + mp4Array.AudioCodec
+        end if
     end if
 
     deviceProfile.TranscodingProfiles.push(tsArray)

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -379,7 +379,8 @@ function getDeviceProfile() as object
         "IsRequired": true
     }
     '
-    ' add mp3 to TranscodingProfile for music
+    ' add mp3 directly to transcoding profile.
+    ' for music i think?
     deviceProfile.TranscodingProfiles.push({
         "Container": "mp3",
         "Type": "Audio",
@@ -396,6 +397,30 @@ function getDeviceProfile() as object
         "Protocol": "http",
         "MaxAudioChannels": maxAudioChannels
     })
+
+    ' setup container arrays
+    tsArray = {
+        "Container": "ts",
+        "Context": "Streaming",
+        "Protocol": "hls",
+        "Type": "Video",
+        "AudioCodec": tsAudioCodecs,
+        "VideoCodec": tsVideoCodecs,
+        "MaxAudioChannels": maxAudioChannels,
+        "MinSegments": 1,
+        "BreakOnNonKeyFrames": false
+    }
+    mp4Array = {
+        "Container": "mp4",
+        "Context": "Streaming",
+        "Protocol": "hls",
+        "Type": "Video",
+        "AudioCodec": mp4AudioCodecs,
+        "VideoCodec": mp4VideoCodecs,
+        "MaxAudioChannels": maxAudioChannels,
+        "MinSegments": 1,
+        "BreakOnNonKeyFrames": false
+    }
 
     ' set preferred audio codec for transcoding
     if isValid(surroundSoundCodec)
@@ -449,29 +474,6 @@ function getDeviceProfile() as object
             "MaxAudioChannels": "2"
         })
     end if
-
-    tsArray = {
-        "Container": "ts",
-        "Context": "Streaming",
-        "Protocol": "hls",
-        "Type": "Video",
-        "AudioCodec": tsAudioCodecs,
-        "VideoCodec": tsVideoCodecs,
-        "MaxAudioChannels": maxAudioChannels,
-        "MinSegments": 1,
-        "BreakOnNonKeyFrames": false
-    }
-    mp4Array = {
-        "Container": "mp4",
-        "Context": "Streaming",
-        "Protocol": "hls",
-        "Type": "Video",
-        "AudioCodec": mp4AudioCodecs,
-        "VideoCodec": mp4VideoCodecs,
-        "MaxAudioChannels": maxAudioChannels,
-        "MinSegments": 1,
-        "BreakOnNonKeyFrames": false
-    }
 
     ' apply max res to transcoding profile
     if maxResSetting <> "off"

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -606,7 +606,7 @@ function getDeviceProfile() as object
     if playAv1 and addAv1
         av1Mp4LevelSupported = 0.0
         av1TsLevelSupported = 0.0
-        av1AssProfiles = []
+        av1AssProfiles = {}
         av1HighestLevel = 0.0
         for each container in profileSupport
             for each profile in profileSupport[container]["av1"]

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -60,7 +60,6 @@ end sub
 
 function getDeviceProfile() as object
     playMpeg2 = m.global.session.user.settings["playback.mpeg2"]
-    playAv1 = m.global.session.user.settings["playback.av1"]
     di = CreateObject("roDeviceInfo")
 
     ' TRANSCODING
@@ -218,7 +217,7 @@ function getDeviceProfile() as object
     av1Profiles = ["main", "main 10"]
     av1Levels = ["4.1", "5.0", "5.1"]
 
-    if playAv1 and addAv1
+    if addAv1
         for each container in profileSupport
             for each profile in av1Profiles
                 for each level in av1Levels
@@ -594,7 +593,7 @@ function getDeviceProfile() as object
         deviceProfile.CodecProfiles.push(codecProfileArray)
     end if
 
-    if playAv1 and addAv1
+    if addAv1
         av1Mp4LevelSupported = 0.0
         av1TsLevelSupported = 0.0
         av1AssProfiles = {}
@@ -859,7 +858,7 @@ function GetDirectPlayProfiles() as object
 
     ' video codec overrides
     ' these codecs play fine but are not correctly detected using CanDecodeVideo()
-    if m.global.session.user.settings["playback.av1"] and di.CanDecodeVideo({ Codec: "av1" }).Result
+    if di.CanDecodeVideo({ Codec: "av1" }).Result
         ' codec must be checked by itself or the result will always be false
         for each container in supportedCodecs
             supportedCodecs[container]["video"].push("av1")

--- a/source/utils/deviceCapabilities.brs
+++ b/source/utils/deviceCapabilities.brs
@@ -396,24 +396,59 @@ function getDeviceProfile() as object
         "Protocol": "http",
         "MaxAudioChannels": maxAudioChannels
     })
-    ' add aac to TranscodingProfile for stereo audio
-    ' NOTE: multichannel aac is not supported. only decode to stereo on some devices
-    deviceProfile.TranscodingProfiles.push({
-        "Container": "ts",
-        "Type": "Audio",
-        "AudioCodec": "aac",
-        "Context": "Streaming",
-        "Protocol": "http",
-        "MaxAudioChannels": "2"
-    })
-    deviceProfile.TranscodingProfiles.push({
-        "Container": "ts",
-        "Type": "Audio",
-        "AudioCodec": "aac",
-        "Context": "Static",
-        "Protocol": "http",
-        "MaxAudioChannels": "2"
-    })
+
+    ' set preferred audio codec for transcoding
+    if isValid(surroundSoundCodec)
+        ' use preferred surround sound codec
+        deviceProfile.TranscodingProfiles.push({
+            "Container": surroundSoundCodec,
+            "Type": "Audio",
+            "AudioCodec": surroundSoundCodec,
+            "Context": "Streaming",
+            "Protocol": "http",
+            "MaxAudioChannels": maxAudioChannels
+        })
+        deviceProfile.TranscodingProfiles.push({
+            "Container": surroundSoundCodec,
+            "Type": "Audio",
+            "AudioCodec": surroundSoundCodec,
+            "Context": "Static",
+            "Protocol": "http",
+            "MaxAudioChannels": maxAudioChannels
+        })
+
+        ' put preferred surround sound codec in the front of AudioCodec strings
+        if tsArray.AudioCodec = ""
+            tsArray.AudioCodec = surroundSoundCodec
+        else
+            tsArray.AudioCodec = surroundSoundCodec + "," + tsArray.AudioCodec
+        end if
+
+        if mp4Array.AudioCodec = ""
+            mp4Array.AudioCodec = surroundSoundCodec
+        else
+            mp4Array.AudioCodec = surroundSoundCodec + "," + mp4Array.AudioCodec
+        end if
+    else
+        ' add aac for stereo audio.
+        ' stereo aac is supported on all devices
+        deviceProfile.TranscodingProfiles.push({
+            "Container": "ts",
+            "Type": "Audio",
+            "AudioCodec": "aac",
+            "Context": "Streaming",
+            "Protocol": "http",
+            "MaxAudioChannels": "2"
+        })
+        deviceProfile.TranscodingProfiles.push({
+            "Container": "ts",
+            "Type": "Audio",
+            "AudioCodec": "aac",
+            "Context": "Static",
+            "Protocol": "http",
+            "MaxAudioChannels": "2"
+        })
+    end if
 
     tsArray = {
         "Container": "ts",
@@ -442,40 +477,6 @@ function getDeviceProfile() as object
     if maxResSetting <> "off"
         tsArray.Conditions = [maxVideoHeightArray, maxVideoWidthArray]
         mp4Array.Conditions = [maxVideoHeightArray, maxVideoWidthArray]
-    end if
-
-    ' surround sound
-    if surroundSoundCodec <> invalid
-        ' add preferred surround sound codec to TranscodingProfile
-        deviceProfile.TranscodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Streaming",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-        deviceProfile.TranscodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Static",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-
-        ' put codec in front of AudioCodec string
-        if tsArray.AudioCodec = ""
-            tsArray.AudioCodec = surroundSoundCodec
-        else
-            tsArray.AudioCodec = surroundSoundCodec + "," + tsArray.AudioCodec
-        end if
-
-        if mp4Array.AudioCodec = ""
-            mp4Array.AudioCodec = surroundSoundCodec
-        else
-            mp4Array.AudioCodec = surroundSoundCodec + "," + mp4Array.AudioCodec
-        end if
     end if
 
     deviceProfile.TranscodingProfiles.push(tsArray)


### PR DESCRIPTION
`CanDecodeVideo()` always spits out false when checking the av1 codec with a container but will correctly report support with no container included. This removes the container when checking for support and adds the av1 codec to all containers direct play profile if av1 is supported.

## Changes
- Fix AV1 direct play
- Fix AV1 profile/level detection
- Remove user setting for av1 playback since device detection is working now

## Issues
Fixes #1392 
