### PR TITLE
Fix crash if video has no audio stream

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -248,7 +248,13 @@ function defaultSubtitleTrackFromVid(videoID) as integer
     if not isValidAndNotEmpty(meta.json.MediaSources[0].MediaStreams) then return SubtitleSelection.none
 
     subtitles = sortSubtitles(meta.id, meta.json.MediaSources[0].MediaStreams)
-    selectedAudioLanguage = meta.json.MediaSources[0].MediaStreams[m.top.selectedAudioStreamIndex].Language ?? ""
+
+    selectedAudioLanguage = ""
+    audioMediaStream = meta.json.MediaSources[0].MediaStreams[m.top.selectedAudioStreamIndex]
+
+    if isValid(audioMediaStream)
+        selectedAudioLanguage = audioMediaStream.Language ?? ""
+    end if
 
     defaultTextSubs = defaultSubtitleTrack(subtitles["text"], selectedAudioLanguage, true) ' Find correct subtitle track (forced text)
     if defaultTextSubs <> SubtitleSelection.none

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -252,6 +252,7 @@ function defaultSubtitleTrackFromVid(videoID) as integer
     selectedAudioLanguage = ""
     audioMediaStream = meta.json.MediaSources[0].MediaStreams[m.top.selectedAudioStreamIndex]
 
+    ' Ensure audio media stream is valid before using language property
     if isValid(audioMediaStream)
         selectedAudioLanguage = audioMediaStream.Language ?? ""
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Checks if audio mediastream is valid before attempting to use language property.

## Issues
Fixes #1670
