### PR TITLE
Ensure loading spinner activates for queue items

### DIFF
--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -120,6 +120,8 @@ sub playQueue()
     nextItemMediaType = getItemType(nextItem)
     if nextItemMediaType = "" then return
 
+    startLoadingSpinner()
+
     if nextItemMediaType = "audio"
         CreateAudioPlayerView()
         return
@@ -149,6 +151,8 @@ sub playQueue()
         CreateVideoPlayerView()
         return
     end if
+
+    stopLoadingSpinner()
 end sub
 
 ' Remove item at end of play queue

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -2,6 +2,7 @@
 sub CreateAudioPlayerView()
     m.view = CreateObject("roSGNode", "AudioPlayerView")
     m.view.observeField("state", "onStateChange")
+    stopLoadingSpinner()
     m.global.sceneManager.callFunc("pushScene", m.view)
 end sub
 
@@ -25,6 +26,7 @@ sub CreateVideoPlayerView()
     m.getPlaybackInfoTask.videoID = mediaSourceId
     m.getPlaybackInfoTask.observeField("data", "onPlaybackInfoLoaded")
 
+    stopLoadingSpinner()
     m.global.sceneManager.callFunc("pushScene", m.view)
 end sub
 

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -452,6 +452,9 @@ function toString(input) as string
 end function
 
 sub startLoadingSpinner()
+    if not isValid(m.scene)
+        m.scene = m.top.getScene()
+    end if
     m.spinner = createObject("roSGNode", "Spinner")
     m.spinner.translation = "[900, 450]"
     m.spinner.visible = true
@@ -467,6 +470,9 @@ sub startMediaLoadingSpinner()
 end sub
 
 sub stopLoadingSpinner()
+    if not isValid(m.scene)
+        m.scene = m.top.getScene()
+    end if
     if isValid(m.spinner)
         m.spinner.visible = false
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Shows loading spinner when playback is called for queued items.
