### PR TITLE
Fix invalid movie data crash

### DIFF
--- a/components/data/MovieData.bs
+++ b/components/data/MovieData.bs
@@ -4,6 +4,7 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setFields()
+    if not isValid(m.top.json) then return
     json = m.top.json
 
     m.top.id = json.id


### PR DESCRIPTION
Ensure data is valid before using to prevent app crash. This comes from the roku.com crash log


Crashlog: 
```
source           <uninitialized> 
json             Invali$1 m                roAssociativeArray refcnt=2 count:2 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/data/MovieData.brs(8) 
#0  Function setfields() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/data/MovieData.brs(8)
```

Which points to this line after running build-prod on 2.0.8:
```
m.top.id = json.id
```

## Changes
- validate data to prevent crash

## Issues
Ref #1164
