### PR TITLE
Create `Episode Image Next Up` user setting

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -146,9 +146,16 @@ sub itemContentChanged()
             drawProgressBar(itemData)
         end if
 
-        if itemData.usePoster = true
+        if localGlobal.session.user.settings["ui.general.episodeimagesnextup"] = "webclient"
+            tmpSetting = localGlobal.session.user.Configuration.useEpisodeImagesInNextUpAndResume
+            if isValid(tmpSetting) and tmpSetting
+                m.itemPoster.uri = itemData.thumbnailURL
+            else
+                m.itemPoster.uri = itemData.widePosterURL
+            end if
+        else if localGlobal.session.user.settings["ui.general.episodeimagesnextup"] = "show"
             m.itemPoster.uri = itemData.widePosterURL
-        else
+        else if localGlobal.session.user.settings["ui.general.episodeimagesnextup"] = "episode"
             m.itemPoster.uri = itemData.thumbnailURL
         end if
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1286,5 +1286,30 @@
             <translation>Show already watched episodes in 'Next Up' sections.</translation>
             <extracomment>User Setting - Setting description</extracomment>
         </message>
+        <message>
+            <source>Episode Images Next Up</source>
+            <translation>Episode Images Next Up</translation>
+            <extracomment>User Setting - Setting title</extracomment>
+        </message>
+        <message>
+            <source>What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.</source>
+            <translation>What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.</translation>
+            <extracomment>User Setting - Setting description</extracomment>
+        </message>
+        <message>
+            <source>Use Web Client Setting</source>
+            <translation>Use Web Client Setting</translation>
+            <extracomment>User Setting - Setting option title</extracomment>
+        </message>
+        <message>
+            <source>Use Episode Image</source>
+            <translation>Use Episode Image</translation>
+            <extracomment>User Setting - Setting option title</extracomment>
+        </message>
+        <message>
+            <source>Use Show Image</source>
+            <translation>Use Show Image</translation>
+            <extracomment>User Setting - Setting option title</extracomment>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -221,6 +221,27 @@
                 "description": "Settings relating to the appearance of the Home screen and the program in general.",
                 "children": [
                     {
+                        "title": "Episode Images Next Up",
+                        "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",
+                        "settingName": "ui.general.episodeimagesnextup",
+                        "type": "radio",
+                        "default": "webclient",
+                        "options": [
+                            {
+                                "title": "Use Web Client Setting",
+                                "id": "webclient"
+                            },
+                            {
+                                "title": "Use Episode Image",
+                                "id": "episode"
+                            },
+                            {
+                                "title": "Use Show Image",
+                                "id": "show"
+                            }
+                        ]
+                    },
+                    {
                         "title": "Hide Clock",
                         "description": "Hide all clocks in Jellyfin. Jellyfin will need to be closed and reopened for changes to take effect.",
                         "settingName": "ui.design.hideclock",

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -584,3 +584,18 @@ function createOverhangUser()
 
     return userLabel
 end function
+
+' convert value to boolean and return value
+function toBoolean(value as dynamic) as dynamic
+    if value = invalid then return invalid
+    if Type(value) = "Boolean" then return value
+    if Type(value) <> "String" then return value
+
+    if value = "true"
+        return true
+    else if value = "false"
+        return false
+    else
+        return value
+    end if
+end function

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -2,6 +2,7 @@
 import "pkg:/source/api/userauth.bs"
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/migrations.bs"
+import "pkg:/source/utils/misc.bs"
 
 namespace session
     ' Initialize the global session array
@@ -182,13 +183,6 @@ namespace session
                 end if
             end for
 
-            if m.global.app.isDev
-                print "m.global.session.user = ", m.global.session.user
-                print "m.global.session.user.Configuration = ", m.global.session.user.Configuration
-                print "m.global.session.user.Policy = ", m.global.session.user.Policy
-                print "m.global.session.user.settings = ", m.global.session.user.settings
-            end if
-
             set_user_setting("serverId", m.global.session.server.id)
 
             if saveCredentials
@@ -204,6 +198,13 @@ namespace session
             session.user.SetServerDeviceName()
             ' Load user preferences from server
             session.user.LoadUserPreferences()
+
+            if m.global.app.isDev
+                print "m.global.session.user = ", m.global.session.user
+                print "m.global.session.user.Configuration = ", m.global.session.user.Configuration
+                print "m.global.session.user.Policy = ", m.global.session.user.Policy
+                print "m.global.session.user.settings = ", m.global.session.user.settings
+            end if
         end sub
 
         ' Sets the global server device name value used by the API
@@ -234,6 +235,14 @@ namespace session
             jsonResponse = getJson(resp)
 
             if isValid(jsonResponse) and isValid(jsonResponse.CustomPrefs)
+                ' save useEpisodeImagesInNextUpAndResume to global session
+                tmpSetting = jsonResponse.CustomPrefs.useEpisodeImagesInNextUpAndResume
+                if isValid(tmpSetting)
+                    tmpConfig = m.global.session.user.Configuration
+                    tmpConfig.AddReplace("useEpisodeImagesInNextUpAndResume", toBoolean(tmpSetting))
+                    session.user.Update("Configuration", tmpConfig)
+                end if
+
                 session.user.SaveUserHomeSections(jsonResponse.CustomPrefs)
 
                 if isValid(jsonResponse.CustomPrefs["landing-livetv"])
@@ -414,16 +423,8 @@ namespace session
             sub Save(name as string, value as string)
                 if name = invalid or value = invalid then return
                 tmpSettingArray = m.global.session.user.settings
-                convertedValue = value
 
-                ' convert to boolean
-                if value = "true"
-                    convertedValue = true
-                else if value = "false"
-                    convertedValue = false
-                end if
-
-                tmpSettingArray[name] = convertedValue
+                tmpSettingArray[name] = toBoolean(value)
 
                 session.user.Update("settings", tmpSettingArray)
             end sub


### PR DESCRIPTION
Adds a user setting and updates the home page to use it (Doesn't affect the new `View All Next Up` screen.)

Defaults to the user's web client setting (which is disabled by default) with option to override client side. 


## Changes
- Create `toBoolean()` helper function to avoid duplicate code
- Save web client `useEpisodeImagesInNextUpAndResume` setting to global session
- Update `HomeItem.bs` to select Episode image based on user setting

## Issues
Fixes #1464
