### PR TITLE
Fix gh-pages deploy

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -2,9 +2,9 @@
 name: deploy-api-docs
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["unstable"]
+    paths: ["docs/**"] # only run if the docs are updated
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-pages-artifact@v2
         with:
           # Only upload the api docs folder
-          path: "docs/api/*"
+          path: "docs/api"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Changes
- use proper file path instead of glob
- only deploy when something inside the docs folder changes (don't deploy for dependency updates etc.)

