### PR TITLE
Change defaults for auto generated function definitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
     "**/.git": true,
     "**/node_modules": true,
     "docs/api/**": true
-  }
+  },
+  "brightscriptcomment.addExtraAtStartAndEnd": false
 }


### PR DESCRIPTION
Before:

![jsdoc-extension-before](https://github.com/jellyfin/jellyfin-roku/assets/16514652/4bb2b373-4a0a-4cb6-b7af-b3dbc753accb)

After:

![jsdoc-extension-after](https://github.com/jellyfin/jellyfin-roku/assets/16514652/dc2215ae-3499-4955-8732-f5ac9273a31a)

Extension options: https://marketplace.visualstudio.com/items?itemName=AliceBeckett.brightscriptcomment