### PR TITLE
Sort auto-generated release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: 🆕 New Features
+      labels:
+        - "new feature"
+    - title: 🔨 Updated Features
+      labels:
+        - "updated feature"
+    - title: ⚙️ New Settings
+      labels:
+        - "new setting"
+    - title: 🔧 Updated Settings
+      labels:
+        - "updated setting"
+    - title: 🐛 Bug Fixes
+      labels:
+        - "bug fix"
+    - title: ⭐ Additional Updates
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,6 +15,9 @@ changelog:
     - title: 🐛 Bug Fixes
       labels:
         - "bug fix"
+    - title: 🧹 Code Cleanup
+      labels:
+        - "code cleanup"
     - title: ⭐ Additional Updates
       labels:
         - "*"


### PR DESCRIPTION
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes

## Changes
- Create `.github/release.yml` to sort auto-generated release notes by label

