### PR TITLE
Fix focus on library row

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -267,6 +267,11 @@ sub createLibraryRow()
 
     sectionName = tr("My Media")
 
+    ' We don't refresh library data, so if section already exists, exit
+    if sectionExists(sectionName)
+        return
+    end if
+
     row = CreateObject("roSGNode", "HomeRow")
     row.title = sectionName
     row.imageWidth = homeRowItemSizes.WIDE_POSTER[0]
@@ -276,19 +281,6 @@ sub createLibraryRow()
     for each item in filteredMedia
         row.appendChild(item)
     end for
-
-    ' Row already exists, replace it with new content
-    if sectionExists(sectionName)
-        m.top.content.replaceChild(row, getSectionIndex(sectionName))
-
-        ' Reset focus to item within the row, if it was previous highlighted
-        if m.top.rowItemFocused[0] = getSectionIndex(sectionName)
-            m.top.jumpToRowItem = [m.top.rowItemFocused[0], m.top.rowItemFocused[1]]
-        end if
-
-        setRowItemSize()
-        return
-    end if
 
     ' Row does not exist, insert it into the home view
     m.top.content.insertChild(row, getOriginalSectionIndex("smalllibrarytiles"))

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -280,6 +280,12 @@ sub createLibraryRow()
     ' Row already exists, replace it with new content
     if sectionExists(sectionName)
         m.top.content.replaceChild(row, getSectionIndex(sectionName))
+
+        ' Reset focus to item within the row, if it was previous highlighted
+        if m.top.rowItemFocused[0] = getSectionIndex(sectionName)
+            m.top.jumpToRowItem = [m.top.rowItemFocused[0], m.top.rowItemFocused[1]]
+        end if
+
         setRowItemSize()
         return
     end if


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes bug where if you chose a library then went back to the home view, focus would reset to index 0 instead of the library you had selected.

Also removes updating the library row since we do not refresh that data.