### PR TITLE
Make GH jobs work with new branch workflow

### DIFF
--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    branches:
-      - unstable
   pull_request_target:
 
 jobs:

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - "*.*.z"
 
 jobs:
   dev:

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -2,11 +2,9 @@ name: build-dev
 
 on:
   pull_request:
-    branches-ignore:
-      - master
   push:
     branches:
-      - unstable
+      - master
 
 jobs:
   dev:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,7 @@ name: build-docs
 on:
   push:
     branches:
-      - unstable
+      - master
 
 jobs:
   docs:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -13,10 +13,12 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Save branch name
+        run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_ENV # this only works with branches that don't include /
       - name: Checkout the branch that triggered the workflow
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${GITHUB_REF##*/} # this only works with branches that don't include /
+          ref: env.branch
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   version-check:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep')
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the branch that triggered the workflow

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -1,64 +1,13 @@
+# Builds the production version of the app
 name: build-prod
 
 on:
-  pull_request:
-    types: [labeled, opened, synchronize, reopened]
   push:
     branches:
       - master
       - "*.*.z"
 
 jobs:
-  version-check:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the branch this PR wants to update
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          ref: ${{ GITHUB_BASE_REF }}
-      - name: Install jq to parse json
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: jq
-      - name: Save old package.json version
-        run: echo "oldPackVersion=$(jq -r ".version" package.json)" >> $GITHUB_ENV
-      - name: Find and save old major_version from manifest
-        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
-      - name: Find and save old minor_version from manifest
-        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
-      - name: Find and save old build_version from manifest
-        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
-      - name: Save old manifest version
-        run: echo "oldManVersion=${{ env.oldMajor }}.${{ env.oldMinor }}.${{ env.oldBuild }}" >> $GITHUB_ENV
-      - name: Save old Makefile version
-        run: awk 'BEGIN { FS=" := " } /^VERSION/ { print "oldMakeVersion="$2; }' Makefile >> $GITHUB_ENV
-      - name: Checkout PR branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Save new package.json version
-        run: echo "newPackVersion=$(jq -r ".version" package.json)" >> $GITHUB_ENV
-      - name: package.json version must be updated
-        if: env.oldPackVersion == env.newPackVersion
-        run: exit 1
-      - name: Find and save new major_version from manifest
-        run: awk 'BEGIN { FS="=" } /^major_version/ { print "newMajor="$2; }' manifest >> $GITHUB_ENV
-      - name: Find and save new minor_version from manifest
-        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "newMinor="$2; }' manifest >> $GITHUB_ENV
-      - name: Find and save new build_version from manifest
-        run: awk 'BEGIN { FS="=" } /^build_version/ { print "newBuild="$2; }' manifest >> $GITHUB_ENV
-      - name: Save new manifest version
-        run: echo "newManVersion=${{ env.newMajor }}.${{ env.newMinor }}.${{ env.newBuild }}" >> $GITHUB_ENV
-      - name: Manifest version must be updated
-        if: env.oldManVersion == env.newManVersion
-        run: exit 1
-      - name: Save new Makefile version
-        run: awk 'BEGIN { FS=" := " } /^VERSION/ { print "newMakeVersion="$2; }' Makefile >> $GITHUB_ENV
-      - name: Makefile version must be updated
-        if: env.oldMakeVersion == env.newMakeVersion
-        run: exit 1
-      - name: All new versions must match
-        if: (env.newManVersion != env.newPackVersion) || (env.newManVersion != env.newMakeVersion)
-        run: exit 1
   prod:
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -13,8 +13,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep')
     runs-on: ubuntu-latest
     steps:
-      # checkout the branch that triggered the workflow
-      - name: Checkout master (the latest release)
+      - name: Checkout the branch that triggered the workflow
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${GITHUB_REF##*/} # this only works with branches that don't include /

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -13,12 +13,10 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Save branch name
-        run: echo "branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV # this only works with branches that don't include /
-      - name: Checkout the branch that triggered the workflow
+      - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: env.branch
+          ref: ${{ GITHUB_BASE_REF }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Save branch name
-        run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_ENV # this only works with branches that don't include /
+        run: echo "branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV # this only works with branches that don't include /
       - name: Checkout the branch that triggered the workflow
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -2,20 +2,22 @@ name: build-prod
 
 on:
   pull_request:
-    branches:
-      - master
+    types: [labeled, opened, synchronize, reopened]
   push:
     branches:
       - master
+      - "*.*.z"
 
 jobs:
   version-check:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep')
     runs-on: ubuntu-latest
     steps:
+      # checkout the branch that triggered the workflow
       - name: Checkout master (the latest release)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: master
+          ref: ${GITHUB_REF##*/} # this only works with branches that don't include /
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
@@ -59,6 +61,7 @@ jobs:
         if: (env.newManVersion != env.newPackVersion) || (env.newManVersion != env.newMakeVersion)
         run: exit 1
   prod:
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -3,7 +3,7 @@ name: deploy-api-docs
 
 on:
   push:
-    branches: ["unstable"]
+    branches: ["master"]
     paths: ["docs/**"] # only run if the docs are updated
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: lint
 on:
   pull_request:
 
-
 jobs:
   brightscript:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,10 +10,12 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Save branch name
+        run: echo "branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ GITHUB_BASE_REF }}
+          ref: env.branch
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,12 +10,12 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
-      - name: DEBUG env.GITHUB_BASE_REF
-        run: echo ${{ env.GITHUB_BASE_REF }}
+      - name: DEBUG ${{ github.event.pull_request.base.ref }}
+        run: echo ${{ ${{ github.event.pull_request.base.ref }} }}
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ env.GITHUB_BASE_REF }}
+          ref: ${{ ${{ github.event.pull_request.base.ref }} }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,78 @@
+# All of the jobs in this workflow will only run if the PR that triggered it has a 'release-prep' label
+name: release-prep
+
+on:
+  pull_request:
+    types: [labeled, opened, reopened, synchronize]
+
+jobs:
+  version-check:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the branch this PR wants to update
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: ${{ GITHUB_BASE_REF }}
+      - name: Install jq to parse json
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: jq
+      - name: Save old package.json version
+        run: echo "oldPackVersion=$(jq -r ".version" package.json)" >> $GITHUB_ENV
+      - name: Find and save old major_version from manifest
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old minor_version from manifest
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old build_version from manifest
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
+      - name: Save old manifest version
+        run: echo "oldManVersion=${{ env.oldMajor }}.${{ env.oldMinor }}.${{ env.oldBuild }}" >> $GITHUB_ENV
+      - name: Save old Makefile version
+        run: awk 'BEGIN { FS=" := " } /^VERSION/ { print "oldMakeVersion="$2; }' Makefile >> $GITHUB_ENV
+      - name: Checkout PR branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Save new package.json version
+        run: echo "newPackVersion=$(jq -r ".version" package.json)" >> $GITHUB_ENV
+      - name: package.json version must be updated
+        if: env.oldPackVersion == env.newPackVersion
+        run: exit 1
+      - name: Find and save new major_version from manifest
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "newMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save new minor_version from manifest
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "newMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save new build_version from manifest
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "newBuild="$2; }' manifest >> $GITHUB_ENV
+      - name: Save new manifest version
+        run: echo "newManVersion=${{ env.newMajor }}.${{ env.newMinor }}.${{ env.newBuild }}" >> $GITHUB_ENV
+      - name: Manifest version must be updated
+        if: env.oldManVersion == env.newManVersion
+        run: exit 1
+      - name: Save new Makefile version
+        run: awk 'BEGIN { FS=" := " } /^VERSION/ { print "newMakeVersion="$2; }' Makefile >> $GITHUB_ENV
+      - name: Makefile version must be updated
+        if: env.oldMakeVersion == env.newMakeVersion
+        run: exit 1
+      - name: All new versions must match
+        if: (env.newManVersion != env.newPackVersion) || (env.newManVersion != env.newMakeVersion)
+        run: exit 1
+    build-prod:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+      - name: NPM install
+        run: npm ci
+      - name: Install roku module dependencies
+        run: npm run ropm
+      - name: Build app for production
+        run: npm run build-prod
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          name: Jellyfin-Roku-v${{ env.newManVersion }}-${{ github.sha }}
+          path: ${{ github.workspace }}/build/staging
+          if-no-files-found: error

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ GITHUB_BASE_REF }}
+          ref: ${{ github.GITHUB_BASE_REF }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,6 +10,14 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
+      - name: DEBUG github.GITHUB_BASE_REF
+        run: echo ${{ github.GITHUB_BASE_REF }}
+      - name: DEBUG github.event.pull_request.head.sha
+        run: echo ${{ github.event.pull_request.head.sha }}
+      - name: DEBUG github.sha
+        run: echo ${{ github.sha }}
+      - name: DEBUG github.event.pull_request.base.sha
+        run: echo ${{ github.event.pull_request.base.sha }}
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,12 +10,10 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Save branch name
-        run: echo "branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: env.branch
+          ref: ${{ GITHUB_BASE_REF }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: DEBUG ${{ github.event.pull_request.base.ref }}
-        run: echo ${{ ${{ github.event.pull_request.base.ref }}
+        run: echo ${{ github.event.pull_request.base.ref }}
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,18 +10,12 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:
-      - name: DEBUG github.GITHUB_BASE_REF
-        run: echo ${{ github.GITHUB_BASE_REF }}
-      - name: DEBUG github.event.pull_request.head.sha
-        run: echo ${{ github.event.pull_request.head.sha }}
-      - name: DEBUG github.sha
-        run: echo ${{ github.sha }}
-      - name: DEBUG github.event.pull_request.base.sha
-        run: echo ${{ github.event.pull_request.base.sha }}
+      - name: DEBUG env.GITHUB_BASE_REF
+        run: echo ${{ env.GITHUB_BASE_REF }}
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ github.GITHUB_BASE_REF }}
+          ref: ${{ env.GITHUB_BASE_REF }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: DEBUG ${{ github.event.pull_request.base.ref }}
-        run: echo ${{ ${{ github.event.pull_request.base.ref }} }}
+        run: echo ${{ ${{ github.event.pull_request.base.ref }}
       - name: Checkout the branch this PR wants to update
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ ${{ github.event.pull_request.base.ref }} }}
+          ref: ${{ ${{ github.event.pull_request.base.ref }}
       - name: Install jq to parse json
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -58,7 +58,7 @@ jobs:
       - name: All new versions must match
         if: (env.newManVersion != env.newPackVersion) || (env.newManVersion != env.newMakeVersion)
         run: exit 1
-    build-prod:
+  build-prod:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release-prep') }}
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jellyfin-roku",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Roku app for Jellyfin media server",
   "dependencies": {
     "@rokucommunity/bslib": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jellyfin-roku",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Roku app for Jellyfin media server",
   "dependencies": {
     "@rokucommunity/bslib": "0.1.1",


### PR DESCRIPTION
Make github action jobs work with the new branch/release workflow.

Dev app will build:
- On push to `master` or `*.*.z`
- On all PRs

Prod app will build:
- On push to `master` or `*.*.z`
- On all PRs with a `release-prep` label

## Changes
- Update workflows to use master branch instead of unstabl
- Create `release-prep` label
- Create `release-prep.yml` file
  - Trigger it on PR event `labeled`, `opened`, `reopened`, or `synchronize`
  - Only run when PR has the `release-prep` label


