### PR TITLE
Update TV Season view data when user goes back to page from Video Player

### DIFF
--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -18,7 +18,7 @@ sub init()
 
     m.rows.observeField("doneLoading", "updateSeason")
 
-    m.firstShow = true
+    m.isFirstRun = true
 end sub
 
 sub setSeasonLoading()
@@ -70,9 +70,11 @@ function getFocusedItem() as dynamic
     return invalid
 end function
 
+' OnScreenShown: Callback function when view is presented on screen
+'
 sub OnScreenShown()
-    if m.firstShow
-        m.firstShow = false
+    if m.isFirstRun
+        m.isFirstRun = false
         return
     end if
 

--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -17,6 +17,8 @@ sub init()
     m.unplayedEpisodeCount = m.top.findNode("unplayedEpisodeCount")
 
     m.rows.observeField("doneLoading", "updateSeason")
+
+    m.firstShow = true
 end sub
 
 sub setSeasonLoading()
@@ -36,6 +38,8 @@ sub updateSeason()
             if m.top.seasonData.UserData.UnplayedItemCount > 0
                 m.unplayedCount.visible = true
                 m.unplayedEpisodeCount.text = m.top.seasonData.UserData.UnplayedItemCount
+            else
+                m.unplayedCount.visible = false
             end if
         end if
     end if
@@ -65,6 +69,16 @@ function getFocusedItem() as dynamic
 
     return invalid
 end function
+
+sub OnScreenShown()
+    if m.firstShow
+        m.firstShow = false
+        return
+    end if
+
+    m.tvEpisodeRow.setFocus(true)
+    m.top.refreshSeasonDetailsData = not m.top.refreshSeasonDetailsData
+end sub
 
 ' Handle navigation input from the remote and act on it
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/tvshows/TVEpisodes.xml
+++ b/components/tvshows/TVEpisodes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="TVEpisodes" extends="JFGroup">
+<component name="TVEpisodes" extends="JFScreen">
   <children>
     <Poster id="seasonPoster" width="300" height="450" translation="[95,175]">
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[210, 0]">
@@ -12,11 +12,13 @@
   </children>
   <interface>
     <field id="episodeSelected" alias="picker.itemSelected" />
+    <field id="refreshSeasonDetailsData" type="bool" alwaysNotify="true" />
     <field id="selectedItem" type="node" alwaysNotify="true" />
     <field id="quickPlayNode" type="node" />
     <field id="seasonData" type="assocarray" onChange="setSeasonLoading" />
     <field id="objects" alias="picker.objects" />
     <field id="episodeObjects" type="assocarray" />
     <field id="extrasObjects" type="assocarray" onChange="setExtraButtonVisibility" />
+    <function name="updateSeason" />
   </interface>
 </component>

--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -81,6 +81,8 @@ sub itemContentChanged()
     ' Add checkmark in corner (if applicable)
     if isValid(itemData.UserData) and isValid(itemData.UserData.Played) and itemData.UserData.Played = true
         m.playedIndicator.visible = true
+    else
+        m.playedIndicator.visible = false
     end if
 
     ' Add progress bar on bottom (if applicable)
@@ -90,6 +92,9 @@ sub itemContentChanged()
         progressWidthInPixels = int(m.progressBackground.width * itemData.UserData.PlayedPercentage / 100)
         m.progressBar.width = progressWidthInPixels
         m.progressBar.visible = true
+    else
+        m.progressBackground.visible = false
+        m.progressBar.visible = false
     end if
 
     ' Display current video_codec and check if there is more than one video to choose from...

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -212,6 +212,26 @@ sub Main (args as dynamic) as void
             end if
             elapsed = timeSpan.TotalMilliseconds() / 1000
             print "Quick Play finished loading in " + elapsed.toStr() + " seconds."
+        else if isNodeEvent(msg, "refreshSeasonDetailsData")
+            startLoadingSpinner()
+
+            currentEpisode = m.global.queueManager.callFunc("getCurrentItem")
+            currentScene = m.global.sceneManager.callFunc("getActiveScene")
+
+            ' Find the object in the scene's data and update its json data
+            for i = 0 to currentScene.objects.Items.count() - 1
+                if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
+                    currentScene.objects.Items[i].json = TVEpisode(currentEpisode.id).Items[0].json
+                    exit for
+                end if
+            end for
+
+            seasonMetaData = ItemMetaData(currentScene.seasonData.id)
+            currentScene.seasonData = seasonMetaData.json
+            currentScene.episodeObjects = currentScene.objects
+            currentScene.callFunc("updateSeason")
+            stopLoadingSpinner()
+
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow
             selectedItem = msg.getData()

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -221,7 +221,8 @@ sub Main (args as dynamic) as void
             ' Find the object in the scene's data and update its json data
             for i = 0 to currentScene.objects.Items.count() - 1
                 if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
-                    currentScene.objects.Items[i].json = TVEpisode(currentEpisode.id).Items[0].json
+                    currentScene.objects.Items[i].json = api.users.GetItem(m.global.session.user.id, currentEpisode.id)
+                    m.global.queueManager.callFunc("setTopStartingPoint", currentScene.objects.Items[i].json.UserData.PlaybackPositionTicks)
                     exit for
                 end if
             end for

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -781,6 +781,8 @@ function CreateSeasonDetailsGroup(series as object, season as object) as dynamic
     group.episodeObjects = group.objects
     group.extrasObjects = TVSeasonExtras(season.id)
 
+    group.observeField("refreshSeasonDetailsData", m.port)
+
     ' watch for button presses
     group.observeField("selectedItem", m.port)
     group.observeField("quickPlayNode", m.port)

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -425,6 +425,36 @@ function TVSeasons(id as string) as dynamic
     return data
 end function
 
+' Returns a single episode of a TV Show
+' Accepts a GUID string for the TV Episode Id
+function TVEpisode(episodeId as string) as dynamic
+    ' Get and validate data
+    data = api.users.GetItemsByQuery(m.global.session.user.id, {
+        "fields": "MediaStreams,MediaSources",
+        "ids": episodeId
+    })
+    if data = invalid or data.Items = invalid then return invalid
+
+    results = []
+    for each item in data.Items
+        tmp = CreateObject("roSGNode", "TVEpisodeData")
+        tmp.image = PosterImage(item.id, { "maxWidth": 400, "maxheight": 250 })
+        if isValid(tmp.image)
+            tmp.image.posterDisplayMode = "scaleToZoom"
+        end if
+        tmp.json = item
+        tmpMetaData = ItemMetaData(item.id)
+
+        ' validate meta data
+        if isValid(tmpMetaData) and isValid(tmpMetaData.overview)
+            tmp.overview = tmpMetaData.overview
+        end if
+        results.push(tmp)
+    end for
+    data.Items = results
+    return data
+end function
+
 ' Returns a list of TV Shows for a given TV Show and season
 ' Accepts strings for the TV Show Id and the season Id
 function TVEpisodes(showId as string, seasonId as string) as dynamic

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -425,36 +425,6 @@ function TVSeasons(id as string) as dynamic
     return data
 end function
 
-' Returns a single episode of a TV Show
-' Accepts a GUID string for the TV Episode Id
-function TVEpisode(episodeId as string) as dynamic
-    ' Get and validate data
-    data = api.users.GetItemsByQuery(m.global.session.user.id, {
-        "fields": "MediaStreams,MediaSources",
-        "ids": episodeId
-    })
-    if data = invalid or data.Items = invalid then return invalid
-
-    results = []
-    for each item in data.Items
-        tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.image = PosterImage(item.id, { "maxWidth": 400, "maxheight": 250 })
-        if isValid(tmp.image)
-            tmp.image.posterDisplayMode = "scaleToZoom"
-        end if
-        tmp.json = item
-        tmpMetaData = ItemMetaData(item.id)
-
-        ' validate meta data
-        if isValid(tmpMetaData) and isValid(tmpMetaData.overview)
-            tmp.overview = tmpMetaData.overview
-        end if
-        results.push(tmp)
-    end for
-    data.Items = results
-    return data
-end function
-
 ' Returns a list of TV Shows for a given TV Show and season
 ' Accepts strings for the TV Show Id and the season Id
 function TVEpisodes(showId as string, seasonId as string) as dynamic


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
1. Updates resume point for last watched episode on TV Season view.
2. Re-evaluates episode watched check mark
3. Re-evaluates episode watched percentage bar
4. Re-evaluates season unwatched episode number

## Issues
Fixes #1748
