### PR TITLE
Fix remember me bug

### DIFF
--- a/components/data/UserData.bs
+++ b/components/data/UserData.bs
@@ -53,12 +53,6 @@ function setPreference(key as string, value as string)
     return set_user_setting("pref-" + key, value)
 end function
 
-sub setActive()
-    if m.global.session.user.settings["global.rememberme"]
-        set_setting("active_user", m.top.id)
-    end if
-end sub
-
 sub setServer(hostname as string)
     m.top.server = hostname
 end sub

--- a/components/data/UserData.xml
+++ b/components/data/UserData.xml
@@ -11,6 +11,5 @@
     <function name="setPreference" />
     <function name="loadFromRegistry" />
     <function name="saveToRegistry" />
-    <function name="setActive" />
   </interface>
 </component>

--- a/source/api/userauth.bs
+++ b/source/api/userauth.bs
@@ -12,9 +12,8 @@ function get_token(user as string, password as string)
 
     userdata = CreateObject("roSGNode", "UserData")
     userdata.json = json
-
-    userdata.callFunc("setActive")
     userdata.callFunc("saveToRegistry")
+
     return userdata
 end function
 
@@ -163,8 +162,8 @@ function AuthenticateViaQuickConnect(secret)
         userdata.json = jsonResponse
         session.user.Update("id", jsonResponse.User.Id)
         session.user.Update("authToken", jsonResponse.AccessToken)
-        userdata.callFunc("setActive")
         userdata.callFunc("saveToRegistry")
+
         return true
     end if
 

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -183,6 +183,10 @@ namespace session
                 set_user_setting("username", tmpSession.user.name)
             end if
 
+            if m.global.session.user.settings["global.rememberme"]
+                set_setting("active_user", tmpSession.user.id)
+            end if
+
             session.user.LoadUserPreferences()
         end sub
 


### PR DESCRIPTION
The active_user id wasn't being set for all login paths creating a bug where remember me would show the user select screen when enabled

## Changes
- Move active user logic to session.user.Login() which is used by all login paths

