### PR TITLE
Fix uninitialized var in login flow

### DIFF
--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -142,7 +142,7 @@ function LoginFlow()
                 print "Auth token is no longer valid"
                 'Try to login without password. If the token is valid, we're done
                 print "Attempting to login with no password"
-                userData = get_token(userSelected, "")
+                userData = get_token(myUsername, "")
                 if isValid(userData)
                     print "login success!"
                     session.user.Login(userData)


### PR DESCRIPTION
Fix uninitialized var bug with login flow. Not sure how the brighterscript vscode extension didn't catch this 🤔 
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
Fixes #1435 
