### PR TITLE
 Fix app crash when refreshing episode list view

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -232,7 +232,7 @@ sub Main (args as dynamic) as void
                 end if
 
                 seasonMetaData = ItemMetaData(currentScene.seasonData.id)
-                currentScene.seasonData = seasonMetaData.json
+                if isValid(seasonMetaData) then currentScene.seasonData = seasonMetaData.json
                 currentScene.episodeObjects = currentScene.objects
                 currentScene.callFunc("updateSeason")
             end if


### PR DESCRIPTION
Missed this one when I was doing #1837

Ensure season meta data is valid before using to prevent app crash. This comes from the roku crash log.



Crashlog: 
```

startingpoint    <uninitialized> 
popupnode        roSGNode:SceneManager refcnt=1 
inputeventvideo  <uninitialized> 
posttask         <uninitialized> 
tmpglobaldevice  <uninitialized> 
event            roAssociativeArray refcnt=1 count:2 
retryvideo       <uninitialized> 
video            <uninitialized> 
info             <uninitialized> 
trackselected    <uninitialized> 
panel            <uninitialized> 
button           <uninitialized> 
movie            <uninitialized> 
trailerdata      <uninitialized> 
buttons          <uninitialized> 
btn              <uninitialized> 
results          <uninitialized> 
options          <uninitialized> 
query            <uninitialized> 
viewhandled      <uninitialized> 
screencontent    <uninitialized> 
selectedindex    <uninitialized> 
albums           <uninitialized> 
series           roSGNode:TVShowDetails refcnt=1 
ptr              roArray refcnt=1 count:2 
node             roSGNode:TVSeasonData refcnt=1 
photoplayer      <uninitialized> 
photoalbumdata   <uninitialized> 
showplaybackoptiondialog <uninitialized> 
audio_stream_idx Integer val:0 (&h0) 
selecteditemtype roString refcnt=1 val:"Episode" 
selecteditem     roInvalid refcnt=1 
moviemetadata    <uninitialized> 
seasonmetadata   Invali$1 i                Integer val:27 (&h1B) 
currentscene     roSGNode:TVEpisodes refcnt=1 
currentepisode   roAssociativeArray refcnt=1 count:29 
elapsed          <uninitialized> 
itemtype         <uninitialized> 
reportingnodetype <uninitialized> 
itemnode         <uninitialized> 
reportingnode    <uninitialized> 
timespan         <uninitialized> 
msg              roSGNodeEvent refcnt=1 
deeplinkvideo    <uninitialized> 
device           roDeviceInfo refcnt=1 
input            roInput refcnt=1 
dialog           <uninitialized> 
userslastrunversion roString refcnt=1 val:"2.0.8" 
filename         <uninitialized> 
re               <uninitialized> 
configencoding   roAssociativeArray refcnt=1 count:33 
group            roSGNode:TVEpisodes refcnt=1 
scenemanager     roSGNode:SceneManager refcnt=1 
playstatetask    roSGNode:PlaystateTask refcnt=1 
m                roAssociativeArray refcnt=2 count:6 
global           Interface:ifGloba$1 args             roAssociativeArray refcnt=2 count:4 
Local Variables: 
   file/line: pkg:/source/Main.brs(218) 
#0  Function main(args As Dynamic) As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(218)
```

which points to this line after running build-prod on 2.0.8:
```
currentScene.seasonData = seasonMetaData.json
```

## Issues
Introduced in #1749
Ref #1164 