### PR TITLE
Fix video player crash (2)

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -662,7 +662,7 @@ sub ReportPlayback(state = "update" as string)
         "PositionTicks": int(m.top.position) * 10000000&, 'Ensure a LongInteger is used
         "IsPaused": (m.top.state = "paused")
     }
-    if m.top.content.live
+    if isValid(m.top.content) and isValid(m.top.content.live) and m.top.content.live
         params.append({
             "MediaSourceId": m.top.transcodeParams.MediaSourceId,
             "LiveStreamId": m.top.transcodeParams.LiveStreamId


### PR DESCRIPTION
Validate video content data is valid to prevent crash. This comes from the roku crash log.


Crashlog: 
```
playstatetask    <uninitialized> 
params           roAssociativeArray refcnt=1 count:4 
m                roAssociativeArray refcnt=4 count:19 
global           Interface:ifGloba$1 state            String (VT_STR_CONST) val:"stop" 
Local Variables: 
   file/line: pkg:/components/video/VideoPlayerView.brs(598) 
#0  Function onstate(msg As Dynamic) As Voi$1 file/line: pkg:/components/video/VideoPlayerView.brs(615) 
#1  Function reportplayback(state As String) As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/video/VideoPlayerView.brs(615)
```

which points to this line after running build-prod on 2.1.2:
```
if m.top.content.live
```

## Issues
Ref #1164 