### PR TITLE
Return to OSD on dialog close

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -110,6 +110,11 @@ end sub
 ' inactiveCheck: Checks if the time since last keypress is greater than or equal to the allowed inactive time of the menu.
 '
 sub inactiveCheck()
+    ' If user is currently seeing a dialog box, ignore inactive check
+    if m.global.sceneManager.callFunc("isDialogOpen")
+        return
+    end if
+
     if m.deviceInfo.timeSinceLastKeypress() >= m.top.inactiveTimeout
         m.top.action = "hide"
     end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -161,14 +161,12 @@ end sub
 '
 sub handleShowSubtitleMenuAction()
     m.top.selectSubtitlePressed = true
-    handleHideAction(false)
 end sub
 
 ' handleShowVideoInfoPopupAction: Handles action to show video info popup
 '
 sub handleShowVideoInfoPopupAction()
     m.top.selectPlaybackInfoPressed = true
-    handleHideAction(false)
 end sub
 
 ' onOSDAction: Process action events from OSD to their respective handlers


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Ignore hide function if dialog is open. This causes the user to return to the OSD after dialog close.

## Issues
Fixes #1504
