### PR TITLE
Update resume state when you press back when watching movie

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -1,6 +1,13 @@
 import "pkg:/source/utils/misc.bs"
 import "pkg:/source/utils/config.bs"
 
+' Valid lost status values for view
+enum LoadStatus
+    init = 0
+    firstLoad = 1
+    reload = 2
+end enum
+
 sub init()
     m.extrasGrp = m.top.findnode("extrasGrp")
     m.extrasGrid = m.top.findNode("extrasGrid")
@@ -21,9 +28,45 @@ sub init()
     m.buttonGrp.setFocus(true)
     m.top.lastFocus = m.buttonGrp
 
+    m.loadStatus = LoadStatus.init
     m.top.observeField("itemContent", "itemContentChanged")
+
+    ' Animation used to swap out posters on reloads
+    m.moviePosterSwapAnimation = m.top.findNode("moviePosterSwapAnimation")
+    m.moviePosterSwapAnimation.observeField("state", "onMoviePosterSwapAnimationStateChange")
+
+    m.top.observeField("newPosterImageURI", "onNewPosterImageURIChange")
+
+    m.moviePoster = m.top.findNode("moviePoster")
+    m.moviePosterSwap = m.top.findNode("moviePosterSwap")
+    m.moviePosterSwap.observeField("loadStatus", "onPosterLoadStatusChanged")
 end sub
 
+' onNewPosterImageURIChange: Handler for newPosterImageURI param change
+'
+sub onNewPosterImageURIChange()
+    m.moviePosterSwap.uri = m.top.newPosterImageURI
+end sub
+
+' onPosterLoadStatusChanged: Handler for changes to m.moviePosterSwap.loadStatus
+'
+sub onPosterLoadStatusChanged()
+    if LCase(m.moviePosterSwap.loadStatus) <> "ready" then return
+    m.moviePosterSwapAnimation.control = "start"
+end sub
+
+' onMoviePosterSwapAnimationStateChange: Handler for changes to m.moviePosterSwapAnimation.state
+'
+sub onMoviePosterSwapAnimationStateChange()
+    if LCase(m.moviePosterSwapAnimation.state) <> "stopped" then return
+    m.moviePoster.uri = m.moviePosterSwap.uri
+    m.moviePoster.opacity = 1
+    m.moviePosterSwap.opacity = 0
+    m.moviePosterSwap.uri = ""
+end sub
+
+' OnScreenShown: Callback function when view is presented on screen
+'
 sub OnScreenShown()
     ' set focus to button group
     if m.extrasGrp.opacity = 1
@@ -31,6 +74,15 @@ sub OnScreenShown()
     else
         m.buttonGrp.setFocus(true)
     end if
+
+    if m.loadStatus = LoadStatus.init
+        m.loadStatus = LoadStatus.firstLoad
+        return
+    end if
+
+    m.loadStatus = LoadStatus.reload
+
+    m.top.refreshMovieDetailsData = not m.top.refreshMovieDetailsData
 end sub
 
 sub trailerAvailableChanged()
@@ -56,6 +108,10 @@ sub itemContentChanged()
     itemData = item.json
     m.top.id = itemData.id
     m.top.findNode("moviePoster").uri = m.top.itemContent.posterURL
+    setWatchedColor()
+
+    ' We dont' need to update everything if this is a reload
+    if m.loadStatus = LoadStatus.reload then return
 
     ' Set default video source if user hasn't selected one yet
     if m.top.selectedVideoStreamId = "" and isValid(itemData.MediaSources)
@@ -144,7 +200,6 @@ sub itemContentChanged()
     end if
 
     setFavoriteColor()
-    setWatchedColor()
     SetUpVideoOptions(itemData.mediaSources)
     SetUpAudioOptions(itemData.mediaStreams)
     m.buttonGrp.visible = true

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="MovieDetails" extends="JFScreen">
   <children>
+    <Poster id="moviePosterSwap" translation="[96,175]" width="300" height="450" />
+
     <LayoutGroup id="main_group" layoutDirection="horiz" itemSpacings="[30]">
       <Poster id="moviePoster" translation="[250,150]" width="300" height="450" />
       <LayoutGroup layoutDirection="vert" translation="[455, 150]" itemSpacings="[25]" id="details">
@@ -43,12 +45,19 @@
 
     <!-- "Cast and Crew" row -->
     <extrasSlider id="movieExtras" />
+
+    <Animation id="moviePosterSwapAnimation" duration="1" repeat="false" easeFunction="linear">
+      <FloatFieldInterpolator id="fadeinLoading" key="[0.0, 1.0]" keyValue="[ 0.00, 1.00 ]" fieldToInterp="moviePosterSwap.opacity" />
+      <FloatFieldInterpolator id="fadeoutLoaded" key="[0.0, 1.0]" keyValue="[ 1.00, 0.00 ]" fieldToInterp="moviePoster.opacity" />
+    </Animation>
   </children>
   <interface>
     <field id="itemContent" type="node" />
     <field id="trailerAvailable" type="bool" onChange="trailerAvailableChanged" value="false" />
     <field id="selectedAudioStreamIndex" type="integer" />
     <field id="selectedVideoStreamId" type="string" />
+    <field id="newPosterImageURI" type="string" />
     <field id="quickPlayNode" type="node" alwaysNotify="true" />
+    <field id="refreshMovieDetailsData" type="bool" alwaysNotify="true" />
   </interface>
 </component>

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -212,6 +212,23 @@ sub Main (args as dynamic) as void
             end if
             elapsed = timeSpan.TotalMilliseconds() / 1000
             print "Quick Play finished loading in " + elapsed.toStr() + " seconds."
+        else if isNodeEvent(msg, "refreshMovieDetailsData")
+            startLoadingSpinner()
+
+            currentScene = m.global.sceneManager.callFunc("getActiveScene")
+
+            ' Refresh movie detail data
+            currentScene.itemContent.json = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
+            movieMetaData = ItemMetaData(currentScene.itemContent.id)
+
+            ' Redraw movie poster
+            currentScene.newPosterImageURI = movieMetaData.posterURL
+
+            ' Set updated starting point for the queue item
+            m.global.queueManager.callFunc("setTopStartingPoint", currentScene.itemContent.json.UserData.PlaybackPositionTicks)
+
+            stopLoadingSpinner()
+
         else if isNodeEvent(msg, "selectedItem")
             ' If you select a library from ANYWHERE, follow this flow
             selectedItem = msg.getData()

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -608,6 +608,9 @@ function CreateMovieDetailsGroup(movie as object) as dynamic
     ' push scene asap (to prevent extra button presses when retriving series/movie info)
     m.global.sceneManager.callFunc("pushScene", group)
     group.itemContent = movieMetaData
+
+    group.observeField("refreshMovieDetailsData", m.port)
+
     ' local trailers
     trailerData = api.users.GetLocalTrailers(m.global.session.user.id, movie.id)
     if isValid(trailerData)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes

1. Updates resume point for movie when you return to Movie Detail view from Video Player
2. Updates poster image with new resume point data using transition to prevent flicker

## Issues
Fixes #1647
