### PR TITLE
Fix infinite spinner bugs

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -569,8 +569,9 @@ end sub
 '
 'Load next set of items
 sub loadMoreData()
-    startLoadingSpinner(false)
     if m.Loading = true then return
+
+    startLoadingSpinner(false)
     m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")

--- a/components/ItemGrid/MovieLibraryView.bs
+++ b/components/ItemGrid/MovieLibraryView.bs
@@ -687,8 +687,9 @@ end sub
 '
 'Load next set of items
 sub loadMoreData()
-    startLoadingSpinner(false)
     if m.Loading = true then return
+
+    startLoadingSpinner(false)
     m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")

--- a/components/ItemGrid/MusicLibraryView.bs
+++ b/components/ItemGrid/MusicLibraryView.bs
@@ -108,7 +108,7 @@ end sub
 'Load initial set of Data
 sub loadInitialItems()
     m.loadItemsTask.control = "stop"
-    startLoadingSpinner()
+    startLoadingSpinner(false)
 
     if LCase(m.top.parentItem.json.Type) = "collectionfolder"
         m.top.HomeLibraryItem = m.top.parentItem.Id
@@ -550,8 +550,9 @@ end sub
 '
 'Load next set of items
 sub loadMoreData()
-    startLoadingSpinner(false)
     if m.Loading = true then return
+
+    startLoadingSpinner(false)
     m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/roku_modules/log/LogMixin.brs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.log = log.Logger("SceneManager")
@@ -120,7 +121,7 @@ sub popScene()
         ' Exit app if the stack is empty after removing group
         m.scene.exit = true
     end if
-
+    stopLoadingSpinner()
 end sub
 
 


### PR DESCRIPTION
In `loadMoreData()`, only show the spinner when `m.Loading` is false.

## Changes
- Fix lazy loading itemgrid spinner bug

