### PR TITLE
Fix ListPoster crash

### DIFF
--- a/components/ListPoster.bs
+++ b/components/ListPoster.bs
@@ -15,10 +15,16 @@ sub init()
 
     m.backdrop = m.top.findNode("backdrop")
 
-    ' Randmomise the background colors
-    posterBackgrounds = m.global.constants.poster_bg_pallet
-    m.backdrop.color = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    ' Randomize the background colors
+    backdropColor = "#00a4db" ' set default in case global var is invalid
+    localGlobal = m.global
 
+    if isValid(localGlobal) and isValid(localGlobal.constants) and isValid(localGlobal.constants.poster_bg_pallet)
+        posterBackgrounds = localGlobal.constants.poster_bg_pallet
+        backdropColor = posterBackgrounds[rnd(posterBackgrounds.count()) - 1]
+    end if
+
+    m.backdrop.color = backdropColor
     updateSize()
 end sub
 


### PR DESCRIPTION
Prevent crash by validating we have access to global constants before using. Comes from roku.com crash log


Crashlog: 
```

posterbackgrounds <uninitialized> 
m                roAssociativeArray refcnt=2 count:11 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/ListPoster.brs(17) 
#0  Function init() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ListPoster.brs(17)
```

which points to this line after running build-prod on 2.1.1:
```
posterBackgrounds = m.global.constants.poster_bg_pallet
```

## Issues
Ref #1164 