### PR TITLE
Add quickplay support to search results

### DIFF
--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -60,7 +60,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "right" and m.searchSelect.itemdata <> invalid and m.searchSelect.itemdata.TotalRecordCount > 0
         m.searchSelect.setFocus(true)
         return true
-    else if key = "play"
+    else if key = "play" and m.searchSelect.rowItemFocused.count() > 0
         print "play was pressed from search results"
         if m.searchSelect.rowItemFocused <> invalid
             m.top.quickPlayNode = m.searchSelect.content.getChild(m.searchSelect.rowItemFocused[0]).getChild(m.searchSelect.rowItemFocused[1])

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -57,7 +57,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = "left" and m.searchSelect.isinFocusChain()
         m.searchAlphabox.setFocus(true)
         return true
-    else if key = "right" and m.searchHelpText.visible = false
+    else if key = "right" and m.searchSelect.itemdata <> invalid and m.searchSelect.itemdata.TotalRecordCount > 0
         m.searchSelect.setFocus(true)
         return true
     else if key = "play"

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -57,7 +57,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = "left" and m.searchSelect.isinFocusChain()
         m.searchAlphabox.setFocus(true)
         return true
-    else if key = "right" and m.searchSelect.itemdata <> invalid and m.searchSelect.itemdata.TotalRecordCount > 0
+    else if key = "right" and m.searchSelect.content <> invalid and m.searchSelect.content.getChildCount() > 0
         m.searchSelect.setFocus(true)
         return true
     else if key = "play" and m.searchSelect.isinFocusChain() and m.searchSelect.rowItemFocused.count() > 0

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -57,7 +57,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = "left" and m.searchSelect.isinFocusChain()
         m.searchAlphabox.setFocus(true)
         return true
-    else if key = "right"
+    else if key = "right" and m.searchHelpText.visible = false
         m.searchSelect.setFocus(true)
         return true
     else if key = "play"

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -41,6 +41,13 @@ sub loadResults()
     m.searchSelect.itemdata = m.searchTask.results
     m.searchSelect.query = m.top.SearchAlpha
     m.searchHelpText.visible = false
+    if m.searchTask.results.TotalRecordCount = 0
+        ' make sure focus is on the keyboard
+        if m.searchSelect.isinFocusChain()
+            m.searchAlphabox.setFocus(true)
+        end if
+        return
+    end if
     m.searchAlphabox = m.top.findnode("searchResults")
     m.searchAlphabox.translation = "[470, 85]"
 end sub
@@ -63,8 +70,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "play" and m.searchSelect.isinFocusChain() and m.searchSelect.rowItemFocused.count() > 0
         print "play was pressed from search results"
         if m.searchSelect.rowItemFocused <> invalid
-            m.top.quickPlayNode = m.searchSelect.content.getChild(m.searchSelect.rowItemFocused[0]).getChild(m.searchSelect.rowItemFocused[1])
-            return true
+            selectedContent = m.searchSelect.content.getChild(m.searchSelect.rowItemFocused[0])
+            if selectedContent <> invalid
+                selectedItem = selectedContent.getChild(m.searchSelect.rowItemFocused[1])
+                if selectedItem <> invalid
+                    m.top.quickPlayNode = selectedItem
+                    return true
+                end if
+            end if
         end if
     end if
     return false

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -60,6 +60,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "right"
         m.searchSelect.setFocus(true)
         return true
+    else if key = "play"
+        print "play was pressed from search results"
+        if m.searchSelect.rowItemFocused <> invalid
+            m.top.quickPlayNode = m.searchSelect.content.getChild(m.searchSelect.rowItemFocused[0]).getChild(m.searchSelect.rowItemFocused[1])
+            return true
+        end if
     end if
     return false
 

--- a/components/search/SearchResults.brs
+++ b/components/search/SearchResults.brs
@@ -60,7 +60,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     else if key = "right" and m.searchSelect.itemdata <> invalid and m.searchSelect.itemdata.TotalRecordCount > 0
         m.searchSelect.setFocus(true)
         return true
-    else if key = "play" and m.searchSelect.rowItemFocused.count() > 0
+    else if key = "play" and m.searchSelect.isinFocusChain() and m.searchSelect.rowItemFocused.count() > 0
         print "play was pressed from search results"
         if m.searchSelect.rowItemFocused <> invalid
             m.top.quickPlayNode = m.searchSelect.content.getChild(m.searchSelect.rowItemFocused[0]).getChild(m.searchSelect.rowItemFocused[1])

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -855,6 +855,7 @@ end function
 function CreateSearchPage()
     ' Search + Results Page
     group = CreateObject("roSGNode", "searchResults")
+    group.observeField("quickPlayNode", m.port)
     options = group.findNode("searchSelect")
     options.observeField("itemSelected", m.port)
 


### PR DESCRIPTION
## Changes
- Observe `quickPlayNode` and update it with the focused item when play is pressed
- Only allow focus to leave keyboard if there are search results data

## Issues
Fixes #1455 
