### PR TITLE
Remove unneeded API call and fix LoadVideoContentTask crash (2)

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -119,8 +119,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         video.logoImage = api.items.GetImageURL(logoLookupID, "logo", 0, { "maxHeight": 65, "maxWidth": 300, "quality": "90" })
     end if
 
-    user = AboutMe()
-    if user.Configuration.EnableNextEpisodeAutoPlay
+    if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay
         if LCase(m.top.itemType) = "episode"
             addNextEpisodesToQueue(video.showID)
         end if


### PR DESCRIPTION
Remove unneeded API call and fix app crash when `AboutMe()` returns invalid. Comes from roku.com crash log:


Crashlog: 
```
transcodingreasons <uninitialized> 
trydirectplay    <uninitialized> 
fully_external   <uninitialized> 
defaultsubtitleindex <uninitialized> 
currentitem      <uninitialized> 
playbackposition <uninitialized> 
user             Invali$1 logoimageexists  Boolean val:fals$1 logolookupid     roString refcnt=1 val:"8a084671e25509fef760fa5362257c67" 
videotype        roString (2.1 was String) refcnt=1 val:"episode" 
subtitle_idx     roInt refcnt=1 val:-2 (&hFFFFFFFE) 
meta             roSGNode:TVEpisodeData refcnt=1 
m                roAssociativeArray refcnt=4 count:3 
global           Interface:ifGloba$1 forcetranscoding Boolean val:fals$1 audio_stream_idx Integer val:0 (&h0) 
mediasourceid    Invali$1 video            roAssociativeArray refcnt=2 count:7 
Local Variables: 
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(47) 
#0  Function loaditems() As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(55) 
#1  Function loaditems_videoplayer(id As String, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Dynami$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(107) 
#2  Function loaditems_addvideocontent(video As Object, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/LoadVideoContentTask.brs(107)
```

which points to this line after running build-prod on 2.1.2:
```
if user.Configuration.EnableNextEpisodeAutoPlay
```

## Issues
Ref #1164 