### PR TITLE
Fix sporadic crash on home screen

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -36,7 +36,7 @@ end sub
 
 
 sub itemContentChanged()
-    m.unplayedCount.visible = false
+    if isValid(m.unplayedCount) then m.unplayedCount.visible = false
     itemData = m.top.itemContent
     if itemData = invalid then return
 
@@ -56,7 +56,6 @@ sub itemContentChanged()
 
     if itemData.isWatched
         m.playedIndicator.visible = true
-        m.unplayedCount.visible = false
     else
         m.playedIndicator.visible = false
 
@@ -64,7 +63,7 @@ sub itemContentChanged()
             if m.global.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
                 if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
                     if itemData.json.UserData.UnplayedItemCount > 0
-                        m.unplayedCount.visible = true
+                        if isValid(m.unplayedCount) then m.unplayedCount.visible = true
                         m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
                     end if
                 end if


### PR DESCRIPTION
Comes from roku crashlog:
```
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/home/HomeItem.brs(34) Backtrace: #0  Function itemcontentchanged() As Void    file/line: pkg:/components/home/HomeItem.brs(35) Local Variables: global           Interface:ifGlobal m                roAssociativeArray refcnt=2 count:2 itemdata         <uninitialized> playedindicatorleftposition <uninitialized> extraprefix      <uninitialized> textextra        <uninitialized>
```

Which points to line 39 in the bs file: `m.unplayedCount.visible = false`

## Changes
- Ensure node is valid before using

## Issues
Ref #1662 
