### PR TITLE
Fix ExtrasItem crash

### DIFF
--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -24,7 +24,7 @@ sub showContent()
     if not isValid(m.name) then initName()
     if not isValid(m.role) then initRole()
 
-    if m.top.itemContent <> invalid
+    if isValid(m.top.itemContent)
         cont = m.top.itemContent
         m.name.text = cont.labelText
         m.name.maxWidth = cont.imageWidth

--- a/components/extras/ExtrasItem.bs
+++ b/components/extras/ExtrasItem.bs
@@ -1,10 +1,29 @@
+import "pkg:/source/utils/misc.bs"
+
 sub init()
+    initPosterImg()
+    initName()
+    initRole()
+end sub
+
+sub initPosterImg()
     m.posterImg = m.top.findNode("posterImg")
+end sub
+
+sub initName()
     m.name = m.top.findNode("pLabel")
+end sub
+
+sub initRole()
     m.role = m.top.findNode("subTitle")
 end sub
 
 sub showContent()
+    ' validate nodes to prevent crash
+    if not isValid(m.posterImg) then initPosterImg()
+    if not isValid(m.name) then initName()
+    if not isValid(m.role) then initRole()
+
     if m.top.itemContent <> invalid
         cont = m.top.itemContent
         m.name.text = cont.labelText


### PR DESCRIPTION
Prevent crash by validating node refs and recreating as needed. Comes from roku.com crash log:

```
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/extras/ExtrasItem.brs(10) 
Backtrace: 
#0  Function showcontent() As Voi$1 file/line: pkg:/components/extras/ExtrasItem.brs(11) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:3 
cont             roSGNode:ExtrasData refcnt=1 
BRIGHTSCRIPT: ERROR: roUrlTransfer.GetToString: Sync-wait interrupted: pkg:/source/api/baserequest.brs(75)
```

which points to this line after running build-prod on 2.1.2:
```
m.name.text = cont.labelText
```

## Issues
Ref #1164 