### PR TITLE
Replace Special episode number with "Special" in TvListDetails

### DIFF
--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -27,7 +27,9 @@ sub itemContentChanged()
         item.selectedVideoStreamId = itemData.MediaSources[0].id
     end if
 
-    if isValid(itemData.indexNumber)
+    if isValid(itemData.parentIndexNumber) and itemData.parentIndexNumber = 0
+        indexNumber = `${tr("Special")} - `
+    else if isValid(itemData.indexNumber)
         indexNumber = `${itemData.indexNumber}. `
         if isValid(itemData.indexNumberEnd)
             indexNumber = `${itemData.indexNumber}-${itemData.indexNumberEnd}. `

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1321,5 +1321,10 @@
             <translation>Use Show Image</translation>
             <extracomment>User Setting - Setting option title</extracomment>
         </message>
+        <message>
+            <source>Special</source>
+            <translation>Special</translation>
+            <extracomment>Special episode of a TV Show</extracomment>
+        </message>
     </context>
 </TS>


### PR DESCRIPTION
<!--

-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Indicate that Specials are specials when displayed in another season as well as in the Specials (Season 0) view.
-Any special episode displayed by TvListDetails will show "Special - " instead of the episode number.
-Add a translation string for "Special"

Before:
![before](https://github.com/jellyfin/jellyfin-roku/assets/116527579/9d98916e-b386-4c3b-9010-a9fd77168cf6)

After:
![after-special](https://github.com/jellyfin/jellyfin-roku/assets/116527579/18f4cf51-6bd3-4cd6-83b0-87fe62f301d7)

This PR mirrors the behavior of web. If this is merged, we may want to look at implementing something similar for #1672 
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes: #1521 