### PR TITLE
Fix launching Live TV channels from outside the guide

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -84,7 +84,6 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         else if isValid(meta.json.Name)
             meta.title = meta.json.Name
         end if
-        meta.showID = meta.json.id
         meta.live = true
         if LCase(meta.json.type) = "program"
             video.id = meta.json.ChannelId

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -77,6 +77,22 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     videotype = LCase(meta.type)
 
+    ' Check for any Live TV streams coming from other places other than the TV Guide
+    if isValid(meta.json) and isValid(meta.json.ChannelId)
+        if isValid(meta.json.EpisodeTitle)
+            meta.title = meta.json.EpisodeTitle
+        else if isValid(meta.json.Name)
+            meta.title = meta.json.Name
+        end if
+        meta.showID = meta.json.id
+        meta.live = true
+        if LCase(meta.json.type) = "program"
+            video.id = meta.json.ChannelId
+        else
+            video.id = meta.json.id
+        end if
+    end if
+
     if videotype = "episode" or videotype = "series"
         video.content.contenttype = "episode"
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Issue: When clicking on a Live TV program, from anywhere but the TV Guide, you get an error getting data from server dialog box.
 
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Add a check for Live TV that existed in AddVideoContents back in to the new LoadItems_AddVideoContent function that was created during the Queue Manager refactor.


