### PR TITLE
Prevent crash when homesection setting is invalid

### DIFF
--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -77,7 +77,10 @@ sub processUserSections()
 
     ' calculate expected row count by processing homesections
     for i = 0 to 6
-        sectionName = LCase(m.global.session.user.settings["homesection" + i.toStr()])
+        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        sectionName = userSection ?? "none"
+        sectionName = LCase(sectionName)
+
         if sectionName = "latestmedia"
             ' expect 1 row per filtered media library
             m.filteredLatest = filterNodeArray(m.libraryData, "id", m.global.session.user.configuration.LatestItemsExcludes)
@@ -94,7 +97,10 @@ sub processUserSections()
     ' Add home sections in order based on user settings
     loadedSections = 0
     for i = 0 to 6
-        sectionName = LCase(m.global.session.user.settings["homesection" + i.toStr()])
+        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        sectionName = userSection ?? "none"
+        sectionName = LCase(sectionName)
+
         sectionLoaded = false
         if sectionName <> "none"
             sectionLoaded = addHomeSection(sectionName)
@@ -142,7 +148,10 @@ function getOriginalSectionIndex(sectionName as string) as integer
     indexLatestMediaSection = 0
 
     for i = 0 to 6
-        settingSectionName = LCase(m.global.session.user.settings["homesection" + i.toStr()])
+        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        settingSectionName = userSection ?? "none"
+        settingSectionName = LCase(settingSectionName)
+
         if settingSectionName = "latestmedia"
             indexLatestMediaSection = i
         end if

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -75,15 +75,17 @@ sub processUserSections()
     m.expectedRowCount = 1 ' the favorites row is hardcoded to always show atm
     m.processedRowCount = 0
 
+    sessionUser = m.global.session.user
+
     ' calculate expected row count by processing homesections
     for i = 0 to 6
-        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        userSection = sessionUser.settings["homesection" + i.toStr()]
         sectionName = userSection ?? "none"
         sectionName = LCase(sectionName)
 
         if sectionName = "latestmedia"
             ' expect 1 row per filtered media library
-            m.filteredLatest = filterNodeArray(m.libraryData, "id", m.global.session.user.configuration.LatestItemsExcludes)
+            m.filteredLatest = filterNodeArray(m.libraryData, "id", sessionUser.configuration.LatestItemsExcludes)
             for each latestLibrary in m.filteredLatest
                 if latestLibrary.collectionType <> "boxsets" and latestLibrary.collectionType <> "livetv" and latestLibrary.json.CollectionType <> "Program"
                     m.expectedRowCount++
@@ -97,7 +99,7 @@ sub processUserSections()
     ' Add home sections in order based on user settings
     loadedSections = 0
     for i = 0 to 6
-        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        userSection = sessionUser.settings["homesection" + i.toStr()]
         sectionName = userSection ?? "none"
         sectionName = LCase(sectionName)
 
@@ -147,8 +149,10 @@ function getOriginalSectionIndex(sectionName as string) as integer
     sectionIndex = 0
     indexLatestMediaSection = 0
 
+    sessionUser = m.global.session.user
+
     for i = 0 to 6
-        userSection = m.global.session.user.settings["homesection" + i.toStr()]
+        userSection = sessionUser.settings["homesection" + i.toStr()]
         settingSectionName = userSection ?? "none"
         settingSectionName = LCase(settingSectionName)
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds invalid check to home section setting. Replaces invalid value with "none" so the rest of the rendering code will work as-is.

We already default invalid data to none in the user setting code. This change adds further defensive coding and does a similar check in the rendering code.

## Issues
Fixed #1619