### PR TITLE
Stop adding `ci` and `github-actions` label to dependency bump PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>jellyfin/.github//renovate-presets/default"
-    ]
+    ],
+    "packageRules": []
 }


### PR DESCRIPTION
When renovate creates a PR to bumb the version of our dependencies, some of the PRs get tagged with [3 labels](https://github.com/jellyfin/jellyfin-roku/pull/1581) and some just get labeled as `dependencies`. This PR overrides the default renovate config to make them all consistent by only using the one `dependencies` label. Or at least it should. Not sure how to test this until it's merged.

Link to default config we are using: https://github.com/jellyfin/.github/blob/master/renovate-presets/default.json