### PR TITLE
Set video MaxVideoDecodeResolution to TV resolution

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -63,6 +63,9 @@ sub init()
     m.top.retrievingBar.filledBarBlendColor = m.global.constants.colors.blue
     m.top.bufferingBar.filledBarBlendColor = m.global.constants.colors.blue
     m.top.trickPlayBar.filledBarBlendColor = m.global.constants.colors.blue
+
+    ' set MaxVideoDecodeResolution to our TVs video resolution
+    m.top.MaxVideoDecodeResolution = [m.global.device.videoWidth, m.global.device.videoHeight]
 end sub
 
 ' handleChapterSkipAction: Handles user command to skip chapters in playing video

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -711,6 +711,9 @@ sub Main (args as dynamic) as void
                 ' The audio codec capability has changed if true.
                 print "event.audioCodecCapabilityChanged = ", event.audioCodecCapabilityChanged
 
+                ' update global device state
+                SaveDeviceToGlobal()
+                ' update the server
                 postTask = createObject("roSGNode", "PostTask")
                 postTask.arrayData = getDeviceCapabilities()
                 postTask.apiUrl = "/Sessions/Capabilities/Full"
@@ -719,6 +722,9 @@ sub Main (args as dynamic) as void
                 ' The video codec capability has changed if true.
                 print "event.videoCodecCapabilityChanged = ", event.videoCodecCapabilityChanged
 
+                ' update global device state
+                SaveDeviceToGlobal()
+                ' update the server
                 postTask = createObject("roSGNode", "PostTask")
                 postTask.arrayData = getDeviceCapabilities()
                 postTask.apiUrl = "/Sessions/Capabilities/Full"


### PR DESCRIPTION
This sets [`MaxVideoDecodeResolution`](https://developer.roku.com/docs/references/scenegraph/media-playback-nodes/video.md#miscellaneous-fields) on the video node to the attached devices resolution to try and prevent memory errors when playing certain files. The default is unlimited and that's what we were using before.

## Changes
- Set video MaxVideoDecodeResolution to TV resolution
- Update the global device state whenever the audio/video codecs change in case the displays resolution has also changed

## Issues
Fixes #1554
