### PR TITLE
Fix in-process recording play functionality.  Prevent app crash when attempting to play in-process recordings.

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -164,6 +164,8 @@ sub loadItems()
                 tmp.image = PosterImage(item.id, { "maxHeight": 425, "maxWidth": 290, "quality": "90" })
             else if item.type = "Episode"
                 tmp = CreateObject("roSGNode", "TVEpisode")
+            else if item.Type = "Recording"
+                tmp = CreateObject("roSGNode", "RecordingData")
             else if item.Type = "Genre"
                 tmp = CreateObject("roSGNode", "ContentNode")
                 tmp.title = item.name

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -82,8 +82,8 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     videotype = LCase(meta.type)
 
-    ' Check for any Live TV streams coming from other places other than the TV Guide
-    if isValid(meta.json) and isValid(meta.json.ChannelId)
+    ' Check for any Live TV streams or Recordings coming from other places other than the TV Guide
+    if videotype = "recording" or (isValid(meta.json) and isValid(meta.json.ChannelId))
         if isValid(meta.json.EpisodeTitle)
             meta.title = meta.json.EpisodeTitle
         else if isValid(meta.json.Name)

--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -31,7 +31,7 @@ sub setData()
             m.top.iconUrl = "pkg:/images/media_type_icons/folder_white.png"
         end if
 
-    else if datum.type = "Episode" or datum.type = "MusicVideo"
+    else if datum.type = "Episode" or datum.type = "Recording" or datum.type = "MusicVideo"
         m.top.isWatched = datum.UserData.Played
 
         imgParams = {}

--- a/components/data/RecordingData.bs
+++ b/components/data/RecordingData.bs
@@ -1,0 +1,18 @@
+sub setFields()
+    datum = m.top.json
+
+    m.top.id = datum.id
+    m.top.title = datum.name
+    m.top.showID = datum.SeriesID
+    m.top.seasonID = datum.SeasonID
+    m.top.overview = datum.overview
+    m.top.favorite = datum.UserData.isFavorite
+end sub
+
+sub setPoster()
+    if m.top.image <> invalid
+        m.top.posterURL = m.top.image.url
+    else
+        m.top.posterURL = ""
+    end if
+end sub

--- a/components/data/RecordingData.xml
+++ b/components/data/RecordingData.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="RecordingData" extends="ContentNode">
+  <interface>
+    <field id="id" type="string" />
+    <field id="title" type="string" />
+    <field id="image" type="node" onChange="setPoster" />
+    <field id="posterURL" type="string" />
+    <field id="showID" type="string" />
+    <field id="seasonID" type="string" />
+    <field id="overview" type="string" />
+    <field id="type" type="string" value="Recording" />
+    <field id="startingPoint" type="longinteger" value="0" />
+    <field id="json" type="assocarray" onChange="setFields" />
+    <field id="selectedVideoStreamId" type="string" />
+    <field id="selectedAudioStreamIndex" type="integer" />
+    <field id="favorite" type="boolean" />
+  </interface>
+</component>

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -121,7 +121,7 @@ sub itemContentChanged()
         return
     end if
 
-    if itemData.type = "Episode"
+    if itemData.type = "Episode" or itemData.type = "Recording"
         m.itemText.text = itemData.json.SeriesName
 
         if itemData.PlayedPercentage > 0

--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -145,6 +145,11 @@ sub playQueue()
         return
     end if
 
+    if nextItemMediaType = "recording"
+        CreateVideoPlayerView()
+        return
+    end if
+
     if nextItemMediaType = "trailer"
         CreateVideoPlayerView()
         return

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -166,7 +166,7 @@ sub Main (args as dynamic) as void
                     m.global.queueManager.callFunc("clear") ' empty queue/playlist
                     m.global.queueManager.callFunc("resetShuffle") ' turn shuffle off
 
-                    if itemType = "episode" or itemType = "movie" or itemType = "video"
+                    if itemType = "episode" or itemType = "recording" or itemType = "movie" or itemType = "video"
                         quickplay.video(itemNode)
                         ' restore focus
                         if LCase(group.subtype()) = "tvepisodes"
@@ -242,8 +242,8 @@ sub Main (args as dynamic) as void
                 else if selectedItemType = "UserView" or selectedItemType = "Folder" or selectedItemType = "Channel" or selectedItemType = "Boxset"
                     group = CreateItemGrid(selectedItem)
                     sceneManager.callFunc("pushScene", group)
-                else if selectedItemType = "Episode"
-                    ' User has selected a TV episode they want us to play
+                else if selectedItemType = "Episode" or selectedItemType = "Recording"
+                    ' User has selected a TV episode or Recording they want us to play
                     audio_stream_idx = 0
                     if isValid(selectedItem.selectedAudioStreamIndex) and selectedItem.selectedAudioStreamIndex > 0
                         audio_stream_idx = selectedItem.selectedAudioStreamIndex
@@ -482,7 +482,7 @@ sub Main (args as dynamic) as void
             startLoadingSpinner()
             node = getMsgPicker(msg)
             ' TODO - swap this based on target.mediatype
-            ' types: [ Series (Show), Episode, Movie, Audio, Person, Studio, MusicArtist ]
+            ' types: [ Series (Show), Episode, Movie, Audio, Person, Studio, MusicArtist, Recording ]
             if node.type = "Series"
                 group = CreateSeriesDetailsGroup(node.id)
             else if node.type = "Movie"
@@ -504,6 +504,9 @@ sub Main (args as dynamic) as void
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Episode"
+                group = CreateVideoPlayerGroup(node.id)
+                sceneManager.callFunc("pushScene", group)
+            else if node.type = "Recording"
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Audio"

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -95,6 +95,11 @@ function ItemMetaData(id as string)
         tmp.image = PosterImage(data.id, imgParams)
         tmp.json = data
         return tmp
+    else if data.type = "Recording"
+        tmp = CreateObject("roSGNode", "RecordingData")
+        tmp.image = PosterImage(data.id, imgParams)
+        tmp.json = data
+        return tmp
     else if data.type = "BoxSet" or data.type = "Playlist"
         tmp = CreateObject("roSGNode", "CollectionData")
         tmp.image = PosterImage(data.id, imgParams)

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -408,7 +408,7 @@ namespace quickplay
         ' get watched episodes by the person
         personEpisodes = api.users.GetItemsByQuery(m.global.session.user.id, {
             "personIds": itemNode.id,
-            "includeItemTypes": "Episode",
+            "includeItemTypes": ["Episode", "Recording"],
             "isPlayed": true,
             "excludeItemTypes": "Season,Series",
             "recursive": true,
@@ -474,7 +474,7 @@ namespace quickplay
         if not isValid(itemNode) or not isValid(itemNode.id) then return
 
         paramArray = {
-            "includeItemTypes": ["Episode", "Movie", "Video"],
+            "includeItemTypes": ["Episode", "Recording", "Movie", "Video"],
             "videoTypes": "VideoFile",
             "sortBy": "Random",
             "limit": 2000,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
1. Add RecordingData object and logic to to allow in-process recordings (recordings that have started, but not yet completed) to be played.  Both normal play and quickplay is supported with this change.  
2. Fix blank graphic and no text for in-process recording in the "Latest in <target library>" row.  

## Issues
Fixes #1692 
