### PR TITLE
Fix invalid episode data crash

### DIFF
--- a/components/data/TVEpisodeData.bs
+++ b/components/data/TVEpisodeData.bs
@@ -13,7 +13,7 @@ sub setFields()
 end sub
 
 sub setPoster()
-    if m.top.image <> invalid
+    if isValid(m.top.image)
         m.top.posterURL = m.top.image.url
     else
         m.top.posterURL = ""

--- a/components/data/TVEpisodeData.bs
+++ b/components/data/TVEpisodeData.bs
@@ -1,4 +1,7 @@
+import "pkg:/source/utils/misc.bs"
+
 sub setFields()
+    if not isValid(m.top.json) then return
     datum = m.top.json
 
     m.top.id = datum.id


### PR DESCRIPTION
Ensure data is valid before using to prevent app crash. This comes from the roku.com crash log


Crashlog: 
```
datum            Invali$1 m                roAssociativeArray refcnt=2 count:2 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/data/TVEpisodeData.brs(3) 
#0  Function setfields() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/data/TVEpisodeData.brs(3)
```

Which points to this line after running build-prod on 2.0.8:
```
m.top.id = datum.id
```

## Changes
- validate data to prevent crash

## Issues
Ref #1164
