### PR TITLE
Fix home page crash (2)

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -30,7 +30,7 @@ sub init()
     end if
 
     ' update the backdrop node
-    m.backdrop = m.top.findNode("backdrop")
+    initBackdrop()
     m.backdrop.color = backdropColor
 end sub
 
@@ -46,6 +46,10 @@ sub initItemTextExtra()
     m.itemTextExtra = m.top.findNode("itemTextExtra")
 end sub
 
+sub initBackdrop()
+    m.backdrop = m.top.findNode("backdrop")
+end sub
+
 sub itemContentChanged()
     if isValid(m.unplayedCount) then m.unplayedCount.visible = false
     itemData = m.top.itemContent
@@ -58,6 +62,7 @@ sub itemContentChanged()
     if not isValid(m.itemPoster) then initItemPoster()
     if not isValid(m.itemText) then initItemText()
     if not isValid(m.itemTextExtra) then initItemTextExtra()
+    if not isValid(m.backdrop) then initBackdrop()
 
     m.itemPoster.width = itemData.imageWidth
     m.itemText.maxWidth = itemData.imageWidth


### PR DESCRIPTION
Prevent crash by validating node ref and recreating as needed. Comes from roku.com crash log:

```
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/home/HomeItem.brs(48) 
Backtrace: 
#0  Function itemcontentchanged() As Voi$1 file/line: pkg:/components/home/HomeItem.brs(49) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:14 
itemdata         roSGNode:HomeData refcnt=1 
localglobal      roSGNode:Node refcnt=2 
playedindicatorleftposition <uninitialized> 
extraprefix      <uninitialized> 
textextra        <uninitialized>
```

which points to this line after running build-prod on 2.1.2:
```
m.backdrop.width = itemData.imageWidth
```

## Issues
Ref #1164 