### PR TITLE
Fix selection and display of subtitles that are not encoded

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -111,19 +111,20 @@ sub processSubtitleSelection()
     end if
 
     if m.selectedSubtitle.IsEncoded
+        ' Roku can not natively display these subtitles, so turn off the caption mode on the device
         m.view.globalCaptionMode = "Off"
     else
+        ' Roku can natively display these subtitles, ensure the caption mode on the device is on
         m.view.globalCaptionMode = "On"
-    end if
 
-    if m.selectedSubtitle.IsExternal
+        ' Roku may rearrange subtitle tracks. Look up track based on name to ensure we get the correct index
         availableSubtitleTrackIndex = availSubtitleTrackIdx(m.selectedSubtitle.Track.TrackName)
         if availableSubtitleTrackIndex = -1 then return
 
         m.view.subtitleTrack = m.view.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
-    else
-        m.view.selectedSubtitle = m.selectedSubtitle.Index
     end if
+
+    m.view.selectedSubtitle = m.selectedSubtitle.Index
 end sub
 
 ' User requested playback info

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -256,6 +256,9 @@ end sub
 
 ' Event handler for when selectedSubtitle changes
 sub onSubtitleChange()
+    ' If the global caption mode is on, that means Roku can display the subtitles natively and doesn't need a video stop/start
+    if LCase(m.top.globalCaptionMode) = "on" then return
+
     ' Save the current video position
     m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Corrects subtitle change logic so it updates video params to match selections when subtitles are not encoded.

Test File: `multiple_sub_sample.mkv` found at https://samples.mplayerhq.hu/Matroska/subtitles/ 

Also prevents video from stopping/resuming when we can change subtitle track directly - without transcoding.

## Issues
Fixes #1607
Fixes #1575
