### PR TITLE
Fix episode list bug where OK was triggering quickplay

### DIFF
--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -48,13 +48,13 @@ end sub
 
 ' get the currently focused item
 function getFocusedItem() as dynamic
-    if isValid(m.top.focusedChild) and isValid(m.top.focusedChild.focusedChild)
-        focusedChild = m.top.focusedChild.focusedChild
-        if not isValid(focusedChild.content) then return invalid
-        m.top.lastFocus = focusedChild
-    else
+    if not isValid(m.top.focusedChild) or not isValid(m.top.focusedChild.focusedChild)
         return invalid
     end if
+
+    focusedChild = m.top.focusedChild.focusedChild
+    if not isValid(focusedChild.content) then return invalid
+    m.top.lastFocus = focusedChild
 
     if isValidAndNotEmpty(focusedChild.rowItemFocused)
         itemToPlay = focusedChild.content.getChild(focusedChild.rowItemFocused[0]).getChild(0)

--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -46,10 +46,28 @@ sub updateSeason()
     m.top.overhangTitle = m.top.seasonData.SeriesName + " - " + m.top.seasonData.name
 end sub
 
+' get the currently focused item
+function getFocusedItem() as dynamic
+    if isValid(m.top.focusedChild) and isValid(m.top.focusedChild.focusedChild)
+        focusedChild = m.top.focusedChild.focusedChild
+        if not isValid(focusedChild.content) then return invalid
+        m.top.lastFocus = focusedChild
+    else
+        return invalid
+    end if
+
+    if isValidAndNotEmpty(focusedChild.rowItemFocused)
+        itemToPlay = focusedChild.content.getChild(focusedChild.rowItemFocused[0]).getChild(0)
+        if isValid(itemToPlay) and isValidAndNotEmpty(itemToPlay.id)
+            return itemToPlay
+        end if
+    end if
+
+    return invalid
+end function
+
 ' Handle navigation input from the remote and act on it
 function onKeyEvent(key as string, press as boolean) as boolean
-    handled = false
-
     if key = "left" and m.tvEpisodeRow.hasFocus()
         m.shuffle.setFocus(true)
         return true
@@ -70,7 +88,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     end if
 
-    if key = "OK" or key = "play"
+    if key = "OK"
+        if m.tvEpisodeRow.isInFocusChain()
+            focusedItem = getFocusedItem()
+            if isValid(focusedItem)
+                m.top.selectedItem = focusedItem
+            end if
+            return true
+        end if
+
         if m.shuffle.hasFocus()
             episodeList = m.rows.getChild(0).objects.items
 
@@ -97,22 +123,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
-    focusedChild = m.top.focusedChild.focusedChild
-    if focusedChild.content = invalid then return handled
-
-    ' OK needs to be handled on release...
-    proceed = false
-    if key = "OK"
-        proceed = true
-    end if
-
-    if press and key = "play" or proceed = true
-        m.top.lastFocus = focusedChild
-        itemToPlay = focusedChild.content.getChild(focusedChild.rowItemFocused[0]).getChild(0)
-        if isValid(itemToPlay) and isValid(itemToPlay.id) and itemToPlay.id <> ""
-            m.top.quickPlayNode = itemToPlay
+    if key = "play"
+        focusedItem = getFocusedItem()
+        if isValid(focusedItem)
+            m.top.quickPlayNode = focusedItem
         end if
-        handled = true
+        return true
     end if
-    return handled
+
+    return false
 end function

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -12,6 +12,7 @@
   </children>
   <interface>
     <field id="episodeSelected" alias="picker.itemSelected" />
+    <field id="selectedItem" type="node" alwaysNotify="true" />
     <field id="quickPlayNode" type="node" />
     <field id="seasonData" type="assocarray" onChange="setSeasonLoading" />
     <field id="objects" alias="picker.objects" />

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -790,7 +790,7 @@ function CreateSeasonDetailsGroup(series as object, season as object) as dynamic
     group.extrasObjects = TVSeasonExtras(season.id)
 
     ' watch for button presses
-    group.observeField("episodeSelected", m.port)
+    group.observeField("selectedItem", m.port)
     group.observeField("quickPlayNode", m.port)
     ' finished building SeasonDetails view
     stopLoadingSpinner()


### PR DESCRIPTION
The episode list was using the quickplaynode to play the episode when selecting the item with OK and play. I didn't realize screens were using the quickplaynode to handle OK presses so this created a bug after I updated quickplay recently.

This PR changes the logic so OK behaves the same way it does on the home screen and only uses the quickplaynode with the play button.

## Changes
- Fix episode list bug where OK was triggering quickplay

