### PR TITLE
restore loading spinner to videos

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -7,6 +7,8 @@ end sub
 
 ' Play Video
 sub CreateVideoPlayerView()
+    m.scene = m.top.getScene()
+    startMediaLoadingSpinner()
     m.playbackData = {}
     m.selectedSubtitle = {}
 
@@ -149,6 +151,7 @@ end sub
 
 ' Playback state change event handlers
 sub onStateChange()
+    stopLoadingSpinner()
     if LCase(m.view.state) = "finished"
         ' Close any open dialogs
         if m.global.sceneManager.callFunc("isDialogOpen")


### PR DESCRIPTION
we lost the first spinner when we moved to universal queue (the one that shows while we wait for the initial request to return) this PR restores it.