### PR TITLE
Fix TV Guide bug

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -735,6 +735,9 @@ sub onChannelSelected(msg)
     if node.watchChannel <> invalid
         ' Clone the node when it's reused/update in the TimeGrid it doesn't automatically start playing
         m.top.selectedItem = node.watchChannel.clone(false)
+        ' Make sure to set watchChanel to invalid in case the user hits back and then selects
+        ' the same channel on the guide (without moving away from the currently selected channel)
+        m.tvGuide.watchChannel = invalid
     end if
 end sub
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
If a user select a TV channel to view and then hits back, trying to view the same channel again does not work unless the user moves away from the selected channel and back again.
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Allows the user to view the same channel again without having to move away from it first.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
