### PR TITLE
Create sample bsconfig.tdd.json file

### DIFF
--- a/bsconfig-tdd-sample.json
+++ b/bsconfig-tdd-sample.json
@@ -18,6 +18,15 @@
     {
       "src": "settings/**/*",
       "dest": "settings"
+    },
+    "!**/*.spec.bs",
+    {
+      "src": "**/BaseTestSuite.spec.bs",
+      "dest": "source"
+    },
+    {
+      "src": "**/isValid.spec.bs",
+      "dest": "source"
     }
   ],
   "diagnosticFilters": ["node_modules/**/*", "**/roku_modules/**/*"],


### PR DESCRIPTION
This creates a working sample `bsconfig.tdd.json` file to show how devs can test only the unit test they are running and not the whole suite of tests. This should make life easier for anyone writing unit tests.

## Changes
- Create sample `bsconfig.tdd.json` file

