### PR TITLE
Rename pauseMenu component to OSD

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -79,7 +79,7 @@ sub resetFocusToDefaultButton()
     m.optionControls.buttonFocused = m.optionControls.getChildCount() - 1
 end sub
 
-' onVisibleChanged: Handler for changes to the visibility of this pause menu.
+' onVisibleChanged: Handler for changes to the visibility of this menu.
 '
 sub onVisibleChanged()
     if m.top.visible
@@ -93,7 +93,7 @@ sub onVisibleChanged()
     m.inactivityTimer.control = "stop"
 end sub
 
-' onFocusChanged: Handler for changes to the focus of this pause menu.
+' onFocusChanged: Handler for changes to the focus of this menu.
 '
 sub onFocusChanged()
     if m.top.hasfocus
@@ -107,7 +107,7 @@ sub onFocusChanged()
     end if
 end sub
 
-' inactiveCheck: Checks if the time since last keypress is greater than or equal to the allowed inactive time of the pause menu.
+' inactiveCheck: Checks if the time since last keypress is greater than or equal to the allowed inactive time of the menu.
 '
 sub inactiveCheck()
     if m.deviceInfo.timeSinceLastKeypress() >= m.top.inactiveTimeout
@@ -115,7 +115,7 @@ sub inactiveCheck()
     end if
 end sub
 
-' onButtonSelected: Handler for selection of buttons from the pause menu.
+' onButtonSelected: Handler for selection of buttons from the menu.
 '
 sub onButtonSelected()
     if m.optionControls.isInFocusChain()

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="PauseMenu" extends="Group" initialFocus="chapterNext">
+<component name="OSD" extends="Group" initialFocus="chapterNext">
   <children>
     <ScrollingLabel id="itemTitle" font="font:LargeBoldSystemFont" translation="[103,61]" maxWidth="1400" />
     <Clock id="clock" translation="[1618, 46]" />

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -24,8 +24,8 @@ sub init()
     m.chapterList = m.top.findNode("chapterList")
     m.chapterMenu = m.top.findNode("chapterMenu")
     m.chapterContent = m.top.findNode("chapterContent")
-    m.pauseMenu = m.top.findNode("pauseMenu")
-    m.pauseMenu.observeField("action", "onPauseMenuAction")
+    m.osd = m.top.findNode("osd")
+    m.osd.observeField("action", "onOSDAction")
 
     m.playbackTimer = m.top.findNode("playbackTimer")
     m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
@@ -91,17 +91,17 @@ sub handleChapterSkipAction(action as string)
     end if
 end sub
 
-' handleHideAction: Handles action to hide pause menu
+' handleHideAction: Handles action to hide OSD menu
 '
 ' @param {boolean} resume - controls whether or not to resume video playback when sub is called
 '
 sub handleHideAction(resume as boolean)
-    m.pauseMenu.visible = false
+    m.osd.visible = false
     m.chapterList.visible = false
-    m.pauseMenu.showChapterList = false
+    m.osd.showChapterList = false
     m.chapterList.setFocus(false)
-    m.pauseMenu.hasFocus = false
-    m.pauseMenu.setFocus(false)
+    m.osd.hasFocus = false
+    m.osd.setFocus(false)
     m.top.setFocus(true)
     if resume
         m.top.control = "resume"
@@ -111,14 +111,14 @@ end sub
 ' handleChapterListAction: Handles action to show chapter list
 '
 sub handleChapterListAction()
-    m.chapterList.visible = m.pauseMenu.showChapterList
+    m.chapterList.visible = m.osd.showChapterList
 
     if not m.chapterList.visible then return
 
     m.chapterMenu.jumpToItem = getCurrentChapterIndex()
 
-    m.pauseMenu.hasFocus = false
-    m.pauseMenu.setFocus(false)
+    m.osd.hasFocus = false
+    m.osd.setFocus(false)
     m.chapterMenu.setFocus(true)
 end sub
 
@@ -171,10 +171,10 @@ sub handleShowVideoInfoPopupAction()
     handleHideAction(false)
 end sub
 
-' onPauseMenuAction: Process action events from pause menu to their respective handlers
+' onOSDAction: Process action events from OSD to their respective handlers
 '
-sub onPauseMenuAction()
-    action = LCase(m.pauseMenu.action)
+sub onOSDAction()
+    action = LCase(m.osd.action)
 
     if action = "hide"
         handleHideAction(false)
@@ -320,7 +320,7 @@ sub onVideoContentLoaded()
     m.top.transcodeParams = videoContent[0].transcodeparams
     m.chapters = videoContent[0].chapters
 
-    m.pauseMenu.itemTitleText = m.top.content.title
+    m.osd.itemTitleText = m.top.content.title
 
     populateChapterMenu()
 
@@ -380,7 +380,7 @@ end sub
 '
 ' Runs Next Episode button animation and sets focus to button
 sub showNextEpisodeButton()
-    if m.pauseMenu.visible then return
+    if m.osd.visible then return
     if m.top.content.contenttype <> 4 then return ' only display when content is type "Episode"
     if m.nextupbuttonseconds = 0 then return ' is the button disabled?
 
@@ -438,10 +438,10 @@ end sub
 ' When Video Player state changes
 sub onPositionChanged()
 
-    ' Pass video position data into pause menu
-    m.pauseMenu.progressPercentage = m.top.position / m.top.duration
-    m.pauseMenu.positionTime = m.top.position
-    m.pauseMenu.remainingPositionTime = m.top.duration - m.top.position
+    ' Pass video position data into OSD
+    m.osd.progressPercentage = m.top.position / m.top.duration
+    m.osd.positionTime = m.top.position
+    m.osd.remainingPositionTime = m.top.duration - m.top.position
 
     if isValid(m.captionTask)
         m.captionTask.currentPos = Int(m.top.position * 1000)
@@ -464,8 +464,8 @@ sub onState(msg)
         m.captionTask.playerState = m.top.state + m.top.globalCaptionMode
     end if
 
-    ' Pass video state into pause menu
-    m.pauseMenu.playbackState = m.top.state
+    ' Pass video state into OSD
+    m.osd.playbackState = m.top.state
 
     ' When buffering, start timer to monitor buffering process
     if m.top.state = "buffering" and m.bufferCheckTimer <> invalid
@@ -568,10 +568,10 @@ sub bufferCheck(msg)
 
 end sub
 
-' stateAllowsPauseMenu: Check if current video state allows showing the pause menu
+' stateAllowsOSD: Check if current video state allows showing the OSD
 '
-' @return {boolean} indicating if video state allows the pause menu to show
-function stateAllowsPauseMenu() as boolean
+' @return {boolean} indicating if video state allows the OSD to show
+function stateAllowsOSD() as boolean
     validStates = ["playing", "paused", "stopped"]
     return inArray(validStates, m.top.state)
 end function
@@ -596,10 +596,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
         if key = "back" or key = "replay"
             m.chapterList.visible = false
-            m.pauseMenu.showChapterList = false
+            m.osd.showChapterList = false
             m.chapterMenu.setFocus(false)
-            m.pauseMenu.hasFocus = true
-            m.pauseMenu.setFocus(true)
+            m.osd.hasFocus = true
+            m.osd.setFocus(true)
             return true
         end if
 
@@ -629,58 +629,58 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = "down" and not m.top.trickPlayBar.visible
         if not m.LoadMetaDataTask.isIntro
             ' Don't allow user to open menu prior to video loading
-            if not stateAllowsPauseMenu() then return true
+            if not stateAllowsOSD() then return true
 
-            m.pauseMenu.visible = true
-            m.pauseMenu.hasFocus = true
-            m.pauseMenu.setFocus(true)
+            m.osd.visible = true
+            m.osd.hasFocus = true
+            m.osd.setFocus(true)
             return true
         end if
 
     else if key = "up" and not m.top.trickPlayBar.visible
         if not m.LoadMetaDataTask.isIntro
             ' Don't allow user to open menu prior to video loading
-            if not stateAllowsPauseMenu() then return true
+            if not stateAllowsOSD() then return true
 
-            m.pauseMenu.visible = true
-            m.pauseMenu.hasFocus = true
-            m.pauseMenu.setFocus(true)
+            m.osd.visible = true
+            m.osd.hasFocus = true
+            m.osd.setFocus(true)
             return true
         end if
 
     else if key = "OK" and not m.top.trickPlayBar.visible
         if not m.LoadMetaDataTask.isIntro
             ' Don't allow user to open menu prior to video loading
-            if not stateAllowsPauseMenu() then return true
+            if not stateAllowsOSD() then return true
 
-            ' Show pause menu, but don't pause video
-            m.pauseMenu.visible = true
-            m.pauseMenu.hasFocus = true
-            m.pauseMenu.setFocus(true)
+            ' Show OSD, but don't pause video
+            m.osd.visible = true
+            m.osd.hasFocus = true
+            m.osd.setFocus(true)
             return true
         end if
 
         return false
     end if
 
-    ' Disable pause menu for intro videos
+    ' Disable OSD for intro videos
     if not m.LoadMetaDataTask.isIntro
         if key = "play" and not m.top.trickPlayBar.visible
 
             ' Don't allow user to open menu prior to video loading
-            if not stateAllowsPauseMenu() then return true
+            if not stateAllowsOSD() then return true
 
-            ' If video is paused, resume it and don't show pause menu
+            ' If video is paused, resume it and don't show OSD
             if m.top.state = "paused"
                 m.top.control = "resume"
                 return true
             end if
 
-            ' Pause video and show pause menu
+            ' Pause video and show OSD
             m.top.control = "pause"
-            m.pauseMenu.visible = true
-            m.pauseMenu.hasFocus = true
-            m.pauseMenu.setFocus(true)
+            m.osd.visible = true
+            m.osd.hasFocus = true
+            m.osd.setFocus(true)
             return true
         end if
     end if

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -30,7 +30,7 @@
     <Group id="captionGroup" translation="[960,1020]" />
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
-    <PauseMenu id="pauseMenu" visible="false" inactiveTimeout="5" />
+    <OSD id="osd" visible="false" inactiveTimeout="5" />
 
     <Rectangle id="chapterList" visible="false" color="0x00000098" width="400" height="380" translation="[103,210]">
       <LabelList id="chaptermenu" itemSpacing="[0,20]" numRows="5" font="font:SmallSystemFont" itemSize="[315,40]" translation="[40,20]">

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1229,7 +1229,7 @@
         <message>
             <source>No Chapter Data Found</source>
             <translation>No Chapter Data Found</translation>
-            <extracomment>Message shown in pause menu when no chapter data is returned by the API</extracomment>
+            <extracomment>Message shown in OSD when no chapter data is returned by the API</extracomment>
         </message>
     </context>
 </TS>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
The name "Pause Menu" no longer makes sense because users can now access it by more than pausing. This PR renames the component, variables, and comments to refer to it as OSD - the industry standard term for On Screen Display.
