### PR TITLE
Display ending episode number for multi-part TV episodes

### DIFF
--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -28,9 +28,9 @@ sub itemContentChanged()
     end if
 
     if isValid(itemData.indexNumber)
-        indexNumber = itemData.indexNumber.toStr() + ". "
+        indexNumber = `${itemData.indexNumber}. `
         if isValid(itemData.indexNumberEnd)
-            indexNumber = itemData.indexNumber.toStr() + "-" + itemData.indexNumberEnd.toStr() + ". "
+            indexNumber = `${itemData.indexNumber}-${itemData.indexNumberEnd}. `
         end if
     else
         indexNumber = ""

--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -29,6 +29,9 @@ sub itemContentChanged()
 
     if isValid(itemData.indexNumber)
         indexNumber = itemData.indexNumber.toStr() + ". "
+        if isValid(itemData.indexNumberEnd)
+            indexNumber = itemData.indexNumber.toStr() + "-" + itemData.indexNumberEnd.toStr() + ". "
+        end if
     else
         indexNumber = ""
     end if


### PR DESCRIPTION
## Changes
In the Episode List view, show the ending episode number for files that contain more than one episode.

## Issues
Fixes: https://github.com/jellyfin/jellyfin-roku/issues/1664


![multi](https://github.com/jellyfin/jellyfin-roku/assets/116527579/18063e7a-91f8-4481-9a7e-fcb29d8f432f)
