### PR TITLE
Remove progressbar delay and speed up animation on home screen

### DIFF
--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -15,7 +15,7 @@
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
     <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
 
-    <Animation id="showProgressBar" delay="1" duration="1" repeat="false" easeFunction="linear">
+    <Animation id="showProgressBar" duration="0.5" repeat="false" easeFunction="linear">
       <FloatFieldInterpolator id="showProgressBarField" key="[0.0, 1.0]" fieldToInterp="progress.width" />
     </Animation>
   </children>


### PR DESCRIPTION
Delay isn't needed and speeding up the animation makes the home page appear to refresh faster

## Changes
- Remove 1sec animation delay
- Reduce animation time from 1sec to 0.5sec

