### PR TITLE
Move selected subtitle to top of selection menu

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -65,7 +65,7 @@ end sub
 
 ' User requested subtitle selection popup
 sub onSelectSubtitlePressed()
-    ' None is always first in the subtitle list
+    ' Manually create the None option
     subtitleData = {
         data: [{
             "Index": -1,
@@ -100,7 +100,12 @@ sub onSelectSubtitlePressed()
             end if
         end if
 
-        subtitleData.data.push(item)
+        ' Put the selected item at the top of the option list
+        if isValid(item.selected) and item.selected
+            subtitleData.data.Unshift(item)
+        else
+            subtitleData.data.push(item)
+        end if
     end for
 
     m.global.sceneManager.callFunc("radioDialog", tr("Select Subtitles"), subtitleData)

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -65,16 +65,8 @@ end sub
 
 ' User requested subtitle selection popup
 sub onSelectSubtitlePressed()
-    ' Manually create the None option
     subtitleData = {
-        data: [{
-            "Index": -1,
-            "IsExternal": false,
-            "Track": {
-                "description": "None"
-            },
-            "Type": "subtitleselection"
-        }]
+        data: []
     }
 
     for each item in m.view.fullSubtitleData
@@ -107,6 +99,16 @@ sub onSelectSubtitlePressed()
             subtitleData.data.push(item)
         end if
     end for
+
+    ' Manually create the None option and place at top
+    subtitleData.data.Unshift({
+        "Index": -1,
+        "IsExternal": false,
+        "Track": {
+            "description": "None"
+        },
+        "Type": "subtitleselection"
+    })
 
     m.global.sceneManager.callFunc("radioDialog", tr("Select Subtitles"), subtitleData)
     m.global.sceneManager.observeField("returnData", "onSelectionMade")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Puts the currently selected subtitle track at the top of the subtitle dialog selection options.

We're unable to set cursor focus to the item when we show the dialog, though the track's radio button is preselected. For videos with a lot of subtitles, this can cause the selected track to not show without scrolling down to find it.

This ensures the selected subtitle track is seen by the user without requiring them to first scroll.