### PR TITLE
Fix search page crash

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -53,6 +53,8 @@ function searchMedia(query as string)
             "limit": 100
         })
 
+        if data = invalid then return []
+
         results = []
         for each item in data.Items
             tmp = CreateObject("roSGNode", "SearchData")


### PR DESCRIPTION
Prevent crash by validating we were given data from the API. Comes from roku.com crash log:

```
tmp              <uninitialized> 
item             <uninitialized> 
results          roArray refcnt=1 count:0 
data             Invali$1 m                roAssociativeArray refcnt=3 count:2 
global           Interface:ifGloba$1 query            roString (2.1 was String) refcnt=1 val:"m" 
Local Variables: 
   file/line: pkg:/components/search/SearchTask.brs(13) 
#0  Function search() As Voi$1 file/line: pkg:/source/api/Items.brs(57) 
#1  Function searchmedia(query As String) As Dynami$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/api/Items.brs(57)
```

which points to this line after running build-prod on 2.1.2:
```
for each item in data.Items
```

## Issues
Ref #1164 