### PR TITLE
Fix default text subtitles not showing when Text Subtitles Only option is enabled

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -250,7 +250,7 @@ function defaultSubtitleTrackFromVid(videoID) as integer
     subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
     selectedAudioLanguage = meta.json.MediaSources[0].MediaStreams[m.top.selectedAudioStreamIndex].Language ?? ""
 
-    defaultTextSubs = defaultSubtitleTrack(subtitles["all"], selectedAudioLanguage, true) ' Find correct subtitle track (forced text)
+    defaultTextSubs = defaultSubtitleTrack(subtitles["text"], selectedAudioLanguage, true) ' Find correct subtitle track (forced text)
     if defaultTextSubs <> SubtitleSelection.none
         return defaultTextSubs
     end if
@@ -494,26 +494,33 @@ function sortSubtitles(id as string, MediaStreams)
                 "IsExternal": stream.IsExternal,
                 "IsEncoded": stream.DeliveryMethod = "Encode"
             }
+
             if stream.isForced
                 trackType = "forced"
             else if stream.IsDefault
                 trackType = "default"
-            else if stream.IsTextSubtitleStream
-                trackType = "text"
             else
                 trackType = "normal"
             end if
+
             if prefered_lang <> "" and prefered_lang = stream.Track.Language
                 tracks[trackType].unshift(stream)
+
+                if stream.IsTextSubtitleStream
+                    tracks["text"].unshift(stream)
+                end if
             else
                 tracks[trackType].push(stream)
+
+                if stream.IsTextSubtitleStream
+                    tracks["text"].push(stream)
+                end if
             end if
         end if
     end for
 
     tracks["default"].append(tracks["normal"])
     tracks["forced"].append(tracks["default"])
-    tracks["forced"].append(tracks["text"])
 
     return { "all": tracks["forced"], "text": tracks["text"] }
 end function


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Currently subtitles can only have 1 type: Forced, Default, Text, Normal. This PR allows subtitles to have more than one type, so subtitles could be text and default.

## Issues
Fixes #1627