### PR TITLE
Don't run certain workflows on forks

### DIFF
--- a/.github/workflows/auto-close-stale-pr.yml
+++ b/.github/workflows/auto-close-stale-pr.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'jellyfin/jellyfin-roku'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   project:
+    if: github.repository == 'jellyfin/jellyfin-roku'
     name: Project board 📊
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +24,7 @@ jobs:
           column: In progress
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
   label:
+    if: github.repository == 'jellyfin/jellyfin-roku'
     name: Labeling 🏷️
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   docs:
+    if: github.repository == 'jellyfin/jellyfin-roku'
     runs-on: ubuntu-latest
-
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
       contents: write
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'jellyfin/jellyfin-roku'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This will disable most of the workflows from running on forks - even if the user enables workflows for their fork.

At first, I just wanted to disable the workflow that deploys the api docs but I've also disabled all the workflows that use the `jellyfin-bot` org secret since the fork won't have access to the jellyfin-bot secrets

## Changes
- Add an if conditional to most of the workflows -> only run if github repo = jellyfin/jellyfin-roku

