### PR TITLE
Fix home page crash

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -6,12 +6,12 @@ import "pkg:/source/roku_modules/log/LogMixin.brs"
 
 sub init()
     m.log = log.Logger("HomeItem")
-    m.itemText = m.top.findNode("itemText")
-    m.itemPoster = m.top.findNode("itemPoster")
+    initItemText()
+    initItemPoster()
     m.itemProgress = m.top.findNode("progress")
     m.itemProgressBackground = m.top.findNode("progressBackground")
     m.itemIcon = m.top.findNode("itemIcon")
-    m.itemTextExtra = m.top.findNode("itemTextExtra")
+    initItemTextExtra()
     m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
     m.unplayedCount = m.top.findNode("unplayedCount")
     m.unplayedEpisodeCount = m.top.findNode("unplayedEpisodeCount")
@@ -34,6 +34,17 @@ sub init()
     m.backdrop.color = backdropColor
 end sub
 
+sub initItemText()
+    m.itemText = m.top.findNode("itemText")
+end sub
+
+sub initItemPoster()
+    m.itemPoster = m.top.findNode("itemPoster")
+end sub
+
+sub initItemTextExtra()
+    m.itemTextExtra = m.top.findNode("itemTextExtra")
+end sub
 
 sub itemContentChanged()
     if isValid(m.unplayedCount) then m.unplayedCount.visible = false
@@ -42,6 +53,11 @@ sub itemContentChanged()
     localGlobal = m.global
 
     itemData.Title = itemData.name ' Temporarily required while we move from "HomeItem" to "JFContentItem"
+
+    ' validate to prevent crash
+    if not isValid(m.itemPoster) then initItemPoster()
+    if not isValid(m.itemText) then initItemText()
+    if not isValid(m.itemTextExtra) then initItemTextExtra()
 
     m.itemPoster.width = itemData.imageWidth
     m.itemText.maxWidth = itemData.imageWidth


### PR DESCRIPTION
This is one of those weird roku bugs it seems since `m.itemText` is created during `init()`. Comes from roku.com crash log and is currently the worst offender:


```
    Type: "Video" 
} 
<Component: roAssociativeArray> = 
    IsRequired: fals$1 Condition: "EqualsAny" 
{ 
nent: roArray> 
    Type: "Audio" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: tru$1 Property: "AudioChannels" 
    Value: 6 
} 
<Component: roAssociativeArray> = 
{ 
    Codec: "mpg123" 
    Conditions: <Component: roArray> 
    Type: "VideoAudio" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: tru$1 Property: "AudioChannels" 
    Value: 2 
} 
<Component: roAssociativeArray> = 
{ 
    Codec: "mpg123" 
    Conditions: <Component: roArray> 
    Type: "Audio" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: tru$1 Property: "AudioChannels" 
    Value: 2 
} 
<Component: roAssociativeArray> = 
{ 
    Codec: "h264" 
    Conditions: <Component: roArray> 
    Type: "Video" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "NotEquals" 
    IsRequired: fals$1 Property: "IsAnamorphic" 
    Value: "true" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: fals$1 Property: "VideoBitDepth" 
    Value: "8" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "EqualsAny" 
    IsRequired: fals$1 Property: "VideoProfile" 
    Value: "high|main" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "EqualsAny" 
    IsRequired: fals$1 Property: "VideoRangeType" 
    Value: "SDR" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: fals$1 Property: "VideoLevel" 
    Value: "42" 
} 
<Component: roAssociativeArray> = 
{ 
    Condition: "LessThanEqual" 
    IsRequired: tru$1 Property: "VideoBitrate" 
    Value: "10000000" 
} 
<Component: roAssociativeArray> = 
{ 
    Codec: "av1" 
    Conditions: <Component: roArray> 
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/home/HomeItem.brs(43) 
Backtrace: 
#0  Function itemcontentchanged() As Voi$1 file/line: pkg:/components/home/HomeItem.brs(44) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:2 
itemdata         roSGNode:HomeData refcnt=1 
localglobal      roSGNode:Node refcnt=2 
playedindicatorleftposition <uninitialized> 
extraprefix      <uninitialized> 
textextra        <uninitialized>
```

which points to this line after running build-prod on 2.0.7:
```
m.itemText.maxWidth = itemData.imageWidth
```

## Issues
Ref #1164 