### PR TITLE
Fix MovieDetails crash (2)

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -131,7 +131,8 @@ sub itemContentChanged()
             else
                 tomato = "pkg:/images/rotten.png"
             end if
-            m.top.findNode("criticRatingIcon").uri = tomato
+            criticRatingIcon = m.top.findNode("criticRatingIcon")
+            if isValid(criticRatingIcon) then criticRatingIcon.uri = tomato
         else
             m.infoGroup.removeChild(m.top.findNode("criticRatingGroup"))
         end if


### PR DESCRIPTION
Validate `criticRatingIcon` node exists before using to prevent crash. This comes from the roku crash log.


Crashlog: 
```

Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/movies/MovieDetails.brs(127) 
Backtrace: 
#0  Function itemcontentchanged() As Voi$1 file/line: pkg:/components/movies/MovieDetails.brs(128) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:14 
item             roSGNode:MovieData refcnt=1 
itemdata         roAssociativeArray refcnt=1 count:53 
tomato           String (VT_STR_CONST) val:"pkg:/images/fresh.png" 
directors        <uninitialized> 
person           <uninitialized> 
airdate          <uninitialized>
```

which points to this line after running build-prod on 2.1.2:
```
m.top.findNode("criticRatingIcon").uri = tomato
```

## Issues
Ref #1164 
