### PR TITLE
Revert subtype code change in SceneManager

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -77,17 +77,16 @@ end sub
 sub popScene()
     group = m.groups.pop()
     if group <> invalid
-        groupType = group.subtype()
-        if groupType = "JFGroup"
+        if group.isSubType("JFGroup")
             unregisterOverhangData(group)
-        else if groupType = "JFVideo"
+        else if group.isSubType("JFVideo")
             ' Stop video to make sure app communicates stop playstate to server
             group.control = "stop"
         end if
 
         group.visible = false
 
-        if groupType = "JFScreen"
+        if group.isSubType("JFScreen")
             group.callFunc("OnScreenHidden")
         end if
     else


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Based on discussion in https://github.com/jellyfin/jellyfin-roku/pull/1428 we found the root issue was code changes to subtype conditions. This PR reverts that code change.

## Issues
Fixes #1427
