### PR TITLE
Show loading spinner and disable remote during login

### DIFF
--- a/source/Main.brs
+++ b/source/Main.brs
@@ -36,6 +36,8 @@ sub Main (args as dynamic) as void
     ' remove previous scenes from the stack
     sceneManager.callFunc("clearScenes")
 
+    stopLoadingSpinner()
+
     ' load home page
     sceneManager.currentUser = m.global.session.user.name
     group = CreateHomeGroup()

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -86,13 +86,13 @@ function LoginFlow()
             end if
             ' push all users to the user select view
             userSelected = CreateUserSelectGroup(publicUsersNodes)
-
             SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
             if userSelected = "backPressed"
                 session.server.Delete()
                 unset_setting("server")
                 goto start_login
-            else
+            else if userSelected <> ""
+                startMediaLoadingSpinner()
                 print "A public user was selected with username=" + userSelected
                 session.user.Update("name", userSelected)
                 regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
@@ -140,6 +140,7 @@ function LoginFlow()
         else
             userSelected = ""
         end if
+        stopLoadingSpinner()
         passwordEntry = CreateSigninGroup(userSelected)
         SendPerformanceBeacon("AppDialogComplete") ' Roku Performance monitoring - Dialog Closed
         if passwordEntry = "backPressed"
@@ -480,6 +481,7 @@ function CreateSigninGroup(user = "")
         else if type(msg) = "roSGNodeEvent"
             node = msg.getNode()
             if node = "submit"
+                startMediaLoadingSpinner()
                 ' Validate credentials
                 activeUser = get_token(username.value, password.value)
                 if isValid(activeUser)
@@ -494,6 +496,7 @@ function CreateSigninGroup(user = "")
                     end if
                     return "true"
                 end if
+                stopLoadingSpinner()
                 print "Login attempt failed..."
                 group.findNode("alert").text = tr("Login attempt failed.")
             else if node = "quickConnect"


### PR DESCRIPTION
When logging in, there is a slight delay. This adds a loading spinner so the user knows the app is working and also disables any further button presses to prevent edge case bugs.

NOTE: Tested with public/private users with and without password. Not tested with quick connect

## Changes
- Show loading spinner and disable remote on login

