### PR TITLE
Fix version-check job

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -51,7 +51,7 @@ jobs:
         if: env.oldManVersion == env.newManVersion
         run: exit 1
       - name: Save new Makefile version
-        run: awk 'BEGIN { FS=" = " } /^VERSION/ { print "newMakeVersion="$2; }' Makefile >> $GITHUB_ENV
+        run: awk 'BEGIN { FS=" := " } /^VERSION/ { print "newMakeVersion="$2; }' Makefile >> $GITHUB_ENV
       - name: Makefile version must be updated
         if: env.oldMakeVersion == env.newMakeVersion
         run: exit 1


### PR DESCRIPTION
When the makefile was updated, the line that sets the version was changed from:
```
VERSION = 1.6.6
```

to:
```
VERSION := 2.0.0
```

which broke my awk command that parsed out the version from the makefile
