### PR TITLE
Increase font size for unwatched episode count

### DIFF
--- a/components/ItemGrid/GridItem.xml
+++ b/components/ItemGrid/GridItem.xml
@@ -5,7 +5,7 @@
       <Poster id="backdrop" width="290" height="425" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
       <Poster id="itemPoster" width="290" height="425" loadDisplayMode="scaleToZoom">
         <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[201, 0]">
-          <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
+          <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
         </Rectangle>
       </Poster>
       <Poster id="itemIcon" width="50" height="50" translation="[230,10]" />

--- a/components/ListPoster.xml
+++ b/components/ListPoster.xml
@@ -5,7 +5,7 @@
     <ScrollingLabel id="Series" horizAlign="center" font="font:SmallSystemFont" repeatCount="0" visible="false" />
     <Poster id="poster" translation="[2,0]" loadDisplayMode="scaleToFit">
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[104, 0]">
-        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
+        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
     </Poster>
     <ScrollingLabel id="title" horizAlign="center" font="font:SmallSystemFont" repeatCount="0" visible="false" />

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -5,7 +5,7 @@
     <Poster id="itemIcon" width="100" height="100" translation="[190,85]" loadDisplayMode="scaleToFit" />
     <Poster id="itemPoster" width="464" height="261" translation="[8,5]" loadDisplayMode="scaleToZoom">
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[375, 0]">
-        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
+        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
       <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" />
     </Poster>

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -3,7 +3,7 @@
   <children>
     <Poster id="seasonPoster" width="300" height="450" translation="[95,175]">
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[210, 0]">
-        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
+        <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
     </Poster>
     <JFButton id="shuffle" minChars="10" text="Shuffle" translation="[90, 640]" visible="false"></JFButton>

--- a/components/tvshows/TVShowDetails.xml
+++ b/components/tvshows/TVShowDetails.xml
@@ -5,7 +5,7 @@
       <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[15]">
         <Poster id="tvshowPoster" width="300" height="450">
           <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[210, 0]">
-            <Label id="unplayedEpisodeCount" width="90" height="60" font="font:SmallestBoldSystemFont" horizAlign="center" vertAlign="center" />
+            <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
           </Rectangle>
         </Poster>
         <LayoutGroup layoutDirection="vert" itemSpacings="[15]">


### PR DESCRIPTION
This increase the font size for the unwatched episode count from `smallest` to `medium` (options are smallest, small, medium, large). This change makes it so that I can read the number without needing my glasses 😛 

## Changes
- Increase font size for unwatched episode count


before:
![unstable](https://github.com/jellyfin/jellyfin-roku/assets/16514652/d0cd3bc8-ca90-4298-957f-02556da7bf59)

after:
![medium-font](https://github.com/jellyfin/jellyfin-roku/assets/16514652/cd2d7ca5-4b9a-44f8-a789-b9240d31586b)
