### PR TITLE
Prevent unneeded video stop/start when turning off text subtitles

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -103,6 +103,7 @@ sub processSubtitleSelection()
     for each item in m.view.fullSubtitleData
         if item.index = m.view.selectedSubtitle
             m.view.previousSubtitleWasEncoded = item.IsEncoded
+            exit for
         end if
     end for
 

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -99,6 +99,13 @@ sub processSubtitleSelection()
     ' The playbackData is now outdated and must be refreshed
     m.playbackData = invalid
 
+    ' Find previously selected subtitle and identify if it was encoded
+    for each item in m.view.fullSubtitleData
+        if item.index = m.view.selectedSubtitle
+            m.view.previousSubtitleWasEncoded = item.IsEncoded
+        end if
+    end for
+
     if LCase(m.selectedSubtitle.track.description) = "none"
         m.view.globalCaptionMode = "Off"
         m.view.subtitleTrack = ""

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -256,8 +256,17 @@ end sub
 
 ' Event handler for when selectedSubtitle changes
 sub onSubtitleChange()
-    ' If the global caption mode is on, that means Roku can display the subtitles natively and doesn't need a video stop/start
-    if LCase(m.top.globalCaptionMode) = "on" then return
+    switchWithoutRefresh = true
+
+    if m.top.SelectedSubtitle <> -1
+        ' If the global caption mode is off, then Roku can't display the subtitles natively and needs a video stop/start
+        if LCase(m.top.globalCaptionMode) <> "on" then switchWithoutRefresh = false
+    end if
+
+    ' If previous sustitle was encoded, then we need to a video stop/start to change subtitle content
+    if m.top.previousSubtitleWasEncoded then switchWithoutRefresh = false
+
+    if switchWithoutRefresh then return
 
     ' Save the current video position
     m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -7,6 +7,7 @@
     <field id="PlaySessionId" type="string" />
     <field id="Subtitles" type="array" />
     <field id="SelectedSubtitle" type="integer" value="-2" alwaysNotify="true" />
+    <field id="previousSubtitleWasEncoded" type="boolean" />
     <field id="container" type="string" />
     <field id="directPlaySupported" type="boolean" />
     <field id="systemOverlay" type="boolean" value="false" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Checks if previous subtitle was text in addition to current subtitle so we can prevent a video stop/start if it's not needed.

## Issues
Fixes #1628
