### PR TITLE
Fix MovieDetails crash (3)

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -51,6 +51,7 @@ end sub
 ' onMoviePosterSwapAnimationStateChange: Handler for changes to m.moviePosterSwapAnimation.state
 '
 sub onMoviePosterSwapAnimationStateChange()
+    if not isValid(m.moviePosterSwapAnimation) then return
     if LCase(m.moviePosterSwapAnimation.state) <> "stopped" then return
     m.moviePoster.uri = m.moviePosterSwap.uri
     m.moviePoster.opacity = 1


### PR DESCRIPTION
Validate animation node exists before using to prevent crash. This comes from the roku crash log.


Crashlog: 
```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/movies/MovieDetails.brs(51) 
Backtrace: 
#0  Function onmovieposterswapanimationstatechange() As Voi$1 file/line: pkg:/components/movies/MovieDetails.brs(51) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:2
```

which points to this line after running build-prod on 2.1.2:
```
if LCase(m.moviePosterSwapAnimation.state) <> "stopped" then
```

## Issues
Ref #1164 