### PR TITLE
Fix default A-Z music sorting

### DIFF
--- a/components/ItemGrid/MusicLibraryView.brs
+++ b/components/ItemGrid/MusicLibraryView.brs
@@ -131,6 +131,7 @@ sub loadInitialItems()
     if not isValid(m.sortField) then m.sortField = "SortName"
     if not isValid(m.filter) then m.filter = "All"
     if not isValid(m.view) then m.view = "ArtistsPresentation"
+    if not isValid(m.sortAscending) then m.sortAscending = true
 
     m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If user hasn't selected a sorting option for their music library, default to A-Z sorting.
