### PR TITLE
Include special characters when filtering by #

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -136,6 +136,36 @@ sub loadItems()
 
     resp = APIRequest(url, params)
     data = getJson(resp)
+
+    ' If user has filtered by #, include special characters sorted after Z as well
+    if isValid(params.NameLessThan)
+        if LCase(params.NameLessThan) = "a"
+            ' Use same params except for name filter param
+            params.NameLessThan = ""
+            params.NameStartsWithOrGreater = "z"
+
+            ' Perform 2nd API lookup for items starting with Z or greater
+            startsWithZAndGreaterResp = APIRequest(url, params)
+            startsWithZAndGreaterData = getJson(startsWithZAndGreaterResp)
+
+            if isValidAndNotEmpty(startsWithZAndGreaterData)
+                specialCharacterItems = []
+
+                ' Filter out items starting with Z
+                for each item in startsWithZAndGreaterData.Items
+                    itemName = LCase(item.name)
+                    if not itemName.StartsWith("z")
+                        specialCharacterItems.Push(item)
+                    end if
+                end for
+
+                ' Append data to results from before A
+                data.Items.Append(specialCharacterItems)
+                data.TotalRecordCount += specialCharacterItems.Count()
+            end if
+        end if
+    end if
+
     if data <> invalid
 
         if data.TotalRecordCount <> invalid then m.top.totalRecordCount = data.TotalRecordCount


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
For items that start with special characters, the server sorts some as being "Less Than" the letter A, and some as being "Greater Than" the letter Z. Our current filtering for # in the A-Z list only includes those less than A. This causes users to have no path to filter to items such as Æon Flux.

This change includes the items greater than Z with the other special characters in the # filter.

## Issues
Fixes #1296
