### PR TITLE
Fix home section for accounts with no section data

### DIFF
--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -187,11 +187,31 @@ namespace session
         ' Saves user's web client home sections as Roku user settings.
         ' Handles unsupported sections and ignores duplicates.
         sub SaveUserHomeSections(customPrefs as object)
+            userPreferences = customPrefs
             rowTypes = []
+
+            ' If user has no section preferences, use default settings
+            if not userPreferences.doesExist("homesection0")
+                userPreferences = {
+                    homesection0: "smalllibrarytiles",
+                    homesection1: "resume",
+                    homesection2: "nextup",
+                    homesection3: "latestmedia",
+                    homesection4: "livetv",
+                    homesection5: "none",
+                    homesection6: "none"
+                }
+            end if
 
             for i = 0 to 6
                 homeSectionKey = "homesection" + i.toStr()
-                rowType = LCase(customPrefs[homeSectionKey])
+
+                ' If home section doesn't exist, create it as a none row
+                if not userPreferences.DoesExist(homeSectionKey)
+                    userPreferences.AddReplace(homeSectionKey, "none")
+                end if
+
+                rowType = LCase(userPreferences[homeSectionKey])
 
                 ' Just in case we get invalid data
                 if not isValid(rowType) then rowType = "none"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes home section display for users with no preference data. Uses default settings based on current production Jellyfin client.

I recreated the bug by creating a new user on my server and not setting home section preferences. I then logged in as this new user on my Roku. It indeed caused the home view to not load. With this PR, the same user had home sections load without issue.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
