### PR TITLE
Save credentials if asked when using quick connect

### DIFF
--- a/components/quickConnect/QuickConnectDialog.bs
+++ b/components/quickConnect/QuickConnectDialog.bs
@@ -33,7 +33,11 @@ sub OnAuthenticated()
         authenticated = AuthenticateViaQuickConnect(m.top.quickConnectJson.secret)
         if authenticated <> invalid and authenticated = true
             currentUser = AboutMe()
-            session.user.Login(currentUser)
+            if m.top.saveCredentials
+                session.user.Login(currentUser, true)
+            else
+                session.user.Login(currentUser)
+            end if
             session.user.LoadUserPreferences()
             LoadUserAbilities()
             m.top.close = true

--- a/components/quickConnect/QuickConnectDialog.bs
+++ b/components/quickConnect/QuickConnectDialog.bs
@@ -33,11 +33,7 @@ sub OnAuthenticated()
         authenticated = AuthenticateViaQuickConnect(m.top.quickConnectJson.secret)
         if authenticated <> invalid and authenticated = true
             currentUser = AboutMe()
-            if m.top.saveCredentials
-                session.user.Login(currentUser, true)
-            else
-                session.user.Login(currentUser)
-            end if
+            session.user.Login(currentUser, m.top.saveCredentials)
             session.user.LoadUserPreferences()
             LoadUserAbilities()
             m.top.close = true

--- a/components/quickConnect/QuickConnectDialog.xml
+++ b/components/quickConnect/QuickConnectDialog.xml
@@ -7,5 +7,6 @@
     <interface>
         <field id="quickConnectJson" type="assocarray" />
         <field id="authenticated" type="boolean" alwaysNotify="true" />
+        <field id="saveCredentials" type="boolean" />
     </interface>
 </component>

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -506,6 +506,7 @@ function CreateSigninGroup(user = "")
                 else
                     ' Server user is talking to is at least 10.8 and has quick connect enabled...
                     m.quickConnectDialog = createObject("roSGNode", "QuickConnectDialog")
+                    m.quickConnectDialog.saveCredentials = checkbox.checkedState[0]
                     m.quickConnectDialog.quickConnectJson = json
                     m.quickConnectDialog.title = tr("Quick Connect")
                     m.quickConnectDialog.message = [tr("Here is your Quick Connect code: ") + json.Code, tr("(Dialog will close automatically)")]


### PR DESCRIPTION
## Changes
- Save state of "Save credentials?" checkbox to quickconnect component field
- Use new component field to determine if we should save credentials after quick connect is authorized

## Issues
Fixes #1488 
