### PR TITLE
Fix rounded corner on unplayed episode count

### DIFF
--- a/components/ItemGrid/GridItem.xml
+++ b/components/ItemGrid/GridItem.xml
@@ -4,7 +4,7 @@
     <maskGroup id="posterMask" maskUri="pkg:/images/postermask.png" scaleRotateCenter="[145, 212.5]" scale="[0.85,0.85]">
       <Poster id="backdrop" width="290" height="425" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
       <Poster id="itemPoster" width="290" height="425" loadDisplayMode="scaleToZoom">
-        <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[201, 0]">
+        <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" opacity=".99" translation="[201, 0]">
           <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
         </Rectangle>
       </Poster>


### PR DESCRIPTION
Rounds the corner of the unplayed episode count in GridItem.

Apparently MaskGroup doesn't work properly on child Rectangle unless rectangle opacity < 1

Before:
![20231128_205842](https://github.com/jellyfin/jellyfin-roku/assets/116527579/80e5b13f-9af4-4d13-abe1-2601bd8cce2d)

After: 
![after2](https://github.com/jellyfin/jellyfin-roku/assets/116527579/b1d8387b-2486-4bdf-938b-22ee5cc731f1)

