### PR TITLE
Add new vscode launch option to deploy app without building

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,27 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Build and Deploy",
             "type": "brightscript",
             "request": "launch",
-            "name": "Jellyfin Debug",
             "rootDir": "${workspaceFolder}/build/staging",
             "preLaunchTask": "build-dev",
+            "stopOnEntry": false,
+            // To enable RALE:
+            // set "brightscript.debug.raleTrackerTaskFileLocation": "/absolute/path/to/rale/TrackerTask.xml" in your vscode user settings
+            // set the below field to true
+            "injectRaleTrackerTask": false,
+            "injectRdbOnDeviceComponent": true,
+            //WARNING: don't edit this value. Instead, set "brightscript.debug.host": "YOUR_HOST_HERE" in your vscode user settings
+            //"host": "${promptForHost}",
+            //WARNING: don't edit this value. Instead, set "brightscript.debug.password": "YOUR_PASSWORD_HERE" in your vscode user settings
+            //"password": "${promptForPassword}",
+        },
+        {
+            "name": "Deploy",
+            "type": "brightscript",
+            "request": "launch",
+            "rootDir": "${workspaceFolder}/build/staging",
             "stopOnEntry": false,
             // To enable RALE:
             // set "brightscript.debug.raleTrackerTaskFileLocation": "/absolute/path/to/rale/TrackerTask.xml" in your vscode user settings


### PR DESCRIPTION
Sometimes we only need to relaunch the debugger without re-building the app (especially if `brightscript.debug.stopDebuggerOnAppExit` is enabled). This adds a new `Deploy` launch option in the vscode debuger.

## Changes
- Rename old launch option from `Jellyfin Debug` -> `Build and Deploy`
- Add vscode debug launch option to deploy app without running npm build

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
