### PR TITLE
Fix startup crash

### DIFF
--- a/source/migrations.bs
+++ b/source/migrations.bs
@@ -71,11 +71,13 @@ sub runRegistryUserMigrations()
                 ' app versions < 2.0.0 didn't save LastRunVersion at the user level
                 ' fall back to using the apps lastRunVersion
                 lastRunVersion = m.global.app.lastRunVersion
-                registry_write("LastRunVersion", lastRunVersion, section)
+                if isValid(lastRunVersion)
+                    registry_write("LastRunVersion", lastRunVersion, section)
+                end if
             end if
 
             ' BASE_MIGRATION
-            if not versionChecker(lastRunVersion, CLIENT_VERSION_REQUIRING_BASE_MIGRATION)
+            if isValid(lastRunVersion) and not versionChecker(lastRunVersion, CLIENT_VERSION_REQUIRING_BASE_MIGRATION)
                 m.wasMigrated = true
                 print `Running Registry Migration for ${CLIENT_VERSION_REQUIRING_BASE_MIGRATION} for userid: ${section}`
 


### PR DESCRIPTION
Caused by migrations (for fresh install I think?). Make sure the lastRunVersion var is valid before using. Fixes this crash from the roku crash logs:

```
Type Mismatch. (runtime error &h18) in pkg:/source/utils/config.brs(26)
file/line: pkg:/source/utils/config.brs(26) #1  Function runregistryusermigrations() As Voi$1 file/line: pkg:/source/migrations.brs(72)
```

Bug introduced in v2.0.0

Fixes #1595 