### PR TITLE
Fix migration crash

### DIFF
--- a/source/migrations.bs
+++ b/source/migrations.bs
@@ -10,16 +10,15 @@ sub runGlobalMigrations()
     appLastRunVersion = m.global.app.lastRunVersion
     ' Global registry migrations
     if isValid(appLastRunVersion) and not versionChecker(appLastRunVersion, CLIENT_VERSION_REQUIRING_BASE_MIGRATION)
+        ' last app version used < CLIENT_VERSION_REQUIRING_BASE_MIGRATION
         m.wasMigrated = true
-        ' last app version used was less than CLIENT_VERSION_REQUIRING_BASE_MIGRATION
         print `Running ${CLIENT_VERSION_REQUIRING_BASE_MIGRATION} global registry migrations`
         ' no longer saving raw password to registry
         ' auth token and username are now stored in user settings and not global settings
 
+        ' migrate saved credentials for "active_user" if found
         savedUserId = get_setting("active_user")
         if isValid(savedUserId)
-            registry_write("serverId", m.global.session.server.id, savedUserId)
-            ' copy saved credentials to user block
             savedUsername = get_setting("username")
             if isValid(savedUsername)
                 registry_write("username", savedUsername, savedUserId)
@@ -30,11 +29,12 @@ sub runGlobalMigrations()
                 registry_write("token", savedToken, savedUserId)
             end if
         end if
+        ' remove settings from global "jellyfin" registry block
         unset_setting("port")
         unset_setting("token")
         unset_setting("username")
         unset_setting("password")
-        ' remove saved credentials from saved_servers
+        ' remove any saved credentials found in saved_servers assocArray
         saved = get_setting("saved_servers")
         if isValid(saved)
             savedServers = ParseJson(saved)


### PR DESCRIPTION
I tracked this down to a bad line of code I wrote in `migrations.bs`. It's trying to use `m.global.session.server.id` but it will always be invalid at this point in the app when the function is called. We should just remove it instead of fixing it because what it's trying to do makes no sense anyway - the active server id is staying on the global "jellyfin" block and doesn't need to be migrated anywhere.

One bad thing about brighterscript is that the lines shown on error logs are for the transpiled files and not the source files. I forgot this and couldn't figure out how line 18 in migrations (from the error tracestack) was writing to the reg but when I checked `build/staging/` the line number matched the right line of code: `registry_write("serverId", m.global.session.server.id, savedUserId)`

![283579710-9fd4db77-36ce-4205-9873-bbdfd4da2e3b](https://github.com/jellyfin/jellyfin-roku/assets/16514652/464e9939-419f-4e03-8b05-c386fcbbc6b8)