### PR TITLE
Add a new option to select preferred audio codec for transcodes

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1113,11 +1113,6 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>Choose your preferred audio codecs when transcoding.</source>
-            <translation>Choose your preferred audio codecs when transcoding.</translation>
-            <extracomment>Settings Menu - Description for option</extracomment>
-        </message>
-        <message>
             <source>Preferred Audio Codec</source>
             <translation>Preferred Audio Codec</translation>
             <extracomment>Settings Menu - Title of option</extracomment>
@@ -1131,11 +1126,6 @@
             <source>Use system settings</source>
             <translation>Use system settings</translation>
             <extracomment>User Setting - Option title</extracomment>
-        </message>
-        <message>
-            <source>Audio Codec Support</source>
-            <translation>Audio Codec Support</translation>
-            <extracomment>Settings Menu - Title of option</extracomment>
         </message>
         <message>
             <source>Direct playing</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1113,14 +1113,34 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>Choose your preferred audio codec when transcoding multichannel audio.</source>
-            <translation>Choose your preferred audio codec when transcoding multichannel audio.</translation>
+            <source>Choose your preferred audio codecs when transcoding.</source>
+            <translation>Choose your preferred audio codecs when transcoding.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>Force all transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</source>
-            <translation>Force all transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</translation>
+            <source>Multichannel Audio - DTS</source>
+            <translation>Multichannel Audio - DTS</translation>
+            <extracomment>Settings Menu - Title of option</extracomment>
+        </message>
+        <message>
+            <source>Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</source>
+            <translation>Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
+        <message>
+            <source>Preferred Audio Codec</source>
+            <translation>Preferred Audio Codec</translation>
+            <extracomment>Settings Menu - Title of option</extracomment>
+        </message>
+        <message>
+            <source>Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.</source>
+            <translation>Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
+        <message>
+            <source>Use system settings</source>
+            <translation>Use system settings</translation>
+            <extracomment>User Setting - Option title</extracomment>
         </message>
         <message>
             <source>Audio Codec Support</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1118,16 +1118,6 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>Multichannel Audio - DTS</source>
-            <translation>Multichannel Audio - DTS</translation>
-            <extracomment>Settings Menu - Title of option</extracomment>
-        </message>
-        <message>
-            <source>Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</source>
-            <translation>Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.</translation>
-            <extracomment>Settings Menu - Description for option</extracomment>
-        </message>
-        <message>
             <source>Preferred Audio Codec</source>
             <translation>Preferred Audio Codec</translation>
             <extracomment>Settings Menu - Title of option</extracomment>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,41 +17,6 @@
         "description": "Settings relating to playback and supported codec and media types.",
         "children": [
             {
-                "title": "Audio Codec Support",
-                "description": "Choose your preferred audio codecs when transcoding.",
-                "children": [
-                    {
-                        "title": "Preferred Audio Codec",
-                        "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
-                        "settingName": "playback.preferredAudioCodec",
-                        "type": "radio",
-                        "default": "auto",
-                        "options": [
-                            {
-                                "title": "Use system settings",
-                                "id": "auto"
-                            },
-                            {
-                                "title": "AAC",
-                                "id": "aac"
-                            },
-                            {
-                                "title": "DD (AC3)",
-                                "id": "ac3"
-                            },
-                            {
-                                "title": "DD+ (EAC3)",
-                                "id": "eac3"
-                            },
-                            {
-                                "title": "DTS",
-                                "id": "dts"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
                 "title": "Bitrate Limit",
                 "description": "Configure the maximum playback bitrate.",
                 "children": [
@@ -208,6 +173,35 @@
                 "settingName": "playback.nextupbuttonseconds",
                 "type": "integer",
                 "default": "30"
+            },
+            {
+                "title": "Preferred Audio Codec",
+                "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
+                "settingName": "playback.preferredAudioCodec",
+                "type": "radio",
+                "default": "auto",
+                "options": [
+                    {
+                        "title": "Use system settings",
+                        "id": "auto"
+                    },
+                    {
+                        "title": "AAC",
+                        "id": "aac"
+                    },
+                    {
+                        "title": "DD (AC3)",
+                        "id": "ac3"
+                    },
+                    {
+                        "title": "DD+ (EAC3)",
+                        "id": "eac3"
+                    },
+                    {
+                        "title": "DTS",
+                        "id": "dts"
+                    }
+                ]
             },
             {
                 "title": "Text Subtitles Only",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -18,14 +18,43 @@
         "children": [
             {
                 "title": "Audio Codec Support",
-                "description": "Choose your preferred audio codec when transcoding multichannel audio.",
+                "description": "Choose your preferred audio codecs when transcoding.",
                 "children": [
                     {
-                        "title": "DTS",
-                        "description": "Force all transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.",
+                        "title": "Multichannel Audio - DTS",
+                        "description": "Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.",
                         "settingName": "playback.forceDTS",
                         "type": "bool",
                         "default": "false"
+                    },
+                    {
+                        "title": "Preferred Audio Codec",
+                        "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
+                        "settingName": "playback.preferredAudioCodec",
+                        "type": "radio",
+                        "default": "auto",
+                        "options": [
+                            {
+                                "title": "Use system settings",
+                                "id": "auto"
+                            },
+                            {
+                                "title": "AAC",
+                                "id": "aac"
+                            },
+                            {
+                                "title": "DD (AC3)",
+                                "id": "ac3"
+                            },
+                            {
+                                "title": "DD+ (EAC3)",
+                                "id": "eac3"
+                            },
+                            {
+                                "title": "DTS",
+                                "id": "dts"
+                            }
+                        ]
                     }
                 ]
             },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -21,13 +21,6 @@
                 "description": "Choose your preferred audio codecs when transcoding.",
                 "children": [
                     {
-                        "title": "Multichannel Audio - DTS",
-                        "description": "Force all audio transcodes to use DTS instead of the default EAC3. The device must support DTS for this setting to have an effect.",
-                        "settingName": "playback.forceDTS",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
                         "title": "Preferred Audio Codec",
                         "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
                         "settingName": "playback.preferredAudioCodec",

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -195,21 +195,13 @@ function getTranscodingProfiles() as object
     ' does the users setup support surround sound?
     maxAudioChannels = "2" ' jellyfin expects this as a string
     ' in order of preference from left to right
-    audioCodecs = ["mp3", "vorbis", "opus", "flac", "alac", "ac4", "pcm", "wma", "wmapro"]
-    surroundSoundCodecs = ["eac3", "ac3", "dts"]
-    if globalUserSettings["playback.forceDTS"] = true
-        surroundSoundCodecs = ["dts", "eac3", "ac3"]
-    end if
+    audioCodecs = ["eac3", "ac3", "dts", "mp3", "vorbis", "opus", "flac", "alac", "ac4", "pcm", "wma", "wmapro"]
 
-    surroundSoundCodec = invalid
     if di.GetAudioOutputChannel() = "5.1 surround"
         maxAudioChannels = "6"
-        for each codec in surroundSoundCodecs
-            if di.CanDecodeAudio({ Codec: codec, ChCnt: 6 }).Result
-                surroundSoundCodec = codec
-                if di.CanDecodeAudio({ Codec: codec, ChCnt: 8 }).Result
-                    maxAudioChannels = "8"
-                end if
+        for each codec in audioCodecs
+            if di.CanDecodeAudio({ Codec: codec, ChCnt: 8 }).Result
+                maxAudioChannels = "8"
                 exit for
             end if
         end for
@@ -401,40 +393,6 @@ function getTranscodingProfiles() as object
     if globalUserSettings["playback.resolution.max"] <> "off"
         tsArray.Conditions = [getMaxHeightArray(), getMaxWidthArray()]
         mp4Array.Conditions = [getMaxHeightArray(), getMaxWidthArray()]
-    end if
-
-    ' surround sound
-    if surroundSoundCodec <> invalid
-        ' add preferred surround sound codec to TranscodingProfile
-        transcodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Streaming",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-        transcodingProfiles.push({
-            "Container": surroundSoundCodec,
-            "Type": "Audio",
-            "AudioCodec": surroundSoundCodec,
-            "Context": "Static",
-            "Protocol": "http",
-            "MaxAudioChannels": maxAudioChannels
-        })
-
-        ' put codec in front of AudioCodec string
-        if tsArray.AudioCodec = ""
-            tsArray.AudioCodec = surroundSoundCodec
-        else
-            tsArray.AudioCodec = surroundSoundCodec + "," + tsArray.AudioCodec
-        end if
-
-        if mp4Array.AudioCodec = ""
-            mp4Array.AudioCodec = surroundSoundCodec
-        else
-            mp4Array.AudioCodec = surroundSoundCodec + "," + mp4Array.AudioCodec
-        end if
     end if
 
     ' add user-selected preferred codec to the front of the list

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -437,6 +437,12 @@ function getTranscodingProfiles() as object
         end if
     end if
 
+    ' add user-selected preferred codec to the front of the list
+    if globalUserSettings["playback.preferredAudioCodec"] <> "auto"
+        tsArray.AudioCodec = globalUserSettings["playback.preferredAudioCodec"] + "," + tsArray.AudioCodec
+        mp4Array.AudioCodec = globalUserSettings["playback.preferredAudioCodec"] + "," + mp4Array.AudioCodec
+    end if
+
     transcodingProfiles.push(tsArray)
     transcodingProfiles.push(mp4Array)
 


### PR DESCRIPTION
## Changes
Add a new option that allows the user to select a preferred audio codec to use during transcoding. 

The user-selected preferred codec is added to the front of the codec list for video transcoding profiles. If a transcode is required, it will be selected first to use (assuming the server and stream type support it). If it is not supported (example: DTS is selected as preferred, but the device does not support it, like the Roku Streambar), the next codec in the list is used. 

Additionally, the wording of the existing **DTS** option has been updated to reflect that it applies to audio transcoding profiles _only_.

## Issues
Addresses #958 and #741, related to #1466

## Additional Context
While watching different movies on my Roku Ultra with image-based subtitles, I noticed that my AVR was only receiving PCM audio. Upon investigation, I realized that all transcodes were using AAC instead of EAC3. Because Roku doesn’t support multichannel AAC, it was being downmixed to stereo before being passed to the AVR.

By changing the preferred codec to AC3 in my setup, I was able to retain the channel layout of a transcoded file (DTS 5.1 -> AC3 5.1 instead of DTS 5.1 -> AAC 5.1 -> AAC 2.0)
