### PR TITLE
Add View All for Next Up

### DIFF
--- a/components/ItemGrid/GridItem.bs
+++ b/components/ItemGrid/GridItem.bs
@@ -114,10 +114,18 @@ sub itemContentChanged()
         end if
         ' Adjust to wide posters for "View All Next Up"
         if m.topParent.overhangTitle = tr("View All Next Up")
-            m.itemPoster.height = 331
-            m.itemPoster.width = 464
+            m.posterMask.maskUri = ""
+
+            m.itemPoster.height = 300
+            m.itemPoster.width = 400
+            m.itemPoster.loadDisplayMode = "scaleToFit"
+
+            m.backdrop.height = 300
+            m.backdrop.width = 400
+            m.backdrop.loadDisplayMode = "scaleToFit"
+
             m.itemText.translation = [0, m.itemPoster.height + 7]
-            m.itemText.maxWidth = 464
+            m.itemText.maxWidth = 400
         end if
     else if itemData.type = "MusicArtist"
         m.itemPoster.uri = itemData.PosterUrl

--- a/components/ItemGrid/GridItem.bs
+++ b/components/ItemGrid/GridItem.bs
@@ -112,6 +112,13 @@ sub itemContentChanged()
         else
             m.itemText.text = itemData.Title
         end if
+        ' Adjust to wide posters for "View All Next Up"
+        if m.topParent.overhangTitle = tr("View All Next Up")
+            m.itemPoster.height = 331
+            m.itemPoster.width = 464
+            m.itemText.translation = [0, m.itemPoster.height + 7]
+            m.itemText.maxWidth = 464
+        end if
     else if itemData.type = "MusicArtist"
         m.itemPoster.uri = itemData.PosterUrl
         m.itemText.text = itemData.Title

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -198,6 +198,15 @@ sub loadInitialItems()
             ' non recursive for collections (folders, boxsets, photo albums, etc)
             m.loadItemsTask.recursive = false
         end if
+
+        if getCollectionType() = "nextup"
+            m.loadItemsTask.itemType = "NextUp"
+            m.itemGrid.itemSize = "[464, 331]"
+            m.itemGrid.itemSpacing = "[5, 5]"
+            m.top.imageDisplayMode = "scaleToFit"
+            m.itemGrid.numColumns = 3
+            m.alpha.visible = false
+        end if
     else if m.top.parentItem.json.type = "Studio"
         m.loadItemsTask.itemId = m.top.parentItem.parentFolder
         m.loadItemsTask.itemType = "Series,Movie"
@@ -357,6 +366,12 @@ sub setPhotoAlbumOptions(options)
     options.filter = []
 end sub
 
+sub setupViewAllNextUpOptions(options)
+    options.views = []
+    options.sort = []
+    options.filter = []
+end sub
+
 ' Set Default view, sort, and filter options
 sub setDefaultOptions(options)
     options.views = [
@@ -402,7 +417,8 @@ sub SetUpOptions()
         setPhotoAlbumOptions(options)
     else if getCollectionType() = "music"
         setMusicOptions(options)
-
+    else if getCollectionType() = "nextup"
+        setupViewAllNextUpOptions(options)
     else
         setDefaultOptions(options)
     end if
@@ -836,7 +852,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.top.quickPlayNode = itemToPlay
             return true
         end if
-    else if key = "left" and topGrp.isinFocusChain()
+    else if key = "left" and topGrp.isinFocusChain() and m.alpha.focusable
         m.top.alphaActive = true
         topGrp.setFocus(false)
         m.alphaMenu.setFocus(true)

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -843,7 +843,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.top.quickPlayNode = itemToPlay
             return true
         end if
-    else if key = "left" and topGrp.isinFocusChain() and m.alpha.focusable
+    else if key = "left" and topGrp.isinFocusChain() and m.alpha.visible
         m.top.alphaActive = true
         topGrp.setFocus(false)
         m.alphaMenu.setFocus(true)

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -366,12 +366,6 @@ sub setPhotoAlbumOptions(options)
     options.filter = []
 end sub
 
-sub setupViewAllNextUpOptions(options)
-    options.views = []
-    options.sort = []
-    options.filter = []
-end sub
-
 ' Set Default view, sort, and filter options
 sub setDefaultOptions(options)
     options.views = [
@@ -417,8 +411,6 @@ sub SetUpOptions()
         setPhotoAlbumOptions(options)
     else if getCollectionType() = "music"
         setMusicOptions(options)
-    else if getCollectionType() = "nextup"
-        setupViewAllNextUpOptions(options)
     else
         setDefaultOptions(options)
     end if
@@ -802,7 +794,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         searchGrp.setFocus(false)
     end if
 
-    if key = "options"
+    if key = "options" and getCollectionType() <> "nextup"
         if m.options.visible = true
             m.options.visible = false
             m.top.removeChild(m.options)

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -201,10 +201,9 @@ sub loadInitialItems()
 
         if getCollectionType() = "nextup"
             m.loadItemsTask.itemType = "NextUp"
-            m.itemGrid.itemSize = "[464, 331]"
-            m.itemGrid.itemSpacing = "[5, 5]"
+            m.itemGrid.itemSize = "[400, 300]"
             m.top.imageDisplayMode = "scaleToFit"
-            m.itemGrid.numColumns = 3
+            m.itemGrid.numColumns = 4
             m.alpha.visible = false
         end if
     else if m.top.parentItem.json.type = "Studio"

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -201,9 +201,7 @@ sub loadItems()
                 tmp = CreateObject("roSGNode", "TVEpisode")
                 if LCase(m.top.ItemType) = "nextup"
                     tmp.title = item.name
-                    tmp.json = item
                     tmp.type = "Episode"
-                    tmp.posterUrl = api.items.GetImageURL(item.id, "primary", 0, { "maxHeight": 331, "maxWidth": 464, "quality": "90" })
                 end if
             else if LCase(item.Type) = "recording"
                 tmp = CreateObject("roSGNode", "RecordingData")
@@ -292,7 +290,7 @@ sub loadItems()
             end if
 
             if tmp <> invalid
-                if LCase(item.Type) <> "genre" and LCase(item.Type) <> "musicgenre" and LCase(m.top.ItemType) <> "nextup"
+                if LCase(item.Type) <> "genre" and LCase(item.Type) <> "musicgenre"
                     tmp.parentFolder = m.top.itemId
                     tmp.json = item
                     if item.UserData <> invalid and item.UserData.isFavorite <> invalid

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -130,6 +130,11 @@ sub loadItems()
         url = Substitute("Users/{0}/Items/", m.global.session.user.id)
         params.append({ ImageTypeLimit: 1 })
         params.append({ EnableImageTypes: "Primary,Backdrop,Banner,Thumb" })
+    else if LCase(m.top.ItemType) = "nextup"
+        url = "Shows/NextUp"
+        params.limit = 100 ' If you have more than 100 in your Next Up queue, maybe go outside a bit more.
+        params.append({ ImageTypeLimit: 1 })
+        params.append({ EnableImageTypes: "Primary,Backdrop,Banner,Thumb" })
     else
         url = Substitute("Users/{0}/Items/", m.global.session.user.id)
     end if
@@ -194,6 +199,12 @@ sub loadItems()
                 tmp.image = PosterImage(item.id, { "maxHeight": 425, "maxWidth": 290, "quality": "90" })
             else if item.type = "Episode"
                 tmp = CreateObject("roSGNode", "TVEpisode")
+                if LCase(m.top.ItemType) = "nextup"
+                    tmp.title = item.name
+                    tmp.json = item
+                    tmp.type = "Episode"
+                    tmp.posterUrl = api.items.GetImageURL(item.id, "primary", 0, { "maxHeight": 331, "maxWidth": 464, "quality": "90" })
+                end if
             else if LCase(item.Type) = "recording"
                 tmp = CreateObject("roSGNode", "RecordingData")
             else if item.Type = "Genre"
@@ -281,7 +292,7 @@ sub loadItems()
             end if
 
             if tmp <> invalid
-                if item.Type <> "Genre" and item.Type <> "MusicGenre"
+                if LCase(item.Type) <> "genre" and LCase(item.Type) <> "musicgenre" and LCase(m.top.ItemType) <> "nextup"
                     tmp.parentFolder = m.top.itemId
                     tmp.json = item
                     if item.UserData <> invalid and item.UserData.isFavorite <> invalid

--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -27,9 +27,9 @@ sub setData()
         end if
 
         ' Add Icon URLs for display if there is no Poster
-        if LCase(datum.CollectionType) = "livetv"
+        if LCase(m.top.CollectionType) = "livetv"
             m.top.iconUrl = "pkg:/images/media_type_icons/live_tv_white.png"
-        else if LCase(datum.CollectionType) = "folders" or LCase(datum.CollectionType) = "nextup"
+        else if LCase(m.top.CollectionType) = "folders" or LCase(m.top.CollectionType) = "nextup"
             m.top.iconUrl = "pkg:/images/media_type_icons/folder_white.png"
         end if
 

--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -19,15 +19,17 @@ sub setData()
 
     ' Set appropriate Images for Wide and Tall based on type
 
-    if datum.type = "CollectionFolder" or datum.type = "UserView"
-        params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
-        m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
-        m.top.widePosterUrl = m.top.thumbnailURL
+    if LCase(datum.type) = "collectionfolder" or LCase(datum.type) = "userview"
+        if IsValid(datum.ImageTags)
+            params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
+            m.top.thumbnailURL = ImageURL(datum.id, "Primary", params)
+            m.top.widePosterUrl = m.top.thumbnailURL
+        end if
 
         ' Add Icon URLs for display if there is no Poster
-        if datum.CollectionType = "livetv"
+        if LCase(datum.CollectionType) = "livetv"
             m.top.iconUrl = "pkg:/images/media_type_icons/live_tv_white.png"
-        else if datum.CollectionType = "folders"
+        else if LCase(datum.CollectionType) = "folders" or LCase(datum.CollectionType) = "nextup"
             m.top.iconUrl = "pkg:/images/media_type_icons/folder_white.png"
         end if
 

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -85,6 +85,9 @@ sub loadItems()
             end if
         end if
 
+        addViewAll = true ' Assume there will be a "View All" to start
+        checkViewAll = false ' Only need to check if we don't have anything in the Next Up home row
+
         resp = APIRequest(url, params)
         data = getJson(resp)
         if isValid(data) and isValid(data.Items)
@@ -93,22 +96,36 @@ sub loadItems()
                 tmp.json = item
                 results.push(tmp)
             end for
-            ' Add "View All"
-            ' Note: Unfortunately you could have 0 items show up on the home screen and still have
-            ' a bunch of items in NextUp that are > 365 days old.  However, checking here for at
-            ' least 1 item in Next Up means you won't have a "Next Up" section with nothing but a single View All folder.
-            if data.Items.Count() > 0
-                tmp = CreateObject("roSGNode", "HomeData")
-                tmp.type = "CollectionFolder"
-                tmp.usePoster = false
-                tmp.json = {
-                    IsFolder: true,
-                    Name: tr("View All Next Up"),
-                    Type: "CollectionFolder",
-                    CollectionType: "nextup"
-                }
-                results.push(tmp)
+            if data.Items.Count() = 0
+                checkViewAll = true
             end if
+        else
+            checkViewAll = true
+        end if
+
+        ' Add "View All"
+        if checkViewAll
+            ' Nothing to show in Next Up, but are there hidden items (e.g. > 365 days old)?
+            params.Delete("NextUpDateCutoff")
+            params["limit"] = 1 ' if there is even one, then we know we need to show "View All"
+            resp = APIRequest(url, params)
+            data = getJson(resp)
+            if not isValid(data) or isValid(data) and isValid(data.Items) and data.Items.Count() = 0
+                addViewAll = false
+            end if
+        end if
+
+        if addViewAll
+            tmp = CreateObject("roSGNode", "HomeData")
+            tmp.type = "CollectionFolder"
+            tmp.usePoster = false
+            tmp.json = {
+                IsFolder: true,
+                Name: tr("View All Next Up"),
+                Type: "CollectionFolder",
+                CollectionType: "nextup"
+            }
+            results.push(tmp)
         end if
         ' Load Continue Watching
     else if m.top.itemsToLoad = "continue"

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -94,16 +94,21 @@ sub loadItems()
                 results.push(tmp)
             end for
             ' Add "View All"
-            tmp = CreateObject("roSGNode", "HomeData")
-            tmp.type = "CollectionFolder"
-            tmp.usePoster = false
-            tmp.json = {
-                IsFolder: true,
-                Name: tr("View All Next Up"),
-                Type: "CollectionFolder",
-                CollectionType: "nextup"
-            }
-            results.push(tmp)
+            ' Note: Unfortunately you could have 0 items show up on the home screen and still have
+            ' a bunch of items in NextUp that are > 365 days old.  However, checking here for at
+            ' least 1 item in Next Up means you won't have a "Next Up" section with nothing but a single View All folder.
+            if data.Items.Count() > 0
+                tmp = CreateObject("roSGNode", "HomeData")
+                tmp.type = "CollectionFolder"
+                tmp.usePoster = false
+                tmp.json = {
+                    IsFolder: true,
+                    Name: tr("View All Next Up"),
+                    Type: "CollectionFolder",
+                    CollectionType: "nextup"
+                }
+                results.push(tmp)
+            end if
         end if
         ' Load Continue Watching
     else if m.top.itemsToLoad = "continue"

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -93,6 +93,17 @@ sub loadItems()
                 tmp.json = item
                 results.push(tmp)
             end for
+            ' Add "View All"
+            tmp = CreateObject("roSGNode", "HomeData")
+            tmp.type = "CollectionFolder"
+            tmp.usePoster = false
+            tmp.json = {
+                IsFolder: true,
+                Name: tr("View All Next Up"),
+                Type: "CollectionFolder",
+                CollectionType: "nextup"
+            }
+            results.push(tmp)
         end if
         ' Load Continue Watching
     else if m.top.itemsToLoad = "continue"

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1271,5 +1271,10 @@
             <translation>Ratings for how good a movie is</translation>
             <extracomment>User Setting - Setting description</extracomment>
         </message>
+        <message>
+            <source>View All Next Up</source>
+            <translation>View All Next Up</translation>
+            <extracomment>Title for viewing all episodes available in the Next Up section</extracomment>
+        </message>
     </context>
 </TS>

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -268,6 +268,9 @@ sub Main (args as dynamic) as void
                         group = CreateMovieLibraryView(selectedItem)
                     else if selectedItem.collectionType = "music"
                         group = CreateMusicLibraryView(selectedItem)
+                    else if selectedItem.collectionType = "nextup"
+                        group = CreateItemGrid(selectedItem)
+                        group.optionsAvailable = false
                     else
                         group = CreateItemGrid(selectedItem)
                     end if


### PR DESCRIPTION
Add "View All Next Up".

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds a new "View All Next Up" on the Next Up home screen row. This adds parity to the web client and allows the user to see items that are Next Up that don't fit within the Roku's max column count or items that might be greater than 365 days old.

## Issues
Fixes #1481 
