### PR TITLE
Use jellyfin-bot to commit and author `Update API docs` commits

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,3 +27,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5
         with:
           commit_message: Update API docs
+          # use jellyfin-bot to commit the changes instead of the default github-actions[bot]
+          commit_user_name: jellyfin-bot
+          commit_user_email: team@jellyfin.org
+          # use jellyfin-bot to author the changes instead of the default author of the merge commit
+          commit_author: jellyfin-bot <team@jellyfin.org>


### PR DESCRIPTION
Currently, the auto generated [`Update API docs` commits](https://github.com/jellyfin/jellyfin-roku/commits/unstable) are authored by the user that triggers the workflow (which is almost always the member that merges the PR because of the merge commit) and committed by `github-actions[bot]`. This changes that so they will be authored and committed by `jellyfin-bot` instead.



