### PR TITLE
Fix `ItemMetaData()` crash

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -95,7 +95,7 @@ function ItemMetaData(id as string)
         tmp.image = PosterImage(data.id, imgParams)
         tmp.json = data
         return tmp
-    else if LCase(data.type) = "recording"
+    else if data.type = "Recording"
         tmp = CreateObject("roSGNode", "RecordingData")
         tmp.image = PosterImage(data.id, imgParams)
         tmp.json = data


### PR DESCRIPTION
It's possible for `data.type` to be invalid. Remove `LCase()` function call causing the crash instead of refactoring. Comes from roku.com crash log:

```
Type Mismatch. (runtime error &h18) in pkg:/source/api/Items.brs(103) 
Backtrace: 
#3  Function itemmetadata(id As String) As Dynami$1 file/line: pkg:/source/api/Items.brs(103) 
#2  Function loaditems_addvideocontent(video As Object, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(63) 
#1  Function loaditems_videoplayer(id As String, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Dynami$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(55) 
#0  Function loaditems() As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(47) 
Local Variables: 
id               roString (2.1 was String) refcnt=4 val:"" 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=5 count:3 
url              roString (2.1 was String) refcnt=1 val:"Users/a2396207402045d2b18c6db80796d6c6/Items/" 
resp             roUrlTransfer refcnt=1 
data             roAssociativeArray refcnt=1 count:3 
imgparams        roAssociativeArray refcnt=1 count:0 
param            <uninitialized> 
tmp              <uninitialized>
```

which points to this line after running build-prod on 2.1.2:
```
else if LCase(data.type) = "recording"
```

## Issues
Ref #1164 