### PR TITLE
Fix new version bump workflow

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -3,9 +3,6 @@ name: build-dev
 on:
   pull_request:
   push:
-    branches:
-      - master
-      - "*.*.z"
 
 jobs:
   dev:


### PR DESCRIPTION
The required `build-dev` workflow wasn't being run for the automated version bump PRs preventing them from being merged.
