### PR TITLE
Fix video player crash

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -574,9 +574,12 @@ end sub
 
 ' When Video Player state changes
 sub onPositionChanged()
-
     ' Pass video position data into OSD
-    m.osd.progressPercentage = m.top.position / m.top.duration
+    if m.top.duration = 0
+        m.osd.progressPercentage = 0
+    else
+        m.osd.progressPercentage = m.top.position / m.top.duration
+    end if
     m.osd.positionTime = m.top.position
     m.osd.remainingPositionTime = m.top.duration - m.top.position
 


### PR DESCRIPTION
Validate video duration is longer than the default value of 0 before dividing to prevent crash. This comes from the roku crash log.


Crashlog: 
```
m                roAssociativeArray refcnt=2 count:23 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/video/VideoPlayerView.brs(538) 
#0  Function onpositionchanged() As Voi$1 Backtrace: 
Divide by Zero. (runtime error &h14) in pkg:/components/video/VideoPlayerView.brs(538)
```

which points to this line after running build-prod on 2.1.2:
```
m.osd.progressPercentage = m.top.position / m.top.duration
```

## Issues
Ref #1164 

Introduced in #1491