### PR TITLE
Fix default A-Z movie sorting

### DIFF
--- a/components/ItemGrid/MovieLibraryView.brs
+++ b/components/ItemGrid/MovieLibraryView.brs
@@ -144,6 +144,7 @@ sub loadInitialItems()
     if not isValid(m.filter) then m.filter = "All"
     if not isValid(m.filterOptions) then m.filterOptions = "{}"
     if not isValid(m.view) then m.view = "Movies"
+    if not isValid(m.sortAscending) then m.sortAscending = true
 
     m.filterOptions = ParseJson(m.filterOptions)
 


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If user hasn't selected a sorting option for their movie library, default to A-Z sorting.

## Issues
Fixes #1444
