### PR TITLE
Remove unneeded API call and fix LoadVideoContentTask crash

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -13,7 +13,6 @@ enum SubtitleSelection
 end enum
 
 sub init()
-    m.user = AboutMe()
     m.top.functionName = "loadItems"
 end sub
 
@@ -565,8 +564,8 @@ function sortSubtitles(id as string, MediaStreams)
 end function
 
 function FindPreferredAudioStream(streams as dynamic) as integer
-    preferredLanguage = m.user.Configuration.AudioLanguagePreference
-    playDefault = m.user.Configuration.PlayDefaultAudioTrack
+    preferredLanguage = m.global.session.user.Configuration.AudioLanguagePreference
+    playDefault = m.global.session.user.Configuration.PlayDefaultAudioTrack
 
     if playDefault <> invalid and playDefault = true
         return 1
@@ -574,7 +573,7 @@ function FindPreferredAudioStream(streams as dynamic) as integer
 
     ' Do we already have the MediaStreams or not?
     if streams = invalid
-        url = Substitute("Users/{0}/Items/{1}", m.user.id, m.top.itemId)
+        url = Substitute("Users/{0}/Items/{1}", m.global.session.user.id, m.top.itemId)
         resp = APIRequest(url)
         jsonResponse = getJson(resp)
 


### PR DESCRIPTION
Remove unneeded API call and fix app crash when `AboutMe()` returns invalid. Comes from roku.com crash log:


Crashlog: 
```
i                <uninitialized> 
jsonresponse     <uninitialized> 
resp             <uninitialized> 
url              <uninitialized> 
playdefault      <uninitialized> 
preferredlanguage <uninitialized> 
m                roAssociativeArray refcnt=3 count:2 
global           Interface:ifGloba$1 streams          Invali$1 Local Variables: 
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(39) 
#0  Function loaditems() As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(527) 
#1  Function findpreferredaudiostream(streams As Dynamic) As Intege$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/LoadVideoContentTask.brs(527)
```

which points to this line after running build-prod on 2.1.2:
```
preferredLanguage = m.user.Configuration.AudioLanguagePreference
```

## Issues
Ref #1164 