### PR TITLE
Add general-improvement label to auto generated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,9 @@ changelog:
     - title: ⚙️ New Settings
       labels:
         - "new-setting"
+    - title: 🔧 General Improvements
+      labels:
+        - "general-improvement"
     - title: 🐛 Bug Fixes
       labels:
         - "bug-fix"


### PR DESCRIPTION
This label already existed for issues but I'm repurposing it for PRs. I removed the label from the existing issues (6).

## Changes
- Add general-improvement label to auto generated changelog

