### PR TITLE
Fix GridItem crash

### DIFF
--- a/components/ItemGrid/GridItem.bs
+++ b/components/ItemGrid/GridItem.bs
@@ -21,18 +21,21 @@ sub init()
     m.checkmark.height = 60
 
     m.itemText.translation = [0, m.itemPoster.height + 7]
-
-    m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
     m.itemText.visible = m.gridTitles = "showalways"
 
     ' Add some padding space when Item Titles are always showing
     if m.itemText.visible then m.itemText.maxWidth = 250
 
-    'Parent is MarkupGrid and it's parent is the ItemGrid
-    m.topParent = m.top.GetParent().GetParent()
-    'Get the imageDisplayMode for these grid items
-    if isValid(m.topParent.imageDisplayMode)
-        m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
+    ' grab data from ItemGrid node
+    m.itemGrid = m.top.GetParent().GetParent() 'Parent is MarkupGrid and it's parent is the ItemGrid
+
+    if isValid(m.itemGrid)
+        if isValid(m.itemGrid.imageDisplayMode)
+            m.itemPoster.loadDisplayMode = m.itemGrid.imageDisplayMode
+        end if
+        if isValid(m.itemGrid.gridTitles)
+            m.gridTitles = m.itemGrid.gridTitles
+        end if
     end if
 
 end sub
@@ -91,7 +94,7 @@ sub itemContentChanged()
         m.itemPoster.uri = itemData.PosterUrl
         'm.itemIcon.uri = itemData.iconUrl
         m.itemText.text = itemData.Title
-        m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
+        m.itemPoster.loadDisplayMode = m.itemGrid.imageDisplayMode
     else if itemData.type = "Video"
         m.itemPoster.uri = itemData.PosterUrl
         m.itemIcon.uri = itemData.iconUrl
@@ -169,7 +172,7 @@ sub focusChanged()
         m.posterMask.scale = [1, 1]
     else
         m.itemText.repeatCount = 0
-        if m.topParent.alphaActive = true
+        if m.itemGrid.alphaActive = true
             m.posterMask.scale = [0.85, 0.85]
         end if
     end if

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -68,6 +68,8 @@ sub init()
 
     'Get reset folder setting
     m.resetGrid = m.global.session.user.settings["itemgrid.reset"]
+
+    m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
 end sub
 
 '

--- a/components/ItemGrid/ItemGrid.xml
+++ b/components/ItemGrid/ItemGrid.xml
@@ -35,5 +35,6 @@
     <field id="alphaSelected" type="string" alias="alpha.letterSelected" alwaysNotify="true" onChange="alphaSelectedChanged" />
     <field id="alphaActive" type="boolean" value="false" />
     <field id="jumpToItem" type="integer" value="" />
+    <field id="gridTitles" type="string" />
   </interface>
 </component>


### PR DESCRIPTION
This appears to be another one of those weird roku bugs since `m.global.session.user.settings` should always be valid after the user logs in. Instead of accessing and validating `m.global` and `m.global.session` etc for every single item in the grid, I'm accessing the user setting from global once and saving it to a field on `ItemGrid`. Even with roku weirdness I believe we will always have access to the parent node and hopefully this way we can avoid adding a bunch of validation for every single item in the grid.

Comes from roku.com crash log:
```
m                roAssociativeArray refcnt=2 count:13 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/GridItem.brs(24) 
Backtrace: 
#0  Function init() As Voi$1 file/line: pkg:/components/ItemGrid/GridItem.brs(24) 
Local Variables: 
global           Interface:ifGlobal
```

which points to this line after running build-prod on 2.1.2:
```
m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
```

## Issues
Ref #1164 