### PR TITLE
Fix movie library crash

### DIFF
--- a/components/ItemGrid/MovieLibraryView.bs
+++ b/components/ItemGrid/MovieLibraryView.bs
@@ -680,7 +680,7 @@ end sub
 '
 'Swap Complete
 sub swapDone()
-    if m.swapAnimation.state = "stopped"
+    if isValid(m.swapAnimation) and m.swapAnimation.state = "stopped"
         'Set main BG node image and hide transitioning node
         m.backdrop.uri = m.newBackdrop.uri
         m.backdrop.opacity = 1


### PR DESCRIPTION
Ensure animation node is valid before using to prevent app crash. This comes from the roku crash log.


Crashlog: 
```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/MovieLibraryView.brs(703) 
Backtrace: 
#0  Function swapdone() As Voi$1 file/line: pkg:/components/ItemGrid/MovieLibraryView.brs(703) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:2
```

which points to this line after running build-prod on 2.1.1:
```
if m.swapAnimation.state = "stopped"
```

## Issues
Ref #1164 