### PR TITLE
Fix sporadic crash when using ItemGrid

### DIFF
--- a/components/ItemGrid/GridItem.bs
+++ b/components/ItemGrid/GridItem.bs
@@ -64,6 +64,10 @@ sub itemContentChanged()
                 end if
             end if
         end if
+
+        m.itemPoster.uri = itemData.PosterUrl
+        m.itemIcon.uri = itemData.iconUrl
+        m.itemText.text = itemData.Title
     else if itemData.type = "Boxset"
         m.itemPoster.uri = itemData.PosterUrl
         m.itemIcon.uri = itemData.iconUrl

--- a/components/ItemGrid/GridItem.bs
+++ b/components/ItemGrid/GridItem.bs
@@ -34,10 +34,13 @@ sub init()
 end sub
 
 sub itemContentChanged()
+    m.backdrop.blendColor = "#00a4db" ' set default in case global var is invalid
+    localGlobal = m.global
 
-    ' Set Random background colors from pallet
-    posterBackgrounds = m.global.constants.poster_bg_pallet
-    m.backdrop.blendColor = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    if isValid(localGlobal) and isValid(localGlobal.constants) and isValid(localGlobal.constants.poster_bg_pallet)
+        posterBackgrounds = localGlobal.constants.poster_bg_pallet
+        m.backdrop.blendColor = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    end if
 
     itemData = m.top.itemContent
 
@@ -48,21 +51,19 @@ sub itemContentChanged()
         m.itemIcon.uri = itemData.iconUrl
         m.itemText.text = itemData.Title
     else if itemData.type = "Series"
-        if m.global.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
-            if isValid(itemData.json) and isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
-                if itemData.json.UserData.UnplayedItemCount > 0
-                    m.unplayedCount.visible = true
-                    m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
-                else
-                    m.unplayedCount.visible = false
-                    m.unplayedEpisodeCount.text = ""
+        if isValid(localGlobal) and isValid(localGlobal.session) and isValid(localGlobal.session.user) and isValid(localGlobal.session.user.settings)
+            if localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"] = false
+                if isValid(itemData.json) and isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
+                    if itemData.json.UserData.UnplayedItemCount > 0
+                        m.unplayedCount.visible = true
+                        m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+                    else
+                        m.unplayedCount.visible = false
+                        m.unplayedEpisodeCount.text = ""
+                    end if
                 end if
             end if
         end if
-
-        m.itemPoster.uri = itemData.PosterUrl
-        m.itemIcon.uri = itemData.iconUrl
-        m.itemText.text = itemData.Title
     else if itemData.type = "Boxset"
         m.itemPoster.uri = itemData.PosterUrl
         m.itemIcon.uri = itemData.iconUrl


### PR DESCRIPTION
Comes from roku.com crashlog:

```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/GridItem.brs(36) Backtrace: #0  Function itemcontentchanged() As Void    file/line: pkg:/components/ItemGrid/GridItem.brs(36) Local Variables: global           Interface:ifGlobal m                roAssociativeArray refcnt=2 count:2 posterbackgrounds <uninitialized> itemdata         <uninitialized>
```
which points to this line in the bs file: `posterBackgrounds = m.global.constants.poster_bg_pallet`

## Changes
- Ensure global constant is valid before using

## Issues
Ref #1662 
