### PR TITLE
Fix for launching Live TV not from a TV Guide

### DIFF
--- a/.github/workflows/auto-close-stale-pr.yml
+++ b/.github/workflows/auto-close-stale-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
         with:
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm run ropm
       - name: Build app
         run: npm run build
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
         with:
           name: Jellyfin-Roku-dev-${{ github.sha }}
           path: ${{ github.workspace }}/build/staging

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run ropm
       - name: Build app for production
         run: npm run build-prod
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
         with:
           name: Jellyfin-Roku-v${{ env.newManVersion }}-${{ github.sha }}
           path: ${{ github.workspace }}/build/staging

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -40,4 +40,4 @@ jobs:
           path: "docs/api"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@77d7344265e1f960dab5c00dbff52287a70b0d4f # v3
+        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -73,7 +73,7 @@ jobs:
         run: npm run ropm
       - name: Build app for production
         run: npm run build-prod
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
         with:
           name: Jellyfin-Roku-v${{ env.newManVersion }}-${{ github.sha }}
           path: ${{ github.workspace }}/build/staging

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -77,6 +77,22 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     videotype = LCase(meta.type)
 
+    ' Special handling for Live TV channels that are not part of a "TV Guide"
+    if isValid(meta.json) and isValid(meta.json.ChannelId)
+        if isValid(meta.json.EpisodeTitle)
+            meta.title = meta.json.EpisodeTitle
+        else if isValid(meta.json.Name)
+            meta.title = meta.json.Name
+        end if
+        meta.showID = meta.json.id
+        meta.live = true
+        if LCase(meta.json.type) = "program"
+            video.id = meta.json.ChannelId
+        else
+            video.id = meta.json.id
+        end if
+    end if
+
     if videotype = "episode" or videotype = "series"
         video.content.contenttype = "episode"
     end if

--- a/locale/de_DE/translations.ts
+++ b/locale/de_DE/translations.ts
@@ -14392,5 +14392,395 @@
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
+    <message>
+        <source>Error During Playback</source>
+        <translation>Wiedergabefehler</translation>
+        <extracomment>Dialog title when error occurs during playback</extracomment>
+    </message>
+    <message>
+        <source>There was an error retrieving the data for this item from the server.</source>
+        <translation>Es gab einen Fehler beim Laden dieses Inhalts von dem Server.</translation>
+        <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+    </message>
+    <message>
+        <source>Loading Channel Data</source>
+        <translation>Kanaldaten werden geladen</translation>
+    </message>
+    <message>
+        <source>Unable to load Channel Data from the server</source>
+        <translation>Laden der Kanaldaten vom Server nicht möglich</translation>
+    </message>
+    <message>
+        <comment>Name or Title field of media item</comment>
+        <source>TITLE</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>CRITIC_RATING</source>
+        <translation>Kritikerbewertung</translation>
+    </message>
+    <message>
+        <source>DATE_ADDED</source>
+        <translation>Hinzugefügt am</translation>
+    </message>
+    <message>
+        <source>RUNTIME</source>
+        <translation>Spieldauer</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <translation>Alter</translation>
+    </message>
+    <message>
+        <source>Cast &amp; Crew</source>
+        <translation type="unfinished">Mitwirkende</translation>
+    </message>
+    <message>
+        <source>More Like This</source>
+        <translation type="unfinished">Empfehlungen</translation>
+    </message>
+    <message>
+        <source>Movies (Presentation)</source>
+        <translation>Filme (Präsentation)</translation>
+        <extracomment>Movie library view option</extracomment>
+    </message>
+    <message>
+        <source>today</source>
+        <translation>heute</translation>
+        <extracomment>Current day</extracomment>
+    </message>
+    <message>
+        <source>Starts</source>
+        <translation>Beginnt</translation>
+        <extracomment>(Future Tense) For defining a day and time when a program will start (e.g. Starts Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Ends at</source>
+        <translation>Endete am</translation>
+        <extracomment>(Past Tense) For defining a day and time when a program ended (e.g. Ended Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Live</source>
+        <translation>Live</translation>
+        <extracomment>If TV Show is being broadcast live (not pre-recorded)</extracomment>
+    </message>
+    <message>
+        <source>TV Guide</source>
+        <translation>TV-Programm</translation>
+        <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
+    </message>
+    <message>
+        <source>View Channel</source>
+        <translation>Kanal ansehen</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+        <extracomment>Title for a cast member for which we have no information for</extracomment>
+    </message>
+    <message>
+        <source>Enter the server name or IP address</source>
+        <translation>Hostnamen oder IP-Adresse des Servers angeben</translation>
+        <extracomment>Title of KeyboardDialog when manually entering a server URL</extracomment>
+    </message>
+    <message>
+        <source>Error Getting Playback Information</source>
+        <translation>Fehler beim Übertragen der Wiedergabeinformationen</translation>
+        <extracomment>Dialog Title: Received error from server when trying to get information about the selected item for playback</extracomment>
+    </message>
+    <message>
+        <source>Playback</source>
+        <translation>Wiedergabe</translation>
+        <extracomment>Title for Playback section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Enable or disable Direct Play for optional codecs</source>
+        <translation>Direkte Wiedergabe für optionale Codecs aktivieren oder deaktivieren</translation>
+        <extracomment>Settings Menu - Title for settings group related to codec support</extracomment>
+    </message>
+    <message>
+        <source>Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.</source>
+        <translation>Unterstützung für das direkte Abspielen von MPEG-2-Inhalten (z.B. Live-TV). Dadurch wird das Transcodieren von MPEG-2-Inhalten vermieden, es wird jedoch erheblich mehr Bandbreite verwendet.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Aktiviert</translation>
+    </message>
+    <message>
+        <source>Media Grid options.</source>
+        <translation>Mediengitter-Optionen</translation>
+    </message>
+    <message>
+        <source>Item Count</source>
+        <translation>Anzahl der Elemente</translation>
+        <extracomment>UI -&gt; Media Grid -&gt; Item Count in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Show item count in the library and index of selected item.</source>
+        <translation>Zeige die Anzahl der Elemente in der Bibliothek und den Index des ausgewählten Elements.</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+    <message>
+        <source>Go to episode</source>
+        <translation>Zur Folge gehen</translation>
+        <extracomment>Continue Watching Popup Menu - Navigate to the Episode Detail Page</extracomment>
+    </message>
+    <message>
+        <source>Quick Connect</source>
+        <translation>Schnellverbindung</translation>
+    </message>
+    <message>
+        <source>Here is your Quick Connect code:</source>
+        <translation>Hier ist der Schnellverbindungscode:</translation>
+    </message>
+    <message>
+        <source>Blur Unwatched Episodes</source>
+        <translation>Unangesehene Episoden verschleiern</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>Go directly to the episode list if a TV series has only one season.</source>
+        <translation>Direkt zur Episodenliste gehen, wenn eine TV-Serie nur eine Staffel hat.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Design Elements</source>
+        <translation type="unfinished">Gestaltungselemente</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation>Extras</translation>
+    </message>
+    <message>
+        <comment>Message displayed in Item Grid when no item to display. %1 is container type (e.g. Boxset, Collection, Folder, etc)</comment>
+        <source>NO_ITEMS</source>
+        <translation>Diese(r) %1 enthält keine Elemente</translation>
+    </message>
+    <message>
+        <source>Movies (Grid)</source>
+        <translation>Filme (Kachelansicht)</translation>
+        <extracomment>Movie library view option</extracomment>
+    </message>
+    <message>
+        <source>Cancel Series Recording</source>
+        <translation>Serienaufnahme abbrechen</translation>
+    </message>
+    <message>
+        <source>An error was encountered while playing this item. Server did not provide required transcoding data.</source>
+        <translation type="unfinished">Bei der Wiedergabe trat ein Fehler auf. Der Server hat die benötigten Transcodinginformationen nicht übermittelt.</translation>
+        <extracomment>Content of message box when trying to play an item which requires transcoding, and the server did not provide transcode url</extracomment>
+    </message>
+    <message>
+        <source>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</source>
+        <translation>Unterstützung für das direkte Abspielen von MPEG-4-Inhalten. Dies muss möglicherweise deaktiviert werden, um DIVX-codierte Videodateien abzuspielen.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Set Watched</source>
+        <translation>Als gesehen markieren</translation>
+        <extracomment>Button Text - When pressed, marks item as Warched</extracomment>
+    </message>
+    <message>
+        <source>Search now</source>
+        <translation>Jetzt suchen</translation>
+        <extracomment>Help text in search Box</extracomment>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation>%1 von %2</translation>
+        <extracomment>Item position and count. %1 = current item. %2 = total number of items</extracomment>
+    </message>
+    <message>
+        <source>Use the replay button to slowly animate to the first item in the folder. (If disabled, the folder will reset to the first item immediately).</source>
+        <translation>Verwenden Sie die Wiederholungstaste, um langsam zum ersten Element im Ordner zu animieren. (Wenn deaktiviert, wird der Ordner sofort auf das erste Element zurückgesetzt).</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+    <message>
+        <source>Blur images of unwatched episodes.</source>
+        <translation>Verschleiere Bilder von unangesehenen Folgen.</translation>
+    </message>
+    <message>
+        <source>MPEG-4</source>
+        <translation>MPEG-4</translation>
+        <extracomment>Name of codec used in settings menu</extracomment>
+    </message>
+    <message>
+        <source>User Interface</source>
+        <translation>Benutzeroberfläche</translation>
+        <extracomment>Title for User Interface section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Use voice remote to search</source>
+        <translation>Sprachfernbedienung zur Suche verwenden</translation>
+        <extracomment>Help text in search voice text box</extracomment>
+    </message>
+    <message>
+        <source>Studios</source>
+        <translation>Studios</translation>
+    </message>
+    <message>
+        <source>Hide Taglines</source>
+        <translation type="unfinished">Slogans ausblenden</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>MPEG-2</source>
+        <translation>MPEG-2</translation>
+        <extracomment>Name of codec used in settings menu</extracomment>
+    </message>
+    <message>
+        <source>Media Grid</source>
+        <translation>Mediengitter</translation>
+        <extracomment>UI -&gt; Media Grid section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Shows</source>
+        <translation>Sendungen</translation>
+    </message>
+    <message>
+        <source>Save Credentials?</source>
+        <translation>Anmeldedaten speichern?</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for options to sort library content</comment>
+        <source>TAB_SORT</source>
+        <translation>Sortieren</translation>
+    </message>
+    <message>
+        <source>Died</source>
+        <translation type="unfinished">Gestorben am</translation>
+    </message>
+    <message>
+        <source>Error loading Channel Data</source>
+        <translation>Fehler beim Laden von Kanaldaten</translation>
+    </message>
+    <message>
+        <source>Delete Saved</source>
+        <translation>Gespeicherte löschen</translation>
+    </message>
+    <message>
+        <source>Networks</source>
+        <translation>Netzwerke</translation>
+    </message>
+    <message>
+        <source>Hides tagline text on details pages.</source>
+        <translation type="unfinished">Blendet Slogan-Text auf Detailseiten aus.</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for options to filter library content</comment>
+        <source>TAB_FILTER</source>
+        <translation>Filtern</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <source>Options for TV Shows.</source>
+        <translation>Optionen für TV-Sendungen.</translation>
+        <extracomment>Description for TV Shows user settings.</extracomment>
+    </message>
+    <message>
+        <comment>Title of Tab for switching &quot;views&quot; when looking at a library</comment>
+        <source>TAB_VIEW</source>
+        <translation>Ansicht</translation>
+    </message>
+    <message>
+        <source>Press &apos;OK&apos; to Close</source>
+        <translation>Drücke &apos;OK&apos; zum Schließen</translation>
+    </message>
+    <message>
+        <source>Additional Parts</source>
+        <translation>Zusätzliche Teile</translation>
+        <extracomment>Additional parts of a video</extracomment>
+    </message>
+    <message>
+        <source>Codec Support</source>
+        <translation type="unfinished">Codec-Support</translation>
+        <extracomment>Settings Menu - Title for settings group related to codec support</extracomment>
+    </message>
+    <message>
+        <source>Special Features</source>
+        <translation type="unfinished">Besonderheiten</translation>
+    </message>
+    <message>
+        <source>Movies</source>
+        <translation>Filme</translation>
+    </message>
+    <message>
+        <source>(Dialog will close automatically)</source>
+        <translation>(Dialog wird automatisch geschlossen)</translation>
+    </message>
+    <message>
+        <source>Use Splashscreen as Home Background</source>
+        <translation>Verwende den Splashscreen als Hintergrund für die Startseite</translation>
+        <extracomment>Option Title in user setting screen</extracomment>
+    </message>
+    <message>
+        <source>You can search for Titles, People, Live TV Channels and more</source>
+        <translation>Es kann nach Titeln, Personen, Live-TV-Sendern und mehr gesucht werden</translation>
+        <extracomment>Help text in search results</extracomment>
+    </message>
+    <message>
+        <source>Options that alter the design of Jellyfin.</source>
+        <translation>Optionen, die das Design von Jellyfin verändern.</translation>
+        <extracomment>Description for Design Elements user settings.</extracomment>
+    </message>
+    <message>
+        <source>Skip Details for Single Seasons</source>
+        <translation>Details für einzelne Staffeln überspringen</translation>
+        <extracomment>Settings Menu - Title for option</extracomment>
+    </message>
+    <message>
+        <source>Set Favorite</source>
+        <translation>Favorit festlegen</translation>
+        <extracomment>Button Text - When pressed, sets item as Favorite</extracomment>
+    </message>
+    <message>
+        <source>Go to season</source>
+        <translation>Zur Staffel gehen</translation>
+        <extracomment>Continue Watching Popup Menu - Navigate to the Season Page</extracomment>
+    </message>
+    <message>
+        <source>PLAY_COUNT</source>
+        <translation>Anzahl der Wiedergaben</translation>
+    </message>
+    <message>
+        <source>TV Shows</source>
+        <translation>TV-Serien</translation>
+    </message>
+    <message>
+        <source>Starts at</source>
+        <translation>Beginnt um</translation>
+        <extracomment>(Future Tense) For defining time when a program will start today (e.g. Starts at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>DATE_PLAYED</source>
+        <translation>Wiedergegeben am</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Deaktiviert</translation>
+    </message>
+    <message>
+        <source>The requested content does not exist on the server</source>
+        <translation>Der gewünschte Inhalt existiert nicht auf dem Server</translation>
+        <extracomment>Content of message box when the requested content is not found on the server</extracomment>
+    </message>
+    <message>
+        <source>Go to series</source>
+        <translation>Zur Serie gehen</translation>
+        <extracomment>Continue Watching Popup Menu - Navigate to the Series Detail Page</extracomment>
+    </message>
+    <message>
+        <source>There was an error authenticating via Quick Connect.</source>
+        <translation>Bei der Authentifizierung der Schnellverbindung ist ein Fehler aufgetreten.</translation>
+    </message>
+    <message>
+        <source>Return to Top</source>
+        <translation>Zurück zum Anfang</translation>
+        <extracomment>UI -&gt; Media Grid -&gt; Item Title in user setting screen.</extracomment>
+    </message>
 </context>
 </TS>

--- a/locale/en_GB/translations.ts
+++ b/locale/en_GB/translations.ts
@@ -255,7 +255,7 @@
     </message>
     <message>
         <source>today</source>
-        <translation type="unfinished">today</translation>
+        <translation>today</translation>
         <extracomment>Current day</extracomment>
     </message>
     <message>
@@ -5585,6 +5585,232 @@
     <message>
         <source>Press &apos;OK&apos; to Close</source>
         <translation type="unfinished">Press &apos;OK&apos; to Close</translation>
+    </message>
+    <message>
+        <source>Cast &amp; Crew</source>
+        <translation>Cast &amp; Crew</translation>
+    </message>
+    <message>
+        <source>More Like This</source>
+        <translation>More Like This</translation>
+    </message>
+    <message>
+        <source>TV Shows</source>
+        <translation>TV Shows</translation>
+    </message>
+    <message>
+        <source>Save Credentials?</source>
+        <translation>Save Credentials?</translation>
+    </message>
+    <message>
+        <source>Delete Saved</source>
+        <translation>Delete Saved</translation>
+    </message>
+    <message>
+        <source>Episodes</source>
+        <translation>Episodes</translation>
+    </message>
+    <message>
+        <source>Press &apos;OK&apos; to Close</source>
+        <translation>Press &apos;OK&apos; to Close</translation>
+    </message>
+    <message>
+        <source>Special Features</source>
+        <translation>Special Features</translation>
+    </message>
+    <message>
+        <source>Record Series</source>
+        <translation>Record Series</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unknown</translation>
+        <extracomment>Title for a cast member for which we have no information for</extracomment>
+    </message>
+    <message>
+        <source>Pick a Jellyfin server from the local network</source>
+        <translation>Select an available Jellyfin server from your local network:</translation>
+        <extracomment>Instructions on initial app launch when the user is asked to pick a server from a list</extracomment>
+    </message>
+    <message>
+        <source>An error was encountered while playing this item. Server did not provide required transcoding data.</source>
+        <translation>An error was encountered while playing this item. Server did not provide required transcoding data.</translation>
+        <extracomment>Content of message box when trying to play an item which requires transcoding, and the server did not provide transcode url</extracomment>
+    </message>
+    <message>
+        <source>Codec Support</source>
+        <translation>Codec Support</translation>
+        <extracomment>Settings Menu - Title for settings group related to codec support</extracomment>
+    </message>
+    <message>
+        <source>MPEG-2</source>
+        <translation>MPEG-2</translation>
+        <extracomment>Name of codec used in settings menu</extracomment>
+    </message>
+    <message>
+        <source>MPEG-4</source>
+        <translation>MPEG-4</translation>
+        <extracomment>Name of codec used in settings menu</extracomment>
+    </message>
+    <message>
+        <source>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</source>
+        <translation>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Disabled</translation>
+    </message>
+    <message>
+        <source>User Interface</source>
+        <translation>User Interface</translation>
+        <extracomment>Title for User Interface section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Media Grid</source>
+        <translation>Media Grid</translation>
+        <extracomment>UI -&gt; Media Grid section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Item Count</source>
+        <translation>Item Count</translation>
+        <extracomment>UI -&gt; Media Grid -&gt; Item Count in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Show item count in the library and index of selected item.</source>
+        <translation>Show item count in the library and index of selected item.</translation>
+        <extracomment>Description for option in Setting Screen</extracomment>
+    </message>
+    <message>
+        <source>Set Favorite</source>
+        <translation>Set Favourite</translation>
+        <extracomment>Button Text - When pressed, sets item as Favorite</extracomment>
+    </message>
+    <message>
+        <source>Set Watched</source>
+        <translation>Set Watched</translation>
+        <extracomment>Button Text - When pressed, marks item as Warched</extracomment>
+    </message>
+    <message>
+        <source>Go to series</source>
+        <translation>Go to series</translation>
+        <extracomment>Continue Watching Popup Menu - Navigate to the Series Detail Page</extracomment>
+    </message>
+    <message>
+        <source>You can search for Titles, People, Live TV Channels and more</source>
+        <translation>You can search for Titles, People, Live TV Channels and more</translation>
+        <extracomment>Help text in search results</extracomment>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <translation>%1 of %2</translation>
+        <extracomment>Item position and count. %1 = current item. %2 = total number of items</extracomment>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Close</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <translation>Age</translation>
+    </message>
+    <message>
+        <source>Died</source>
+        <translation>Died</translation>
+    </message>
+    <message>
+        <source>Cancel Recording</source>
+        <translation>Cancel Recording</translation>
+    </message>
+    <message>
+        <source>Additional Parts</source>
+        <translation>Additional Parts</translation>
+        <extracomment>Additional parts of a video</extracomment>
+    </message>
+    <message>
+        <source>Quick Connect</source>
+        <translation>Quick Connect</translation>
+    </message>
+    <message>
+        <source>On Now</source>
+        <translation>On Now</translation>
+    </message>
+    <message>
+        <source>Extras</source>
+        <translation>Extras</translation>
+    </message>
+    <message>
+        <source>Born</source>
+        <translation>Born</translation>
+    </message>
+    <message>
+        <source>Record</source>
+        <translation>Record</translation>
+    </message>
+    <message>
+        <source>View Channel</source>
+        <translation>View Channel</translation>
+    </message>
+    <message>
+        <source>...or enter server URL manually:</source>
+        <translation>If no server is listed above, you may also enter the server URL manually:</translation>
+        <extracomment>Instructions on initial app launch when the user is asked to manually enter a server URL</extracomment>
+    </message>
+    <message>
+        <source>Error Getting Playback Information</source>
+        <translation>Error Getting Playback Information</translation>
+        <extracomment>Dialog Title: Received error from server when trying to get information about the selected item for playback</extracomment>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <source>Playback</source>
+        <translation>Playback</translation>
+        <extracomment>Title for Playback section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>Media Grid options.</source>
+        <translation>Media Grid options.</translation>
+    </message>
+    <message>
+        <source>Use voice remote to search</source>
+        <translation>Use voice remote to search</translation>
+        <extracomment>Help text in search voice text box</extracomment>
+    </message>
+    <message>
+        <source>Search now</source>
+        <translation>Search now</translation>
+        <extracomment>Help text in search Box</extracomment>
+    </message>
+    <message>
+        <source>Go to episode</source>
+        <translation>Go to episode</translation>
+        <extracomment>Continue Watching Popup Menu - Navigate to the Episode Detail Page</extracomment>
+    </message>
+    <message>
+        <source>Enable or disable Direct Play for optional codecs</source>
+        <translation>Enable or disable Direct Play for optional codecs</translation>
+        <extracomment>Settings Menu - Title for settings group related to codec support</extracomment>
+    </message>
+    <message>
+        <source>Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.</source>
+        <translation>Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content but uses significantly more bandwidth.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Enabled</translation>
+    </message>
+    <message>
+        <source>Cancel Series Recording</source>
+        <translation>Cancel Series Recording</translation>
+    </message>
+    <message>
+        <source>Enter the server name or IP address</source>
+        <translation>Enter the server name or IP address</translation>
+        <extracomment>Title of KeyboardDialog when manually entering a server URL</extracomment>
     </message>
 </context>
 </TS>

--- a/locale/fr/translations.ts
+++ b/locale/fr/translations.ts
@@ -10735,5 +10735,196 @@
         <source>NO_ITEMS</source>
         <translation>Ce %1 ne contient pas d&apos;éléments</translation>
     </message>
+    <message>
+        <source>Video Codec</source>
+        <translation>Codec Vidéo</translation>
+    </message>
+    <message>
+        <source>Sunday</source>
+        <translation>Dimanche</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.</source>
+        <translation>Prise en charge de la lecture directe du contenu MPEG-4. Il faudra peut-être désactiver cette option pour la lecture des fichiers vidéo encodés au format DIVX.</translation>
+        <extracomment>Settings Menu - Description for option</extracomment>
+    </message>
+    <message>
+        <source>Tuesday</source>
+        <translation>Mardi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Wednesday</source>
+        <translation>Mercredi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Started at</source>
+        <translation>A débuté à</translation>
+        <extracomment>(Past Tense) For defining time when a program started today (e.g. Started at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Starts at</source>
+        <translation>Débute à</translation>
+        <extracomment>(Future Tense) For defining time when a program will start today (e.g. Starts at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Starts</source>
+        <translation>Débute</translation>
+        <extracomment>(Future Tense) For defining a day and time when a program will start (e.g. Starts Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Ended at</source>
+        <translation>A fini à</translation>
+        <extracomment>(Past Tense) For defining time when a program will ended (e.g. Ended at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Live</source>
+        <translation>En direct</translation>
+        <extracomment>If TV Show is being broadcast live (not pre-recorded)</extracomment>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>Répéter</translation>
+        <extracomment>If TV Shows has previously been broadcasted</extracomment>
+    </message>
+    <message>
+        <source>TV Guide</source>
+        <translation>Guide TV</translation>
+        <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
+    </message>
+    <message>
+        <source>User Interface</source>
+        <translation>Interface utilisateur</translation>
+        <extracomment>Title for User Interface section in user setting screen.</extracomment>
+    </message>
+    <message>
+        <source>IMDB_RATING</source>
+        <translation>Score IMDb</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for options to filter library content</comment>
+        <source>TAB_FILTER</source>
+        <translation>Filtrer</translation>
+    </message>
+    <message>
+        <source>Died</source>
+        <translation>Mort</translation>
+    </message>
+    <message>
+        <source>Cast &amp; Crew</source>
+        <translation>Casting et Equipe</translation>
+    </message>
+    <message>
+        <source>More Like This</source>
+        <translation>Contenu similaire</translation>
+    </message>
+    <message>
+        <source>Special Features</source>
+        <translation>Fonctionnalités spéciales</translation>
+    </message>
+    <message>
+        <source>Movies (Presentation)</source>
+        <translation>Films (Présentation)</translation>
+        <extracomment>Movie library view option</extracomment>
+    </message>
+    <message>
+        <source>today</source>
+        <translation>aujourd&apos;hui</translation>
+        <extracomment>Current day</extracomment>
+    </message>
+    <message>
+        <source>Save Credentials?</source>
+        <translation>Sauvegarder vos identifiants ?</translation>
+    </message>
+    <message>
+        <source>Monday</source>
+        <translation>Lundi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Ends at</source>
+        <translation>Fini à</translation>
+        <extracomment>(Past Tense) For defining a day and time when a program ended (e.g. Ended Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Press &apos;OK&apos; to Close</source>
+        <translation>Appuyez sur «OK» pour fermer</translation>
+    </message>
+    <message>
+        <source>Thursday</source>
+        <translation>Jeudi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Friday</source>
+        <translation>Vendredi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Channels</source>
+        <translation>Chaînes</translation>
+        <extracomment>Menu option for showing Live TV Channel List</extracomment>
+    </message>
+    <message>
+        <source>yesterday</source>
+        <translation>hier</translation>
+        <extracomment>Previous day</extracomment>
+    </message>
+    <message>
+        <source>Additional Parts</source>
+        <translation>Contenu supplémentaire</translation>
+        <extracomment>Additional parts of a video</extracomment>
+    </message>
+    <message>
+        <source>Movies</source>
+        <translation>Films</translation>
+    </message>
+    <message>
+        <source>Movies (Grid)</source>
+        <translation>Films (Grille)</translation>
+        <extracomment>Movie library view option</extracomment>
+    </message>
+    <message>
+        <source>Born</source>
+        <translation>Né</translation>
+    </message>
+    <message>
+        <source>Studios</source>
+        <translation>Studios</translation>
+    </message>
+    <message>
+        <source>TV Shows</source>
+        <translation>Émissions TV</translation>
+    </message>
+    <message>
+        <source>Saturday</source>
+        <translation>Samedi</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Started</source>
+        <translation>A débuté</translation>
+        <extracomment>(Past Tense) For defining a day and time when a program started (e.g. Started Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Direct playing</source>
+        <translation>Lecture en directe</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Taille</translation>
+        <extracomment>Video size</extracomment>
+    </message>
+    <message>
+        <source>Age</source>
+        <translation>Âge</translation>
+    </message>
+    <message>
+        <source>tomorrow</source>
+        <translation>demain</translation>
+        <extracomment>Next day</extracomment>
+    </message>
 </context>
 </TS>

--- a/locale/it_IT/translations.ts
+++ b/locale/it_IT/translations.ts
@@ -142,7 +142,7 @@
     </message>
     <message>
         <source>Sort Order</source>
-        <translation>Tiipo di ordinamento</translation>
+        <translation>Tipo di ordinamento</translation>
     </message>
     <message>
         <source>Descending</source>
@@ -2592,6 +2592,274 @@
     <message>
         <source>Save Credentials?</source>
         <translation>Salvare le credenziali?</translation>
+    </message>
+    <message>
+        <source>Change Server</source>
+        <translation>Cambia Server</translation>
+    </message>
+    <message>
+        <source>Sign Out</source>
+        <translation>Esci</translation>
+    </message>
+    <message>
+        <source>Save Credentials?</source>
+        <translation>Salva credenziali?</translation>
+    </message>
+    <message>
+        <source>Delete Saved</source>
+        <translation>Cancella salvati</translation>
+    </message>
+    <message>
+        <source>Error During Playback</source>
+        <translation>Errore durante riproduzione</translation>
+        <extracomment>Dialog title when error occurs during playback</extracomment>
+    </message>
+    <message>
+        <source>RUNTIME</source>
+        <translation>Durata</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for options to filter library content</comment>
+        <source>TAB_FILTER</source>
+        <translation>Filtra</translation>
+    </message>
+    <message>
+        <source>yesterday</source>
+        <translation>ieri</translation>
+        <extracomment>Previous day</extracomment>
+    </message>
+    <message>
+        <source>Tuesday</source>
+        <translation>Martedì</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Wednesday</source>
+        <translation>Mercoledì</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Thursday</source>
+        <translation>Giovedì</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Started</source>
+        <translation>Iniziato</translation>
+        <extracomment>(Past Tense) For defining a day and time when a program started (e.g. Started Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Starts at</source>
+        <translation>Inizia a</translation>
+        <extracomment>(Future Tense) For defining time when a program will start today (e.g. Starts at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Ended at</source>
+        <translation>Terminato alle</translation>
+        <extracomment>(Past Tense) For defining time when a program will ended (e.g. Ended at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Ends at</source>
+        <translation>Termina</translation>
+        <extracomment>(Past Tense) For defining a day and time when a program ended (e.g. Ended Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Error Getting Playback Information</source>
+        <translation>Errore nel recupero delle informazioni di riproduzione</translation>
+        <extracomment>Dialog Title: Received error from server when trying to get information about the selected item for playback</extracomment>
+    </message>
+    <message>
+        <source>View Channel</source>
+        <translation>Guarda il Canale</translation>
+    </message>
+    <message>
+        <source>Died</source>
+        <translation>Morto</translation>
+    </message>
+    <message>
+        <source>Cast &amp; Crew</source>
+        <translation>Cast &amp; Troupe</translation>
+    </message>
+    <message>
+        <source>today</source>
+        <translation>oggi</translation>
+        <extracomment>Current day</extracomment>
+    </message>
+    <message>
+        <source>Age</source>
+        <translation>Età</translation>
+    </message>
+    <message>
+        <source>IMDB_RATING</source>
+        <translation>Valutazione di IMDb</translation>
+    </message>
+    <message>
+        <comment>Name or Title field of media item</comment>
+        <source>TITLE</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for options to sort library content</comment>
+        <source>TAB_SORT</source>
+        <translation>Ordina</translation>
+    </message>
+    <message>
+        <comment>Title of Tab for switching &quot;views&quot; when looking at a library</comment>
+        <source>TAB_VIEW</source>
+        <translation>Visualizzazione</translation>
+    </message>
+    <message>
+        <source>Starts</source>
+        <translation>Inizia</translation>
+        <extracomment>(Future Tense) For defining a day and time when a program will start (e.g. Starts Wednesday, 08:00) </extracomment>
+    </message>
+    <message>
+        <source>More Like This</source>
+        <translation>Simile a questo</translation>
+    </message>
+    <message>
+        <source>Record Series</source>
+        <translation>Registra Serie</translation>
+    </message>
+    <message>
+        <source>On Now</source>
+        <translation>In onda ora</translation>
+    </message>
+    <message>
+        <source>There was an error retrieving the data for this item from the server.</source>
+        <translation>C&apos;è stato un errore nel recupero dei dati per questo elemento dal server.</translation>
+        <extracomment>Dialog detail when unable to load Content from Server</extracomment>
+    </message>
+    <message>
+        <source>CRITIC_RATING</source>
+        <translation>Valutazione della critica</translation>
+    </message>
+    <message>
+        <source>DATE_ADDED</source>
+        <translation>Data di aggiunta</translation>
+    </message>
+    <message>
+        <source>DATE_PLAYED</source>
+        <translation>Visto il</translation>
+    </message>
+    <message>
+        <source>OFFICIAL_RATING</source>
+        <translation>Classificazione Parentale</translation>
+    </message>
+    <message>
+        <source>PLAY_COUNT</source>
+        <translation>Numero di Riproduzioni</translation>
+    </message>
+    <message>
+        <source>Born</source>
+        <translation>Nato</translation>
+    </message>
+    <message>
+        <source>Sunday</source>
+        <translation>Domenica</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Monday</source>
+        <translation>Lunedì</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Saturday</source>
+        <translation>Sabato</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Friday</source>
+        <translation>Venerdì</translation>
+        <extracomment>Day of Week</extracomment>
+    </message>
+    <message>
+        <source>Live</source>
+        <translation>In Diretta</translation>
+        <extracomment>If TV Show is being broadcast live (not pre-recorded)</extracomment>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>Replica</translation>
+        <extracomment>If TV Shows has previously been broadcasted</extracomment>
+    </message>
+    <message>
+        <source>TV Guide</source>
+        <translation>Guida TV</translation>
+        <extracomment>Menu option for showing Live TV Guide / Schedule</extracomment>
+    </message>
+    <message>
+        <source>Channels</source>
+        <translation>Canali</translation>
+        <extracomment>Menu option for showing Live TV Channel List</extracomment>
+    </message>
+    <message>
+        <source>Record</source>
+        <translation>Registra</translation>
+    </message>
+    <message>
+        <source>Cancel Recording</source>
+        <translation>Annulla Registrazione</translation>
+    </message>
+    <message>
+        <source>Special Features</source>
+        <translation>Contenuti Speciali</translation>
+    </message>
+    <message>
+        <source>Movies</source>
+        <translation>Film</translation>
+    </message>
+    <message>
+        <source>RELEASE_DATE</source>
+        <translation>Data di Rilascio</translation>
+    </message>
+    <message>
+        <source>TV Shows</source>
+        <translation>Serie TV</translation>
+    </message>
+    <message>
+        <source>tomorrow</source>
+        <translation>domani</translation>
+        <extracomment>Next day</extracomment>
+    </message>
+    <message>
+        <source>Started at</source>
+        <translation>Iniziato a</translation>
+        <extracomment>(Past Tense) For defining time when a program started today (e.g. Started at 08:00) </extracomment>
+    </message>
+    <message>
+        <source>Cancel Series Recording</source>
+        <translation>Annulla Registrazione della Serie</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Chiudi</translation>
+    </message>
+    <message>
+        <source>Connecting to Server</source>
+        <translation>Connessione al Server</translation>
+        <extracomment>Message to display to user while client is attempting to connect to the server</extracomment>
+    </message>
+    <message>
+        <source>Not found</source>
+        <translation>Non trovato</translation>
+        <extracomment>Title of message box when the requested content is not found on the server</extracomment>
+    </message>
+    <message>
+        <source>The requested content does not exist on the server</source>
+        <translation>Il contenuto richiesto non esiste sul server</translation>
+        <extracomment>Content of message box when the requested content is not found on the server</extracomment>
+    </message>
+    <message>
+        <source>Pick a Jellyfin server from the local network</source>
+        <translation>Scegli un server Jellyfin dalla rete locale:</translation>
+        <extracomment>Instructions on initial app launch when the user is asked to pick a server from a list</extracomment>
+    </message>
+    <message>
+        <source>...or enter server URL manually:</source>
+        <translation>Se il server non è nella lista, puoi inserire l&apos;URL manualmente:</translation>
+        <extracomment>Instructions on initial app launch when the user is asked to manually enter a server URL</extracomment>
     </message>
     <message>
         <source>Change Server</source>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "roku-deploy": "3.11.1",
         "roku-log-bsc-plugin": "0.8.1",
         "rooibos-roku": "5.8.0",
-        "ropm": "0.10.20",
+        "ropm": "0.10.21",
         "spellchecker-cli": "6.1.1",
         "undent": "0.1.0"
       }
@@ -5164,20 +5164,20 @@
       "dev": true
     },
     "node_modules/ropm": {
-      "version": "0.10.20",
-      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.10.20.tgz",
-      "integrity": "sha512-Xm5QZklaROcMWpm52CDNnKdpTOfvR26vphBT59WPkybuv+sRNQ7eQLpj0pJbzUlzOBEsoxUkDWt3V1x2xzLVjA==",
+      "version": "0.10.21",
+      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.10.21.tgz",
+      "integrity": "sha512-aQhrsfRcss3evGraHiCnjEipZK5Qp/dwBB5gEOielwsutSzLBsUMqAyk1EEdVyOgzmreVBCj6PZxfpqkgVgxrw==",
       "dev": true,
       "dependencies": {
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.65.10",
+        "brighterscript": "^0.65.12",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
         "latinize": "0.5.0",
         "npm-packlist": "2.1.4",
-        "roku-deploy": "^3.10.5",
+        "roku-deploy": "^3.11.1",
         "semver": "7.3.4",
         "yargs": "16.2.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jellyfin-roku",
-  "version": "1.6.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jellyfin-roku",
-      "version": "1.6.6",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@rokucommunity/bslint": "0.8.12",
-        "brighterscript": "0.65.11",
+        "brighterscript": "0.65.13",
         "brighterscript-jsdocs-plugin": "0.6.0",
         "clean-jsdoc-theme": "4.2.17",
         "jsdoc": "4.0.2",
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/brighterscript": {
-      "version": "0.65.11",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.11.tgz",
-      "integrity": "sha512-eoTqnfp3cuL6tgmqZ45zP0M4bljONBKLSA53W+UwKgPPuChC37mzjWKCpeoFgTfwhI0cL1dZNf6B9i1Pd/Uudw==",
+      "version": "0.65.13",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.13.tgz",
+      "integrity": "sha512-f2Mvdpl+RRuVGLnwXvydpVjftSJl0n9L0HCBQlLZPQelksGV7n0ahIBcbPavqhXaZj/wB4wOKn2vQwWJI0G+tA==",
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@xml-tools/parser": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPL-2.0",
       "dependencies": {
         "@rokucommunity/bslib": "0.1.1",
-        "brighterscript-formatter": "1.6.35",
+        "brighterscript-formatter": "1.6.36",
         "log": "npm:roku-log@0.11.1"
       },
       "devDependencies": {
@@ -793,11 +793,11 @@
       }
     },
     "node_modules/brighterscript-formatter": {
-      "version": "1.6.35",
-      "resolved": "https://registry.npmjs.org/brighterscript-formatter/-/brighterscript-formatter-1.6.35.tgz",
-      "integrity": "sha512-OtExVLvgfZ7QlBDFpNqDUZQiSbO8sNO1l0wEfkspYJzPbhbhKYL2NEEL9OSTzUJYCrO/I8ZL7bo57ZGNQlcNBQ==",
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/brighterscript-formatter/-/brighterscript-formatter-1.6.36.tgz",
+      "integrity": "sha512-f9Y3Re6egB1MCUftph8AT8RxWTtXmeMjwigRv1biNGmEuGeSOipoBnCbwY4U1CFz46L7W39/TL4n1JMV9URD6w==",
       "dependencies": {
-        "brighterscript": "^0.65.9",
+        "brighterscript": "^0.65.12",
         "glob-all": "^3.3.0",
         "jsonc-parser": "^3.0.0",
         "source-map": "^0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "log": "npm:roku-log@0.11.1"
       },
       "devDependencies": {
-        "@rokucommunity/bslint": "0.8.12",
+        "@rokucommunity/bslint": "0.8.13",
         "brighterscript": "0.65.13",
         "brighterscript-jsdocs-plugin": "0.6.0",
         "clean-jsdoc-theme": "4.2.17",
@@ -303,9 +303,9 @@
       "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
     },
     "node_modules/@rokucommunity/bslint": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@rokucommunity/bslint/-/bslint-0.8.12.tgz",
-      "integrity": "sha512-0kU6sHpjEq51f54ajzscxzLT5Tq7SjF8FPszr7pRMSmUHHIDmTu5e1vDu8gS5UzWM+RGhXHqa3EXXt789B6sdQ==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@rokucommunity/bslint/-/bslint-0.8.13.tgz",
+      "integrity": "sha512-EC5tQdtRFTJxOo+9lnZz6yLcsyctuchCzUNJX391ZgCN0EKJTjGigyqTsdsFprINmr0pBojUiys/ZpS/Bv3ROQ==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Roku app for Jellyfin media server",
   "dependencies": {
     "@rokucommunity/bslib": "0.1.1",
-    "brighterscript-formatter": "1.6.35",
+    "brighterscript-formatter": "1.6.36",
     "log": "npm:roku-log@0.11.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "roku-deploy": "3.11.1",
     "roku-log-bsc-plugin": "0.8.1",
     "rooibos-roku": "5.8.0",
-    "ropm": "0.10.20",
+    "ropm": "0.10.21",
     "spellchecker-cli": "6.1.1",
     "undent": "0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rokucommunity/bslint": "0.8.12",
-    "brighterscript": "0.65.11",
+    "brighterscript": "0.65.13",
     "brighterscript-jsdocs-plugin": "0.6.0",
     "clean-jsdoc-theme": "4.2.17",
     "jsdoc": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "log": "npm:roku-log@0.11.1"
   },
   "devDependencies": {
-    "@rokucommunity/bslint": "0.8.12",
+    "@rokucommunity/bslint": "0.8.13",
     "brighterscript": "0.65.13",
     "brighterscript-jsdocs-plugin": "0.6.0",
     "clean-jsdoc-theme": "4.2.17",

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>jellyfin/.github//renovate-presets/default"
-    ]
+    ],
+    "packageRules": []
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Issue: If launching a TV station from anywhere other than the TV Guide it doesn't work.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds back the check from before the Queue manager refactor (found in AddVideoContent()) that checks to see if the "program" being launched is in fact a Live TV channel. 

