### PR TITLE
Create workflow to auto bump version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,235 @@
+name: "Create PR to bump version"
+
+on:
+  workflow_dispatch:
+    inputs:
+      targetBranch:
+        description: 'Target Branch'
+        required: true
+        type: choice
+        options:
+        - bugfix
+        - master
+      versionType:
+        description: 'What Version to Bump'
+        required: true
+        type: choice
+        options:
+        - build
+        - minor
+        - major
+
+jobs:
+  build:
+    if: ${{ github.event.inputs.versionType == 'build' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Install required packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: jq
+      - name: Save targetBranch to env
+        if: github.event.inputs.targetBranch != 'bugfix'
+        run: echo "targetBranch=${{ github.event.inputs.targetBranch }}" >> $GITHUB_ENV
+      # Save old version
+      - name: Find and save old major_version from manifest
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old minor_version from manifest
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old build_version from manifest
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
+      # Bugfix branch
+      - name: Save bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "bugfixBranch=${{ env.oldMajor }}.${{ env.oldMinor }}.z" >> $GITHUB_ENV
+      - name: Update targetBranch with actual bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "targetBranch=${{ env.bugfixBranch }}" >> $GITHUB_ENV
+      - name: Checkout bugfix branch
+        if: github.event.inputs.targetBranch == 'bugfix'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: ${{ env.targetBranch }}
+      # Save old version again if needed
+      - name: Find and save old major_version from manifest
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old minor_version from manifest
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old build_version from manifest
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
+      # Calculate new version
+      - name: Calculate new build_version
+        run: echo "newBuild=$((${{ env.oldBuild }} + 1))" >> $GITHUB_ENV
+      - name: Save new version to env var
+        run: echo "newVersion=${{ env.oldMajor }}.${{ env.oldMinor }}.${{ env.newBuild }}" >> $GITHUB_ENV
+      - name: Save a copy of newVersion without periods to env var
+        run: echo "newVersionSlug=${{ env.newVersion }}" | sed -e 's/\.//g' >> $GITHUB_ENV
+      # Update files with new versions
+      - name: Update manifest build_version
+        run: sed -i "s/build_version=.*/build_version=${{ env.newBuild }}/g" manifest
+      - name: Update package-lock.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package-lock.json version 2
+        run: echo "$( jq '.packages."".version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package.json )" > package.json 
+      - name: Update Makefile version
+        run: sed -i "s/VERSION := .*/VERSION := ${{ env.newVersion }}/g" Makefile
+      # Create PR
+      - name: Save new branch name to env
+        run: echo "newBranch=bump-${{ github.event.inputs.targetBranch }}-to-${{ env.newVersionSlug }}" >> $GITHUB_ENV
+      - name: Create PR with new version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          git config user.name "jellyfin-bot"
+          git config user.email "team@jellyfin.org"
+          git checkout -b "${{ env.newBranch }}"
+          git add .
+          git commit -m "Bump ${{ github.event.inputs.versionType }} version"
+          git push --set-upstream origin "${{ env.newBranch }}"
+          gh pr create --title "Bump ${{ github.event.inputs.targetBranch }} branch to ${{ env.newVersion }}" --body "Bump version to prep for next release." --label ignore-changelog --base ${{ env.targetBranch }} 
+  minor:
+    if: ${{ github.event.inputs.versionType == 'minor' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Install jq to update json
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: jq
+      - name: Save targetBranch to env
+        if: github.event.inputs.targetBranch != 'bugfix'
+        run: echo "targetBranch=${{ github.event.inputs.targetBranch }}" >> $GITHUB_ENV
+      # Save old version
+      - name: Find and save old major_version from manifest
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old minor_version from manifest
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old build_version from manifest
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
+      # Bugfix branch
+      - name: Save bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "bugfixBranch=${{ env.oldMajor }}.${{ env.oldMinor }}.z" >> $GITHUB_ENV
+      - name: Update targetBranch with actual bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "targetBranch=${{ env.bugfixBranch }}" >> $GITHUB_ENV
+      - name: Checkout bugfix branch
+        if: github.event.inputs.targetBranch == 'bugfix'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: ${{ env.targetBranch }}
+      # Calculate new version
+      - name: Calculate new build_version
+        run: echo "newMinor=$((${{ env.oldMinor }} + 1))" >> $GITHUB_ENV
+      - name: Save new version to env var
+        run: echo "newVersion=${{ env.oldMajor }}.${{ env.newMinor }}.0" >> $GITHUB_ENV
+      - name: Save a copy of newVersion without periods to env var
+        run: echo "newVersionSlug=${{ env.newVersion }}" | sed -e 's/\.//g' >> $GITHUB_ENV
+      # Update files with new versions
+      - name: Update manifest minor_version
+        run: sed -i "s/minor_version=.*/minor_version=${{ env.newMinor }}/g" manifest
+      - name: Update manifest build_version
+        run: sed -i "s/build_version=.*/build_version=0/g" manifest
+      - name: Update package-lock.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package-lock.json version 2
+        run: echo "$( jq '.packages."".version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package.json )" > package.json 
+      - name: Update Makefile version
+        run: sed -i "s/VERSION := .*/VERSION := ${{ env.newVersion }}/g" Makefile
+      # Create PR
+      - name: Save new branch name to env
+        run: echo "newBranch=bump-${{ github.event.inputs.targetBranch }}-to-${{ env.newVersionSlug }}" >> $GITHUB_ENV
+      - name: Create PR with new version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          git config user.name "jellyfin-bot"
+          git config user.email "team@jellyfin.org"
+          git checkout -b "${{ env.newBranch }}"
+          git add .
+          git commit -m "Bump ${{ github.event.inputs.versionType }} version"
+          git push --set-upstream origin "${{ env.newBranch }}"
+          gh pr create --title "Bump ${{ github.event.inputs.targetBranch }} branch to ${{ env.newVersion }}" --body "Bump version to prep for next release." --label ignore-changelog --base ${{ env.targetBranch  }} 
+      
+  major:
+    if: ${{ github.event.inputs.versionType == 'major' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Install jq to update json
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: jq
+      - name: Save targetBranch to env
+        if: github.event.inputs.targetBranch != 'bugfix'
+        run: echo "targetBranch=${{ github.event.inputs.targetBranch }}" >> $GITHUB_ENV
+      # Save old version
+      - name: Find and save old major_version from manifest
+        run: awk 'BEGIN { FS="=" } /^major_version/ { print "oldMajor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old minor_version from manifest
+        run: awk 'BEGIN { FS="=" } /^minor_version/ { print "oldMinor="$2; }' manifest >> $GITHUB_ENV
+      - name: Find and save old build_version from manifest
+        run: awk 'BEGIN { FS="=" } /^build_version/ { print "oldBuild="$2; }' manifest >> $GITHUB_ENV
+      # Bugfix branch
+      - name: Save bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "bugfixBranch=${{ env.oldMajor }}.${{ env.oldMinor }}.z" >> $GITHUB_ENV
+      - name: Update targetBranch with actual bugfix branch name
+        if: github.event.inputs.targetBranch == 'bugfix'
+        run: echo "targetBranch=${{ env.bugfixBranch }}" >> $GITHUB_ENV
+      - name: Checkout bugfix branch
+        if: github.event.inputs.targetBranch == 'bugfix'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: ${{ env.targetBranch }}
+      # Calculate new version
+      - name: Calculate new build_version
+        run: echo "newMajor=$((${{ env.oldMajor }} + 1))" >> $GITHUB_ENV
+      - name: Save new version to env var
+        run: echo "newVersion=${{ env.newMajor }}.0.0" >> $GITHUB_ENV
+      - name: Save a copy of newVersion without periods to env var
+        run: echo "newVersionSlug=${{ env.newVersion }}" | sed -e 's/\.//g' >> $GITHUB_ENV
+      # Update files with new versions
+      - name: Update manifest major_version
+        run: sed -i "s/major_version=.*/major_version=${{ env.newMajor }}/g" manifest
+      - name: Update manifest minor_version
+        run: sed -i "s/minor_version=.*/minor_version=0/g" manifest
+      - name: Update manifest build_version
+        run: sed -i "s/build_version=.*/build_version=0/g" manifest
+      - name: Update package-lock.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package-lock.json version 2
+        run: echo "$( jq '.packages."".version = "'"${{ env.newVersion }}"'"' package-lock.json )" > package-lock.json
+      - name: Update package.json version
+        run: echo "$( jq '.version = "'"${{ env.newVersion }}"'"' package.json )" > package.json 
+      - name: Update Makefile version
+        run: sed -i "s/VERSION := .*/VERSION := ${{ env.newVersion }}/g" Makefile
+      # Create PR
+      - name: Save new branch name to env
+        run: echo "newBranch=bump-${{ github.event.inputs.targetBranch }}-to-${{ env.newVersionSlug }}" >> $GITHUB_ENV
+      - name: Create PR with new version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          git config user.name "jellyfin-bot"
+          git config user.email "team@jellyfin.org"
+          git checkout -b "${{ env.newBranch }}"
+          git add .
+          git commit -m "Bump ${{ github.event.inputs.versionType }} version"
+          git push --set-upstream origin "${{ env.newBranch }}"
+          gh pr create --title "Bump ${{ github.event.inputs.targetBranch }} branch to ${{ env.newVersion }}" --body "Bump version to prep for next release." --label ignore-changelog --base ${{ env.targetBranch  }} 
+      


### PR DESCRIPTION
This creates a new workflow that can only be triggered manually. Based on the options selected, a PR is created to bump to the chosen version on the chosen branch. The `ignore-changelog` label is added to all PRs created.

![bump-version-roku](https://github.com/jellyfin/jellyfin-roku/assets/16514652/d7af9ddc-e861-4185-b943-a4690c73060f)

Test PRs from my fork: https://github.com/cewert/jellyfin-roku/pulls
