### PR TITLE
Fix saved credentials when using multiple users

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -92,8 +92,7 @@ function LoginFlow()
                 startLoadingSpinner()
                 print "A public user was selected with username=" + userSelected
                 session.user.Update("name", userSelected)
-                regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
-                session.user.Update("friendlyName", regex.ReplaceAll(userSelected, ""))
+
                 ' save userid to session
                 for each user in publicUsersNodes
                     if user.name = userSelected
@@ -159,8 +158,7 @@ function LoginFlow()
             print "Auth token found in registry"
             session.user.Update("authToken", myAuthToken)
             session.user.Update("name", myUsername)
-            regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
-            session.user.Update("friendlyName", regex.ReplaceAll(myUsername, ""))
+
             print "Attempting to use API with auth token"
             currentUser = AboutMe()
             if currentUser = invalid

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -126,7 +126,7 @@ namespace session
             tmpSessionUser[key] = value
 
             ' keep friendlyName in sync
-            if key = "name"
+            if LCase(key) = "name"
                 regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
                 tmpSessionUser["friendlyName"] = regex.ReplaceAll(value, "")
             end if

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -135,7 +135,7 @@ namespace session
             session.Update("user", tmpSessionUser)
 
             ' keep auth header in sync
-            if key = "name"
+            if LCase(key) = "name"
                 session.user.SetServerDeviceName()
             end if
         end sub

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -119,12 +119,25 @@ namespace session
         sub Update(key as string, value as dynamic)
             ' validate parameters
             if key = "" or value = invalid then return
+
             ' make copy of global user session
             tmpSessionUser = m.global.session.user
             ' update the temp user array
             tmpSessionUser[key] = value
+
+            ' keep friendlyName in sync
+            if key = "name"
+                regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
+                tmpSessionUser["friendlyName"] = regex.ReplaceAll(value, "")
+            end if
+
             ' update global user session using the temp array
             session.Update("user", tmpSessionUser)
+
+            ' keep auth header in sync
+            if key = "name"
+                session.user.SetServerDeviceName()
+            end if
         end sub
 
         ' Update the global session after user is authenticated.
@@ -187,28 +200,32 @@ namespace session
                 set_setting("active_user", tmpSession.user.id)
             end if
 
+            ' Save device id so we don't calculate it every time we need it
+            session.user.SetServerDeviceName()
+            ' Load user preferences from server
             session.user.LoadUserPreferences()
         end sub
 
         ' Sets the global server device name value used by the API
         sub SetServerDeviceName()
-            ' default value is the unique id for the device
-            deviceName = m.global.device.id
-            if isValid(m.global.session.user) and isValid(m.global.session.user.friendlyName)
-                deviceName = deviceName + m.global.session.user.friendlyName
+            localGlobal = m.global
+
+            ' default device name is the unique id for the device
+            deviceName = localGlobal.device.id
+            if isValid(localGlobal.session.user) and isValid(localGlobal.session.user.friendlyName)
+                deviceName = deviceName + localGlobal.session.user.friendlyName
             end if
 
-            ' update the global device array
-            tmpDevice = m.global.device
-            tmpDevice.AddReplace("serverDeviceName", deviceName)
-            m.global.setFields({ device: tmpDevice })
+            ' update global if needed
+            if localGlobal.device.serverDeviceName <> deviceName
+                tmpDevice = localGlobal.device
+                tmpDevice.AddReplace("serverDeviceName", deviceName)
+                m.global.setFields({ device: tmpDevice })
+            end if
         end sub
 
         ' Load and parse Display Settings from server
         sub LoadUserPreferences()
-            ' Save device id so we don't calculate it every time we need it
-            session.user.SetServerDeviceName()
-
             id = m.global.session.user.id
             ' Currently using client "emby", which is what website uses so we get same Display prefs as web.
             ' May want to change to specific Roku display settings
@@ -377,6 +394,8 @@ namespace session
 
                 ' load globals
                 session.user.settings.LoadGlobals()
+                ' Reset server device name state
+                session.user.SetServerDeviceName()
             end sub
 
             ' Grab global vars from registry and overwrite defaults
@@ -388,9 +407,6 @@ namespace session
                         session.user.settings.Save(item, get_setting(item))
                     end if
                 end for
-
-                ' Reset server device name state
-                session.user.SetServerDeviceName()
             end sub
 
             ' Saves the user setting to the global session.

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -192,11 +192,16 @@ namespace session
 
         ' Sets the global server device name value used by the API
         sub SetServerDeviceName()
+            ' default value is the unique id for the device
+            deviceName = m.global.device.id
             if isValid(m.global.session.user) and isValid(m.global.session.user.friendlyName)
-                m.global.device.serverDeviceName = m.global.device.id + m.global.session.user.friendlyName
-            else
-                m.global.device.serverDeviceName = m.global.device.id
+                deviceName = deviceName + m.global.session.user.friendlyName
             end if
+
+            ' update the global device array
+            tmpDevice = m.global.device
+            tmpDevice.AddReplace("serverDeviceName", deviceName)
+            m.global.setFields({ device: tmpDevice })
         end sub
 
         ' Load and parse Display Settings from server


### PR DESCRIPTION
Saved credentials currently only works right with one user. Once a second user auths using the device, the first user's saved auth token will stop working. This fixes that

NOTE: It only breaks for user's with a password. If your public user doesn't have a password, you won't notice this behavior because the client will automatically try to use a blank password to authenticate when you select your public user.

## Changes
- Update `SetServerDeviceName()` so that global gets updated as expected.
- Small QOL refactor to automatically update the auth header and session.user.friendlyName whenever we manually update `m.global.session.user.name` i.e. using `session.user.Update("name", userSelected)`  will automatically format and save the friendlyName and update the auth string

## Issues
Fixes #1636
