### PR TITLE
"Next Episode" button updates

### DIFF
--- a/components/JFVideo.brs
+++ b/components/JFVideo.brs
@@ -90,10 +90,13 @@ end sub
 '
 ' Runs Next Episode button animation and sets focus to button
 sub showNextEpisodeButton()
-    if m.global.session.user.configuration.EnableNextEpisodeAutoPlay and not m.nextEpisodeButton.visible
+    if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
+    if m.nextupbuttonseconds = 0 then return ' is the button disabled?
+
+    if m.nextEpisodeButton.opacity = 0 and m.global.session.user.configuration.EnableNextEpisodeAutoPlay
+        m.nextEpisodeButton.visible = true
         m.showNextEpisodeButtonAnimation.control = "start"
         m.nextEpisodeButton.setFocus(true)
-        m.nextEpisodeButton.visible = true
     end if
 end sub
 
@@ -117,13 +120,22 @@ end sub
 
 ' Checks if we need to display the Next Episode button
 sub checkTimeToDisplayNextEpisode()
-    if m.top.content.contenttype <> 4 then return
-    if m.nextupbuttonseconds = 0 then return
+    if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
+    if m.nextupbuttonseconds = 0 then return ' is the button disabled?
 
-    if int(m.top.position) >= (m.top.duration - m.nextupbuttonseconds)
-        showNextEpisodeButton()
-        updateCount()
-        return
+    if isValid(m.top.duration) and isValid(m.top.position)
+        nextEpisodeCountdown = Int(m.top.duration - m.top.position)
+
+        if nextEpisodeCountdown < 0 and m.nextEpisodeButton.opacity = 0.9
+            hideNextEpisodeButton()
+            return
+        else if nextEpisodeCountdown > 1 and int(m.top.position) >= (m.top.duration - m.nextupbuttonseconds - 1)
+            updateCount()
+            if m.nextEpisodeButton.opacity = 0
+                showNextEpisodeButton()
+            end if
+            return
+        end if
     end if
 
     if m.nextEpisodeButton.visible or m.nextEpisodeButton.hasFocus()
@@ -266,8 +278,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     else
         'Hide Next Episode Button
-        if m.nextEpisodeButton.visible or m.nextEpisodeButton.hasFocus()
-            m.nextEpisodeButton.visible = false
+        if m.nextEpisodeButton.opacity > 0 or m.nextEpisodeButton.hasFocus()
+            m.nextEpisodeButton.opacity = 0
             m.nextEpisodeButton.setFocus(false)
             m.top.setFocus(true)
         end if

--- a/components/JFVideo.xml
+++ b/components/JFVideo.xml
@@ -40,7 +40,7 @@
     <Animation id="showNextEpisodeButton" duration="1.0" repeat="false" easeFunction="inQuad">
       <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[0.0, .9]" fieldToInterp="nextEpisode.opacity" />
     </Animation>
-    <Animation id="hideNextEpisodeButton" duration=".2" repeat="false" easeFunction="inQuad">
+    <Animation id="hideNextEpisodeButton" duration=".25" repeat="false" easeFunction="inQuad">
       <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[.9, 0]" fieldToInterp="nextEpisode.opacity" />
     </Animation>
   </children>

--- a/components/video/VideoPlayerView.brs
+++ b/components/video/VideoPlayerView.brs
@@ -218,6 +218,9 @@ end sub
 
 ' Checks if we need to display the Next Episode button
 sub checkTimeToDisplayNextEpisode()
+    ' only display the Next Episode button when the content is type "Episode"
+    if m.top.content.contenttype <> 4 then return
+
     if int(m.top.position) >= (m.top.duration - 30)
         showNextEpisodeButton()
         updateCount()

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -36,7 +36,7 @@
     <Animation id="showNextEpisodeButton" duration="1.0" repeat="false" easeFunction="inQuad">
       <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[0.0, .9]" fieldToInterp="nextEpisode.opacity" />
     </Animation>
-    <Animation id="hideNextEpisodeButton" duration=".2" repeat="false" easeFunction="inQuad">
+    <Animation id="hideNextEpisodeButton" duration=".25" repeat="false" easeFunction="inQuad">
       <FloatFieldInterpolator key="[0.0, 1.0]" keyValue="[.9, 0]" fieldToInterp="nextEpisode.opacity" />
     </Animation>
   </children>


### PR DESCRIPTION
The "Next Episode" popup was being shown on all video types. This changes that so it only shows for episodes (type = 4. see [here](https://developer.roku.com/docs/developer-program/getting-started/architecture/content-metadata.md#descriptive-attributes) for docs), fixes some bugs, and hides the button a second before the next video is loaded.

## Changes
- Only show the "Next Episode" button when the video content is type "Episode"
- Use opacity instead of visibility when checking the button's state
- Show the button 1 second early to allow time for the 1sec animation
- Hide the button when the countdown reaches 1 instead of letting the button show 0 and never removing it


A lot of code taken from https://github.com/jellyfin/jellyfin-roku/pull/1051 so credit @1hitsong 

Fixes a bug where the button was displayed for all media types i.e. Movies
Fixes a bug where the button would display negative numbers if you paused the show


