### PR TITLE
Fix crash on user selection screen

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -42,9 +42,10 @@ function LoginFlow()
         SendPerformanceBeacon("AppDialogInitiate") ' Roku Performance monitoring - Dialog Starting
 
         publicUsers = GetPublicUsers()
-        savedUsers = getSavedUsers()
+        numPubUsers = 0
+        if isValid(publicUsers) then numPubUsers = publicUsers.count()
 
-        numPubUsers = publicUsers.count()
+        savedUsers = getSavedUsers()
         numSavedUsers = savedUsers.count()
 
         if numPubUsers > 0 or numSavedUsers > 0


### PR DESCRIPTION
Validate server api request data to prevent app crash on user selection view. Comes from roku.com crash log


Crashlog: 
```
myauthtoken      <uninitialized> 
myusername       <uninitialized> 
passwordentry    <uninitialized> 
userdata         <uninitialized> 
currentuser      <uninitialized> 
mytoken          <uninitialized> 
userselected     <uninitialized> 
saveduser        <uninitialized> 
user             <uninitialized> 
item             <uninitialized> 
publicuserids    <uninitialized> 
publicusersnodes <uninitialized> 
numsavedusers    <uninitialized> 
numpubusers      <uninitialized> 
savedusers       roArray refcnt=1 count:1 
publicusers      Invali$1 activeuser       Invali$1 invalidserver    Boolean (2.1 was roBoolean) val:fals$1 startover        Boolean val:fals$1 serverurl        roString (2.1 was String) refcnt=1 val:"XXX" 
m                roAssociativeArray refcnt=3 count:6 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/source/Main.brs(48) 
#0  Function main(args As Dynamic) As Voi$1 file/line: pkg:/source/ShowScenes.brs(41) 
#1  Function loginflow() As Dynami$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/ShowScenes.brs(41)

```

which points to this line after running build-prod on 2.1.1:
```
numPubUsers = publicUsers.count()
```

## Issues
Ref #1164 