### PR TITLE
Fix user registry migration logic + print out registry when asked

### DIFF
--- a/manifest
+++ b/manifest
@@ -24,3 +24,5 @@ ui_resolutions=fhd
 confirm_partner_button=1
 
 supports_input_launch=1
+
+bs_const=printReg=false

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -1,4 +1,5 @@
 sub Main (args as dynamic) as void
+    printRegistry()
     ' The main function that runs when the application is launched.
     m.screen = CreateObject("roSGScreen")
     ' Set global constants

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -16,6 +16,18 @@ sub Main (args as dynamic) as void
     SaveDeviceToGlobal()
     session.Init()
 
+    ' migrate registry if needed
+    m.wasMigrated = false
+    runGlobalMigrations()
+    runRegistryUserMigrations()
+    ' update LastRunVersion now that migrations are finished
+    showWhatsNew = false
+    if m.global.app.version <> m.global.app.lastRunVersion
+        showWhatsNew = true
+        set_setting("LastRunVersion", m.global.app.version)
+    end if
+    if m.wasMigrated then printRegistry()
+
     m.scene = m.screen.CreateScene("JFScene")
     m.screen.show() ' vscode_rale_tracker_entry
 
@@ -63,24 +75,11 @@ sub Main (args as dynamic) as void
         end if
     end if
 
-    ' Save the global last run version of the app
-    if m.global.app.version <> m.global.app.lastRunVersion
-        ' update global LastRunVersion
-        set_setting("LastRunVersion", m.global.app.version)
-
-        ' Show the Whats New popup
-        if m.global.session.user.settings["load.allowwhatsnew"] = true
-            dialog = createObject("roSGNode", "WhatsNewDialog")
-            m.scene.dialog = dialog
-            m.scene.dialog.observeField("buttonSelected", m.port)
-        end if
-    end if
-
-    ' Save the user last run version of the app
-    if m.global.session.user.lastRunVersion <> m.global.app.lastRunVersion
-        ' update user LastRunVersion
-        set_user_setting("LastRunVersion", m.global.app.version)
-        session.user.Update("lastRunVersion", m.global.app.version)
+    ' Show the Whats New popup
+    if showWhatsNew and m.global.session.user.settings["load.allowwhatsnew"]
+        dialog = createObject("roSGNode", "WhatsNewDialog")
+        m.scene.dialog = dialog
+        m.scene.dialog.observeField("buttonSelected", m.port)
     end if
 
     ' Handle input messages

--- a/source/migrations.bs
+++ b/source/migrations.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/utils/misc.bs"
+import "pkg:/source/utils/conditional.bs"
 
 ' Functions that update the registry based on the last run version and the currently running version
 
@@ -44,17 +45,27 @@ sub runGlobalMigrations()
             end if
         end if
     end if
-    if m.global.app.lastRunVersion <> invalid
-        runRegistryUserMigrations(m.global.app.lastRunVersion)
-    end if
+
+    runRegistryUserMigrations()
+
+    printRegistry()
 end sub
 
-sub runRegistryUserMigrations(version as string)
+sub runRegistryUserMigrations()
     regSections = getRegistrySections()
     for each section in regSections
         if LCase(section) <> "jellyfin"
-            if version = "2.0.0"
-                print "Running User Registry Migration for 2.0.0"
+            reg = CreateObject("roRegistrySection", section)
+            if reg.exists("LastRunVersion")
+                lastRunVersion = reg.read("LastRunVersion")
+            else
+                ' fall back to using the apps lastRunVersion
+                ' NOTE: app versions < 2.0.0 didn't save this at the user level
+                lastRunVersion = m.global.app.lastRunVersion
+            end if
+
+            if not versionChecker(lastRunVersion, "2.0.0")
+                print "Running Registry Migration for 2.0.0 for userid: " + section
                 ' now saving LastRunVersion globally and per user so that we can run user specific registry migrations
                 ' duplicate LastRunVersion to all user settings in the registry so that we can run user specific migrations
                 '

--- a/source/migrations.bs
+++ b/source/migrations.bs
@@ -1,16 +1,18 @@
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/conditional.bs"
 
-' Functions that update the registry based on the last run version and the currently running version
+' @fileoverview Functions that update the registry based on the last run version and the currently running version
+
+const CLIENT_VERSION_REQUIRING_BASE_MIGRATION = "2.0.0"
 
 ' Run all necessary registry mirations on the "global" Jellyfin registry section
 sub runGlobalMigrations()
     appLastRunVersion = m.global.app.lastRunVersion
     ' Global registry migrations
-    if isValid(appLastRunVersion) and not versionChecker(appLastRunVersion, "2.0.0")
+    if isValid(appLastRunVersion) and not versionChecker(appLastRunVersion, CLIENT_VERSION_REQUIRING_BASE_MIGRATION)
         m.wasMigrated = true
-        ' last app version used was less than 2.0.0
-        print "Running 2.0.0 global registry migrations"
+        ' last app version used was less than CLIENT_VERSION_REQUIRING_BASE_MIGRATION
+        print `Running ${CLIENT_VERSION_REQUIRING_BASE_MIGRATION} global registry migrations`
         ' no longer saving raw password to registry
         ' auth token and username are now stored in user settings and not global settings
 
@@ -59,19 +61,17 @@ sub runRegistryUserMigrations()
                 lastRunVersion = reg.read("LastRunVersion")
             else
                 hasUserVersion = false
+                ' app versions < 2.0.0 didn't save LastRunVersion at the user level
                 ' fall back to using the apps lastRunVersion
-                ' NOTE: app versions < 2.0.0 didn't save this at the user level
                 lastRunVersion = m.global.app.lastRunVersion
                 registry_write("LastRunVersion", m.global.app.version, section)
             end if
 
-            ' 2.0.0
-            if not versionChecker(lastRunVersion, "2.0.0")
+            ' BASE_MIGRATION
+            if not versionChecker(lastRunVersion, CLIENT_VERSION_REQUIRING_BASE_MIGRATION)
                 m.wasMigrated = true
-                print "Running Registry Migration for 2.0.0 for userid: " + section
-                ' now saving LastRunVersion per user in addition to globally so that we can run user specific registry migrations
-                ' duplicate LastRunVersion to all user settings in the registry so that we can run user specific migrations
-                '
+                print `Running Registry Migration for ${CLIENT_VERSION_REQUIRING_BASE_MIGRATION} for userid: ${section}`
+
                 ' no longer saving password to registry
                 registry_delete("password", section)
                 ' av1 playback no longer hidden behind user setting

--- a/source/migrations.bs
+++ b/source/migrations.bs
@@ -5,8 +5,10 @@ import "pkg:/source/utils/conditional.bs"
 
 ' Run all necessary registry mirations on the "global" Jellyfin registry section
 sub runGlobalMigrations()
+    appLastRunVersion = m.global.app.lastRunVersion
     ' Global registry migrations
-    if isValid(m.global.app.lastRunVersion) and not versionChecker(m.global.app.lastRunVersion, "2.0.0")
+    if isValid(appLastRunVersion) and not versionChecker(appLastRunVersion, "2.0.0")
+        m.wasMigrated = true
         ' last app version used was less than 2.0.0
         print "Running 2.0.0 global registry migrations"
         ' no longer saving raw password to registry
@@ -45,10 +47,6 @@ sub runGlobalMigrations()
             end if
         end if
     end if
-
-    runRegistryUserMigrations()
-
-    printRegistry()
 end sub
 
 sub runRegistryUserMigrations()
@@ -57,24 +55,32 @@ sub runRegistryUserMigrations()
         if LCase(section) <> "jellyfin"
             reg = CreateObject("roRegistrySection", section)
             if reg.exists("LastRunVersion")
+                hasUserVersion = true
                 lastRunVersion = reg.read("LastRunVersion")
             else
+                hasUserVersion = false
                 ' fall back to using the apps lastRunVersion
                 ' NOTE: app versions < 2.0.0 didn't save this at the user level
                 lastRunVersion = m.global.app.lastRunVersion
+                registry_write("LastRunVersion", m.global.app.version, section)
             end if
 
+            ' 2.0.0
             if not versionChecker(lastRunVersion, "2.0.0")
+                m.wasMigrated = true
                 print "Running Registry Migration for 2.0.0 for userid: " + section
-                ' now saving LastRunVersion globally and per user so that we can run user specific registry migrations
+                ' now saving LastRunVersion per user in addition to globally so that we can run user specific registry migrations
                 ' duplicate LastRunVersion to all user settings in the registry so that we can run user specific migrations
                 '
-                ' now saving LastRunVersion per user in addition to globally
-                registry_write("LastRunVersion", m.global.app.version, section)
                 ' no longer saving password to registry
                 registry_delete("password", section)
                 ' av1 playback no longer hidden behind user setting
                 registry_delete("playback.av1", section)
+            end if
+
+            ' update lastRunVersion if needed
+            if hasUserVersion and lastRunVersion <> m.global.app.version
+                registry_write("LastRunVersion", m.global.app.version, section)
             end if
         end if
     end for

--- a/source/utils/conditional.bs
+++ b/source/utils/conditional.bs
@@ -1,0 +1,16 @@
+' @fileoverview Conditional functions that depend on 'bs_const' values specified in the manifest file
+
+' Print out all of the registry contents to the debug log
+sub printRegistry()
+    #if printReg
+        ' get a list of every registry section
+        regSections = getRegistrySections()
+        for each section in regSections
+            ' read all the data from the section
+            sectionData = RegistryReadAll(section)
+            ' print the assocArray with all the data
+            print "Registry section: " + section
+            print sectionData
+        end for
+    #end if
+end sub

--- a/source/utils/config.bs
+++ b/source/utils/config.bs
@@ -36,11 +36,8 @@ function RegistryReadAll(section as string) as dynamic
     regKeyList = registry.GetKeyList()
     registryData = {}
     for each item in regKeyList
-        ' ignore session related tokens
-        if item <> "token" and item <> "username" and item <> "password" and LCase(item) <> "lastrunversion"
-            if registry.Exists(item)
-                registryData.AddReplace(item, registry.Read(item))
-            end if
+        if registry.Exists(item)
+            registryData.AddReplace(item, registry.Read(item))
         end if
     end for
 

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -73,9 +73,6 @@ namespace session
                 session.server.Delete()
             end if
 
-            ' migrate registry if needed
-            runGlobalMigrations()
-
             return success
         end function
 
@@ -166,7 +163,10 @@ namespace session
             ' update user session settings with values from registry
             userSettings = RegistryReadAll(tmpSession.user.id)
             for each setting in userSettings
-                session.user.settings.Save(setting, userSettings[setting])
+                ' don't add auth token to user session
+                if setting <> "token"
+                    session.user.settings.Save(setting, userSettings[setting])
+                end if
             end for
 
             if m.global.app.isDev


### PR DESCRIPTION

## Changes
- Fix bug with user migration logic
- Utilize `bs_const` conditional vars to print out the registry when enabled. defaults to disabled.
  - Prints first thing before the app does anything
  - Prints again after any registry migrations have been ran

