### PR TITLE
Fix sporadic crash on home screen

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -21,9 +21,17 @@ sub init()
     m.showProgressBarField = m.top.findNode("showProgressBarField")
 
     ' Randomize the background colors
+    backdropColor = "#00a4db" ' set default in case global var is invalid
+    localGlobal = m.global
+
+    if isValid(localGlobal) and isValid(localGlobal.constants) and isValid(localGlobal.constants.poster_bg_pallet)
+        posterBackgrounds = localGlobal.constants.poster_bg_pallet
+        backdropColor = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    end if
+
+    ' update the backdrop node
     m.backdrop = m.top.findNode("backdrop")
-    posterBackgrounds = m.global.constants.poster_bg_pallet
-    m.backdrop.color = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    m.backdrop.color = backdropColor
 end sub
 
 


### PR DESCRIPTION
The crash in #1642 should never happen in theory because we are setting the global constants super early in the app. This PR should fix the crash by setting a default backdrop color value and overwriting it with a random value like before but only if the global var is valid.

## Issues
Fixes #1642
