### PR TITLE
Fix overhang on home not reshowing when returning from movie library view

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -87,7 +87,7 @@ sub popScene()
 
         group.visible = false
 
-        if groupType = "JFScreen"
+        if groupType = "JFScreen" or LCase(groupType) = "movielibraryview"
             group.callFunc("OnScreenHidden")
         end if
     else

--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -87,7 +87,7 @@ sub popScene()
 
         group.visible = false
 
-        if groupType = "JFScreen" or LCase(groupType) = "movielibraryview"
+        if LCase(groupType) = "jfscreen" or LCase(groupType) = "movielibraryview"
             group.callFunc("OnScreenHidden")
         end if
     else


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Calls OnScreenHidden() for movie library view.

## Issues
Fixes #1427
