### PR TITLE
Add progress bar to pause menu

### DIFF
--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -165,7 +165,7 @@ sub audioPositionChanged()
 
     ' Update displayed position timestamp
     if isValid(m.global.audioPlayer.position)
-        m.positionTimestamp.text = secondsToHuman(m.global.audioPlayer.position)
+        m.positionTimestamp.text = secondsToHuman(m.global.audioPlayer.position, false)
     else
         m.positionTimestamp.text = "0:00"
     end if

--- a/components/video/PauseMenu.bs
+++ b/components/video/PauseMenu.bs
@@ -7,9 +7,14 @@ sub init()
     m.inactivityTimer = m.top.findNode("inactivityTimer")
     m.itemTitle = m.top.findNode("itemTitle")
     m.videoPlayPause = m.top.findNode("videoPlayPause")
+    m.videoPositionTime = m.top.findNode("videoPositionTime")
+    m.videoRemainingTime = m.top.findNode("videoRemainingTime")
+    m.progressBar = m.top.findNode("progressBar")
+    m.progressBarBackground = m.top.findNode("progressBarBackground")
 
     m.top.observeField("visible", "onVisibleChanged")
     m.top.observeField("hasFocus", "onFocusChanged")
+    m.top.observeField("progressPercentage", "onProgressPercentageChanged")
     m.top.observeField("playbackState", "onPlaybackStateChanged")
     m.top.observeField("itemTitleText", "onItemTitleTextChanged")
 
@@ -21,6 +26,14 @@ sub init()
 
     m.videoControls.getChild(m.defaultButtonIndex).focus = true
     m.deviceInfo = CreateObject("roDeviceInfo")
+end sub
+
+' onProgressPercentageChanged: Handler for changes to m.top.progressPercentage param
+'
+sub onProgressPercentageChanged()
+    m.videoPositionTime.text = secondsToHuman(m.top.positionTime)
+    m.videoRemainingTime.text = secondsToHuman(m.top.remainingPositionTime)
+    m.progressBar.width = m.progressBarBackground.width * m.top.progressPercentage
 end sub
 
 ' onPlaybackStateChanged: Handler for changes to m.top.playbackState param

--- a/components/video/PauseMenu.bs
+++ b/components/video/PauseMenu.bs
@@ -31,8 +31,8 @@ end sub
 ' onProgressPercentageChanged: Handler for changes to m.top.progressPercentage param
 '
 sub onProgressPercentageChanged()
-    m.videoPositionTime.text = secondsToHuman(m.top.positionTime)
-    m.videoRemainingTime.text = secondsToHuman(m.top.remainingPositionTime)
+    m.videoPositionTime.text = secondsToHuman(m.top.positionTime, true)
+    m.videoRemainingTime.text = secondsToHuman(m.top.remainingPositionTime, true)
     m.progressBar.width = m.progressBarBackground.width * m.top.progressPercentage
 end sub
 

--- a/components/video/PauseMenu.xml
+++ b/components/video/PauseMenu.xml
@@ -10,17 +10,27 @@
       <IconButton id="showSubtitleMenu" background="#070707" focusBackground="#00a4dc" padding="0" icon="pkg:/images/icons/subtitle.png" height="65" width="100" />
     </ButtonGroup>
 
-    <ButtonGroup id="videoControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="center" translation="[960,950]">
+    <ButtonGroup id="videoControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="center" translation="[960,875]">
       <IconButton id="chapterBack" background="#070707" focusBackground="#00a4dc" padding="16" icon="pkg:/images/icons/previousChapter.png" height="65" width="100" />
       <IconButton id="videoPlayPause" background="#070707" focusBackground="#00a4dc" padding="35" icon="pkg:/images/icons/play.png" height="65" width="100" />
       <IconButton id="chapterNext" background="#070707" focusBackground="#00a4dc" padding="16" icon="pkg:/images/icons/nextChapter.png" height="65" width="100" />
     </ButtonGroup>
+
+    <Rectangle id="progressBarBackground" color="0x00000098" width="1536" height="8" translation="[192,970]">
+      <Rectangle id="progressBar" color="#e5e4e2FF" width="0" height="8" />
+    </Rectangle>
+
+    <Label id="videoPositionTime" font="font:SmallestSystemFont" color="0xffffffFF" translation="[192,985]" />
+    <Label id="videoRemainingTime" font="font:SmallestSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1528,985]" />
 
     <Timer id="inactivityTimer" duration="1" repeat="true" />
   </children>
   <interface>
     <field id="itemTitleText" type="string" />
     <field id="inactiveTimeout" type="integer" />
+    <field id="progressPercentage" type="float" />
+    <field id="positionTime" type="float" />
+    <field id="remainingPositionTime" type="float" />
     <field id="playbackState" type="string" alwaysNotify="true" />
     <field id="action" type="string" alwaysNotify="true" />
     <field id="showChapterList" type="boolean" alwaysNotify="true" />

--- a/components/video/PauseMenu.xml
+++ b/components/video/PauseMenu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="PauseMenu" extends="Group" initialFocus="chapterNext">
   <children>
-    <Label id="itemTitle" font="font:LargeBoldSystemFont" translation="[103,61]" />
+    <ScrollingLabel id="itemTitle" font="font:LargeBoldSystemFont" translation="[103,61]" maxWidth="1400" />
     <Clock id="clock" translation="[1618, 46]" />
 
     <ButtonGroup id="optionControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="left" translation="[103,120]">
@@ -16,12 +16,12 @@
       <IconButton id="chapterNext" background="#070707" focusBackground="#00a4dc" padding="16" icon="pkg:/images/icons/nextChapter.png" height="65" width="100" />
     </ButtonGroup>
 
-    <Rectangle id="progressBarBackground" color="0x00000098" width="1536" height="8" translation="[192,970]">
+    <Rectangle id="progressBarBackground" color="0x00000098" width="1714" height="8" translation="[103,970]">
       <Rectangle id="progressBar" color="#e5e4e2FF" width="0" height="8" />
     </Rectangle>
 
-    <Label id="videoPositionTime" font="font:SmallestSystemFont" color="0xffffffFF" translation="[192,985]" />
-    <Label id="videoRemainingTime" font="font:SmallestSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1528,985]" />
+    <Label id="videoPositionTime" font="font:MediumSystemFont" color="0xffffffFF" translation="[103,985]" />
+    <Label id="videoRemainingTime" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,985]" />
 
     <Timer id="inactivityTimer" duration="1" repeat="true" />
   </children>

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -437,6 +437,12 @@ end sub
 
 ' When Video Player state changes
 sub onPositionChanged()
+
+    ' Pass video position data into pause menu
+    m.pauseMenu.progressPercentage = m.top.position / m.top.duration
+    m.pauseMenu.positionTime = m.top.position
+    m.pauseMenu.remainingPositionTime = m.top.duration - m.top.position
+
     if isValid(m.captionTask)
         m.captionTask.currentPos = Int(m.top.position * 1000)
     end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -618,7 +618,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if not press then return false
 
-    if key = "down"
+    if key = "down" and not m.top.trickPlayBar.visible
         if not m.LoadMetaDataTask.isIntro
             m.pauseMenu.visible = true
             m.pauseMenu.hasFocus = true
@@ -626,7 +626,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             return true
         end if
 
-    else if key = "up"
+    else if key = "up" and not m.top.trickPlayBar.visible
         if not m.LoadMetaDataTask.isIntro
             m.pauseMenu.visible = true
             m.pauseMenu.hasFocus = true

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -43,16 +43,31 @@ function ticksToHuman(ticks as longinteger) as string
     return r
 end function
 
-function secondsToHuman(totalSeconds as integer) as string
+function secondsToHuman(totalSeconds as integer, addLeadingMinuteZero as boolean) as string
+    humanTime = ""
     hours = stri(int(totalSeconds / 3600)).trim()
     minutes = stri(int((totalSeconds - (val(hours) * 3600)) / 60)).trim()
     seconds = stri(totalSeconds - (val(hours) * 3600) - (val(minutes) * 60)).trim()
-    if val(hours) > 0 and val(minutes) < 10 then minutes = "0" + minutes
-    if val(seconds) < 10 then seconds = "0" + seconds
-    r = ""
-    if val(hours) > 0 then r = hours + ":"
-    r = r + minutes + ":" + seconds
-    return r
+
+    if val(hours) > 0 or addLeadingMinuteZero
+        if val(minutes) < 10
+            minutes = "0" + minutes
+        end if
+    end if
+
+    if val(seconds) < 10
+        seconds = "0" + seconds
+    end if
+
+    if val(hours) > 0
+        hours = hours + ":"
+    else
+        hours = ""
+    end if
+
+    humanTime = hours + minutes + ":" + seconds
+
+    return humanTime
 end function
 
 ' Format time as 12 or 24 hour format based on system clock setting


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds a progress bar indicator to the pause menu showing the user their current position, time left in the video, and a visual percentage bar.

## Demo
https://github.com/jellyfin/jellyfin-roku/assets/3330318/afd0db32-2210-4f3a-8118-dbe409858043

