### PR TITLE
Fix app crashes when refreshing episode list view

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -215,22 +215,28 @@ sub Main (args as dynamic) as void
         else if isNodeEvent(msg, "refreshSeasonDetailsData")
             startLoadingSpinner()
 
-            currentEpisode = m.global.queueManager.callFunc("getCurrentItem")
             currentScene = m.global.sceneManager.callFunc("getActiveScene")
 
-            ' Find the object in the scene's data and update its json data
-            for i = 0 to currentScene.objects.Items.count() - 1
-                if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
-                    currentScene.objects.Items[i].json = api.users.GetItem(m.global.session.user.id, currentEpisode.id)
-                    m.global.queueManager.callFunc("setTopStartingPoint", currentScene.objects.Items[i].json.UserData.PlaybackPositionTicks)
-                    exit for
-                end if
-            end for
+            if isValid(currentScene) and isValid(currentScene.objects) and isValid(currentScene.seasonData)
+                currentEpisode = m.global.queueManager.callFunc("getCurrentItem")
 
-            seasonMetaData = ItemMetaData(currentScene.seasonData.id)
-            currentScene.seasonData = seasonMetaData.json
-            currentScene.episodeObjects = currentScene.objects
-            currentScene.callFunc("updateSeason")
+                if isValid(currentScene.objects.Items) and isValid(currentEpisode) and isValid(currentEpisode.id)
+                    ' Find the object in the scene's data and update its json data
+                    for i = 0 to currentScene.objects.Items.count() - 1
+                        if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
+                            currentScene.objects.Items[i].json = api.users.GetItem(m.global.session.user.id, currentEpisode.id)
+                            m.global.queueManager.callFunc("setTopStartingPoint", currentScene.objects.Items[i].json.UserData.PlaybackPositionTicks)
+                            exit for
+                        end if
+                    end for
+                end if
+
+                seasonMetaData = ItemMetaData(currentScene.seasonData.id)
+                currentScene.seasonData = seasonMetaData.json
+                currentScene.episodeObjects = currentScene.objects
+                currentScene.callFunc("updateSeason")
+            end if
+
             stopLoadingSpinner()
         else if isNodeEvent(msg, "refreshMovieDetailsData")
             startLoadingSpinner()


### PR DESCRIPTION
Ensure data is valid before using to prevent app crash. This comes from the roku crash log and fixes numbers 2 and 3 on this list:

![roku-208-crashlog](https://github.com/user-attachments/assets/dedd3f94-0e12-41c6-a590-9d19c2d30f1d)


Crashlog: 
```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(210) 

'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(211) 
```

210 points to this line after running build-prod on 2.0.8:
```
for i = 0 to currentScene.objects.Items.count() - 1
```
211 points to this line after running build-prod on 2.0.8:
```
if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
```

## Issues
Introduced in #1749
Ref #1164 