### PR TITLE
Calculate device id on login and use for API calls

### DIFF
--- a/components/GetPlaybackInfoTask.brs
+++ b/components/GetPlaybackInfoTask.brs
@@ -35,7 +35,7 @@ end function
 ' Returns an array of playback info to be displayed during playback.
 ' In the future, with a custom playback info view, we can return an associated array.
 sub getPlaybackInfoTask()
-    sessions = api.sessions.Get()
+    sessions = api.sessions.Get({ "deviceId": m.global.device.serverDeviceName })
 
     m.playbackInfo = ItemPostPlaybackInfo(m.top.videoID)
 

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -119,7 +119,6 @@ function LoginFlow()
                     else
                         print "Success! Auth token is still valid"
                         session.user.Login(currentUser, true)
-                        session.user.LoadUserPreferences()
                         LoadUserAbilities()
                         return true
                     end if
@@ -132,7 +131,6 @@ function LoginFlow()
                 if isValid(userData)
                     print "login success!"
                     session.user.Login(userData, true)
-                    session.user.LoadUserPreferences()
                     LoadUserAbilities()
                     return true
                 else
@@ -175,7 +173,6 @@ function LoginFlow()
                 if isValid(userData)
                     print "login success!"
                     session.user.Login(userData, true)
-                    session.user.LoadUserPreferences()
                     LoadUserAbilities()
                     return true
                 else
@@ -201,7 +198,6 @@ function LoginFlow()
         goto start_login
     end if
 
-    session.user.LoadUserPreferences()
     LoadUserAbilities()
     m.global.sceneManager.callFunc("clearScenes")
 

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -468,7 +468,8 @@ end sub
 ' Returns an array of playback info to be displayed during playback.
 ' In the future, with a custom playback info view, we can return an associated array.
 function GetPlaybackInfo()
-    sessions = api.sessions.Get()
+    sessions = api.sessions.Get({ "deviceId": m.global.device.serverDeviceName })
+
     if isValid(sessions) and sessions.Count() > 0
         return GetTranscodingStats(sessions[0])
     end if

--- a/source/api/baserequest.brs
+++ b/source/api/baserequest.brs
@@ -205,11 +205,7 @@ function authRequest(request as object) as object
         auth = auth + ", UserId=" + QUOTE + m.global.session.user.id + QUOTE
     end if
 
-    if m.global.session.user <> invalid and m.global.session.user.friendlyName <> invalid
-        auth = auth + ", DeviceId=" + QUOTE + m.global.device.id + m.global.session.user.friendlyName + QUOTE
-    else
-        auth = auth + ", DeviceId=" + QUOTE + m.global.device.id + QUOTE
-    end if
+    auth = auth + ", DeviceId=" + QUOTE + m.global.device.serverDeviceName + QUOTE
 
     if m.global.session.user.authToken <> invalid
         auth = auth + ", Token=" + QUOTE + m.global.session.user.authToken + QUOTE

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1374,7 +1374,7 @@ namespace api
         end function
 
         ' Gets a list of sessions.
-        function Get(params = { "deviceId": m.global.device.id } as object)
+        function Get(params = {} as object)
             req = APIRequest("/sessions", params)
             return getJson(req)
         end function

--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1374,7 +1374,7 @@ namespace api
         end function
 
         ' Gets a list of sessions.
-        function Get(params = {} as object)
+        function Get(params = { "deviceId": m.global.device.serverDeviceName } as object)
             req = APIRequest("/sessions", params)
             return getJson(req)
         end function

--- a/source/utils/globals.brs
+++ b/source/utils/globals.brs
@@ -107,6 +107,7 @@ sub SaveDeviceToGlobal()
             uuid: deviceInfo.GetRandomUUID(),
             name: displayName,
             friendlyName: filteredFriendly,
+            serverDeviceName: "",
             model: deviceInfo.GetModel(),
             modelType: deviceInfo.GetModelType(),
             modelDetails: deviceInfo.GetModelDetails(),

--- a/source/utils/globals.brs
+++ b/source/utils/globals.brs
@@ -107,7 +107,7 @@ sub SaveDeviceToGlobal()
             uuid: deviceInfo.GetRandomUUID(),
             name: displayName,
             friendlyName: filteredFriendly,
-            serverDeviceName: "",
+            serverDeviceName: deviceInfo.getChannelClientID(),
             model: deviceInfo.GetModel(),
             modelType: deviceInfo.GetModelType(),
             modelDetails: deviceInfo.GetModelDetails(),

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -177,6 +177,13 @@ namespace session
 
         ' Load and parse Display Settings from server
         sub LoadUserPreferences()
+            ' Save device id so we don't calculate it every time we need it
+            if isValid(m.global.session.user) and isValid(m.global.session.user.friendlyName)
+                m.global.device.serverDeviceName = m.global.device.id + m.global.session.user.friendlyName
+            else
+                m.global.device.serverDeviceName = m.global.device.id
+            end if
+
             id = m.global.session.user.id
             ' Currently using client "emby", which is what website uses so we get same Display prefs as web.
             ' May want to change to specific Roku display settings

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -177,7 +177,7 @@ namespace session
             session.user.LoadUserPreferences()
         end sub
 
-        ' Sets the global service device name value used by the API
+        ' Sets the global server device name value used by the API
         sub SetServerDeviceName()
             if isValid(m.global.session.user) and isValid(m.global.session.user.friendlyName)
                 m.global.device.serverDeviceName = m.global.device.id + m.global.session.user.friendlyName

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -173,16 +173,23 @@ namespace session
                 set_user_setting("token", tmpSession.user.authToken)
                 set_user_setting("username", tmpSession.user.name)
             end if
+
+            session.user.LoadUserPreferences()
         end sub
 
-        ' Load and parse Display Settings from server
-        sub LoadUserPreferences()
-            ' Save device id so we don't calculate it every time we need it
+        ' Sets the global service device name value used by the API
+        sub SetServerDeviceName()
             if isValid(m.global.session.user) and isValid(m.global.session.user.friendlyName)
                 m.global.device.serverDeviceName = m.global.device.id + m.global.session.user.friendlyName
             else
                 m.global.device.serverDeviceName = m.global.device.id
             end if
+        end sub
+
+        ' Load and parse Display Settings from server
+        sub LoadUserPreferences()
+            ' Save device id so we don't calculate it every time we need it
+            session.user.SetServerDeviceName()
 
             id = m.global.session.user.id
             ' Currently using client "emby", which is what website uses so we get same Display prefs as web.
@@ -344,6 +351,9 @@ namespace session
                         session.user.settings.Save(item, get_setting(item))
                     end if
                 end for
+
+                ' Reset server device name state
+                session.user.SetServerDeviceName()
             end sub
 
             ' Saves the user setting to the global session.


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Calculates the device ID value we need to use for API calls on login and uses it instead of recalculating it on use. Removes the param value from the SDK and passes the value into the session.get() call. This change fixes the video playback info dialog.

## Issues
Fixes #1417