### PR TITLE
Make music artist presentation views honor the Item Titles setting

### DIFF
--- a/components/ItemGrid/MusicLibraryView.bs
+++ b/components/ItemGrid/MusicLibraryView.bs
@@ -140,14 +140,12 @@ sub loadInitialItems()
         m.loadItemsTask.itemId = m.top.parentItem.parentFolder
     else if LCase(m.view) = "artistspresentation" or LCase(m.options.view) = "artistspresentation"
         m.loadItemsTask.genreIds = ""
-        m.top.showItemTitles = "hidealways"
     else if LCase(m.view) = "artistsgrid" or LCase(m.options.view) = "artistsgrid"
         m.loadItemsTask.genreIds = ""
     else if LCase(m.view) = "albumartistsgrid" or LCase(m.options.view) = "albumartistsgrid"
         m.loadItemsTask.genreIds = ""
     else if LCase(m.view) = "albumartistspresentation" or LCase(m.options.view) = "albumartistspresentation"
         m.loadItemsTask.genreIds = ""
-        m.top.showItemTitles = "hidealways"
     else
         m.loadItemsTask.itemId = m.top.parentItem.Id
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Makes the artist and album artist presentation views in the music library honor the Item Titles user setting instead of being hard coded.

## Issues
Fixes #1548
