### PR TITLE
Fix LoadVideoContentTask crash

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -395,6 +395,12 @@ sub addAudioStreamsToVideo(video)
 end sub
 
 sub addSubtitlesToVideo(video, meta)
+    if not isValid(meta) then return
+    if not isValid(meta.id) then return
+    if not isValid(m.playbackInfo) then return
+    if not isValidAndNotEmpty(m.playbackInfo.MediaSources) then return
+    if not isValid(m.playbackInfo.MediaSources[0].MediaStreams) then return
+
     subtitles = sortSubtitles(meta.id, m.playbackInfo.MediaSources[0].MediaStreams)
     safesubs = subtitles["all"]
     subtitleTracks = []


### PR DESCRIPTION
Prevent crash by ensuring data is valid. Comes from roku.com crash log:


Crashlog: 
```
subtitle         <uninitialized> 
subtitletracks   <uninitialized> 
safesubs         <uninitialized> 
subtitles        <uninitialized> 
m                roAssociativeArray refcnt=5 count:4 
global           Interface:ifGloba$1 meta             roSGNode:ChannelData refcnt=2 
video            roAssociativeArray refcnt=3 count:4 
Local Variables: 
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(47) 
#0  Function loaditems() As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(55) 
#1  Function loaditems_videoplayer(id As String, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Dynami$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(131) 
#2  Function loaditems_addvideocontent(video As Object, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(362) 
#3  Function addsubtitlestovideo(video As Dynamic, meta As Dynamic) As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/LoadVideoContentTask.brs(362)
```

which points to this line after running build-prod on 2.1.2:
```
subtitles = sortSubtitles(meta.id, m.playbackInfo.MediaSources[0].MediaStreams)
```

## Issues
Ref #1164 