### PR TITLE
Use scaleToZoom for user profile image

### DIFF
--- a/components/login/UserItem.xml
+++ b/components/login/UserItem.xml
@@ -2,7 +2,7 @@
 <component name="UserItem" extends="Group">
   <children>
     <LayoutGroup layoutDirection="vert">
-      <Poster id="profileImage" width="300" height="300" />
+      <Poster id="profileImage" width="300" height="300" loadDisplayMode="scaleToZoom" />
       <Label id="profileName" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" color="#EBEBEB" height="64" width="300" />
     </LayoutGroup>
   </children>


### PR DESCRIPTION

## Changes
Use `scaleToZoom` instead of the default `noScale` for the user profile images on the UserSelect view. See docs [here](https://developer.roku.com/docs/references/scenegraph/renderable-nodes/poster.md#fields)

## Issues
Fixes #1780 
