### PR TITLE
Add scenegraph inspector code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,7 @@
             // set "brightscript.debug.raleTrackerTaskFileLocation": "/absolute/path/to/rale/TrackerTask.xml" in your vscode user settings
             // set the below field to true
             "injectRaleTrackerTask": false,
+            "injectRdbOnDeviceComponent": true,
             //WARNING: don't edit this value. Instead, set "brightscript.debug.host": "YOUR_HOST_HERE" in your vscode user settings
             //"host": "${promptForHost}",
             //WARNING: don't edit this value. Instead, set "brightscript.debug.password": "YOUR_PASSWORD_HERE" in your vscode user settings

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -28,6 +28,7 @@ sub Main (args as dynamic) as void
 
     m.scene = m.screen.CreateScene("JFScene")
     m.screen.show() ' vscode_rale_tracker_entry
+    'vscode_rdb_on_device_component_entry
 
     playstateTask = CreateObject("roSGNode", "PlaystateTask")
     playstateTask.id = "playstateTask"


### PR DESCRIPTION
Added code to allow scenegraph inspector to run in vscode. This helps with stying as you can adjust values in the scenegraph inspector debug section.


<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Added this to main.brs file
'vscode_rdb_on_device_component_entry

Added this to launch.js
"injectRdbOnDeviceComponent": true"
