### PR TITLE
Allow default subtitles to enable global caption mode

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -338,7 +338,7 @@ sub onVideoContentLoaded()
     ' Allow default subtitles
     m.top.unobserveField("selectedSubtitle")
 
-    ' Set subtitleTrack property is subs are natively supported by Roku
+    ' Set subtitleTrack property if subs are natively supported by Roku
     selectedSubtitle = invalid
     for each subtitle in m.top.fullSubtitleData
         if subtitle.Index = videoContent[0].selectedSubtitle
@@ -350,7 +350,10 @@ sub onVideoContentLoaded()
     if isValid(selectedSubtitle)
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
         if availableSubtitleTrackIndex <> -1
-            m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
+            if not selectedSubtitle.IsEncoded
+                m.top.globalCaptionMode = "On"
+                m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
+            end if
         end if
     end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Allows default subtitles to enable global caption mode, just like the subtitle selection popup does. This way it's just like the user selected the subtitle from the popup except the system did it for them.

## Issues
Fixes #1639
