### PR TITLE
Fix app crash when refreshing movie detail screen

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -237,15 +237,17 @@ sub Main (args as dynamic) as void
 
             currentScene = m.global.sceneManager.callFunc("getActiveScene")
 
-            ' Refresh movie detail data
-            currentScene.itemContent.json = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
-            movieMetaData = ItemMetaData(currentScene.itemContent.id)
+            if isValid(currentScene) and isValid(currentScene.itemContent) and isValid(currentScene.itemContent.id) and isValid(currentScene.itemContent.json)
+                ' Refresh movie detail data
+                currentScene.itemContent.json = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
+                movieMetaData = ItemMetaData(currentScene.itemContent.id)
 
-            ' Redraw movie poster
-            currentScene.newPosterImageURI = movieMetaData.posterURL
+                ' Redraw movie poster
+                currentScene.newPosterImageURI = movieMetaData.posterURL
 
-            ' Set updated starting point for the queue item
-            m.global.queueManager.callFunc("setTopStartingPoint", currentScene.itemContent.json.UserData.PlaybackPositionTicks)
+                ' Set updated starting point for the queue item
+                m.global.queueManager.callFunc("setTopStartingPoint", currentScene.itemContent.json.UserData.PlaybackPositionTicks)
+            end if
 
             stopLoadingSpinner()
         else if isNodeEvent(msg, "selectedItem")

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -237,7 +237,7 @@ sub Main (args as dynamic) as void
 
             currentScene = m.global.sceneManager.callFunc("getActiveScene")
 
-            if isValid(currentScene) and isValid(currentScene.itemContent) and isValid(currentScene.itemContent.id) and isValid(currentScene.itemContent.json)
+            if isValid(currentScene) and isValid(currentScene.itemContent) and isValid(currentScene.itemContent.id)
                 ' Refresh movie detail data
                 currentScene.itemContent.json = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
                 movieMetaData = ItemMetaData(currentScene.itemContent.id)


### PR DESCRIPTION
Remake of #1833

Ensure data is valid before using to prevent app crash. This comes from the roku crash log and is by far the worst offender right now.

![roku-208-crashlog](https://github.com/user-attachments/assets/dedd3f94-0e12-41c6-a590-9d19c2d30f1d)


Crashlog: 
```

'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(226) 
Backtrace: 
#0  Function main(args As Dynamic) As Voi$1 file/line: pkg:/source/Main.brs(226) 
Local Variables: 
args             roAssociativeArray refcnt=2 count:4 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:6 
playstatetask    roSGNode:PlaystateTask refcnt=1 
scenemanager     roSGNode:SceneManager refcnt=1 
group            roSGNode:MovieDetails refcnt=1 
configencoding   roAssociativeArray refcnt=1 count:43 
re               <uninitialized> 
filename         <uninitialized> 
userslastrunversion roString refcnt=1 val:"2.0.8" 
dialog           <uninitialized> 
input            roInput refcnt=1 
device           roDeviceInfo refcnt=1 
deeplinkvideo    <uninitialized> 
msg              roSGNodeEvent refcnt=1 
timespan         <uninitialized> 
reportingnode    <uninitialized> 
itemnode         <uninitialized> 
reportingnodetype <uninitialized> 
itemtype         <uninitialized> 
elapsed          <uninitialized> 
currentepisode   <uninitialized> 
currentscene     roSGNode:MovieLibraryView refcnt=1 
i                <uninitialized> 
seasonmetadata   <uninitialized> 
moviemetadata    <uninitialized> 
selecteditem     roSGNode:MovieData refcnt=1 
selecteditemtype roString refcnt=1 val:"Movie" 
audio_stream_idx roInt refcnt=1 val:5 (&h5) 
showplaybackoptiondialog <uninitialized> 
photoalbumdata   <uninitialized> 
photoplayer      <uninitialized> 
node             <uninitialized> 
ptr              <uninitialized> 
series           <uninitialized> 
albums           <uninitialized> 
selectedindex    <uninitialized> 
screencontent    <uninitialized> 
viewhandled      <uninitialized> 
query            <uninitialized> 
options          <uninitialized> 
results          <uninitialized> 
btn              roSGNode:Button refcnt=1 
buttons          <uninitialized> 
trailerdata      <uninitialized> 
movie            <uninitialized> 
button           <uninitialized> 
panel            <uninitialized> 
trackselected    <uninitialized> 
info             <uninitialized> 
video            <uninitialized> 
retryvideo       <uninitialized> 
event            roAssociativeArray refcnt=1 count:2 
tmpglobaldevice  <uninitialized> 
posttask         <uninitialized> 
inputeventvideo  <uninitialized> 
popupnode        <uninitialized> 
startingpoint    <uninitialized>
```

Which points to this line after running build-prod on 2.0.8:
```
currentScene.itemContent.json = api_users_GetItem(m.global.session.user.id, currentScene.itemContent.id)
```

## Issues
Introduced in #1771 
Ref #1164
