### PR TITLE
Fix sporadic crash on home screen 2

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -62,7 +62,7 @@ sub itemContentChanged()
 
         if LCase(itemData.type) = "series"
             if isValid(localGlobal) and isValid(localGlobal.session) and isValid(localGlobal.session.user) and isValid(localGlobal.session.user.settings)
-                if localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
+                if not localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"]
                     if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
                         if itemData.json.UserData.UnplayedItemCount > 0
                             if isValid(m.unplayedCount) then m.unplayedCount.visible = true

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -39,6 +39,7 @@ sub itemContentChanged()
     m.unplayedCount.visible = false
     itemData = m.top.itemContent
     if itemData = invalid then return
+    localGlobal = m.global
 
     itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
 
@@ -61,11 +62,13 @@ sub itemContentChanged()
         m.playedIndicator.visible = false
 
         if LCase(itemData.type) = "series"
-            if m.global.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
-                if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
-                    if itemData.json.UserData.UnplayedItemCount > 0
-                        m.unplayedCount.visible = true
-                        m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+            if isValid(localGlobal) and isValid(localGlobal.session) and isValid(localGlobal.session.user) and isValid(localGlobal.session.user.settings)
+                if localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
+                    if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
+                        if itemData.json.UserData.UnplayedItemCount > 0
+                            m.unplayedCount.visible = true
+                            m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+                        end if
                     end if
                 end if
             end if


### PR DESCRIPTION
Comes from roku.com crashlog:

```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/home/HomeItem.brs(55) Backtrace: #0  Function itemcontentchanged() As Void    file/line: pkg:/components/home/HomeItem.brs(55) Local Variables: global           Interface:ifGlobal m                roAssociativeArray refcnt=2 count:15 itemdata         roSGNode:HomeData refcnt=1 playedindicatorleftposition <uninitialized> extraprefix      <uninitialized> textextra        <uninitialized>
```

which points to this line: `if m.global.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false`

## Changes
- Validate global var before using

## Issues
Ref #1662
