### PR TITLE
Only show Whats New popup and update lastRunVersion on prod

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -72,15 +72,18 @@ sub Main (args as dynamic) as void
         end if
     end if
 
-    ' has the current user ran this version before?
-    usersLastRunVersion = m.global.session.user.settings.lastRunVersion
-    if not isValid(usersLastRunVersion) or not versionChecker(m.global.session.user.settings.lastRunVersion, m.global.app.version)
-        set_user_setting("LastRunVersion", m.global.app.version)
-        ' show what's new popup
-        if m.global.session.user.settings["load.allowwhatsnew"]
-            dialog = createObject("roSGNode", "WhatsNewDialog")
-            m.scene.dialog = dialog
-            m.scene.dialog.observeField("buttonSelected", m.port)
+    ' only show whats new popup and update lastRunVersion on prod
+    if not m.global.app.isDev
+        ' has the current user ran this version before?
+        usersLastRunVersion = m.global.session.user.settings.lastRunVersion
+        if not isValid(usersLastRunVersion) or not versionChecker(m.global.session.user.settings.lastRunVersion, m.global.app.version)
+            set_user_setting("LastRunVersion", m.global.app.version)
+            ' show what's new popup
+            if m.global.session.user.settings["load.allowwhatsnew"]
+                dialog = createObject("roSGNode", "WhatsNewDialog")
+                m.scene.dialog = dialog
+                m.scene.dialog.observeField("buttonSelected", m.port)
+            end if
         end if
     end if
 

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -76,7 +76,7 @@ sub Main (args as dynamic) as void
     if not m.global.app.isDev
         ' has the current user ran this version before?
         usersLastRunVersion = m.global.session.user.settings.lastRunVersion
-        if not isValid(usersLastRunVersion) or not versionChecker(m.global.session.user.settings.lastRunVersion, m.global.app.version)
+        if not isValid(usersLastRunVersion) or not versionChecker(usersLastRunVersion, m.global.app.version)
             set_user_setting("LastRunVersion", m.global.app.version)
             ' show what's new popup
             if m.global.session.user.settings["load.allowwhatsnew"]


### PR DESCRIPTION
This allows devs and testers who have already sideloaded that version to still get the whats new popup when prod updates.

A downside may be testing registry migrations since `lastRunVersion` won't update on dev deploy

## Changes
- Only show Whats New popup and update lastRunVersion on prod
