### PR TITLE
Fix ItemGrid crash

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -70,13 +70,11 @@ sub init()
     m.resetGrid = m.global.session.user.settings["itemgrid.reset"]
 end sub
 
-'
 'Genre Item Selected
 sub onGenreItemSelected()
     m.top.selectedItem = m.genreList.content.getChild(m.genreList.rowItemSelected[0]).getChild(m.genreList.rowItemSelected[1])
 end sub
 
-'
 'Load initial set of Data
 sub loadInitialItems()
     m.loadItemsTask.control = "stop"
@@ -436,7 +434,6 @@ sub SetUpOptions()
     m.options.options = options
 end sub
 
-'
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
@@ -497,7 +494,6 @@ sub ItemDataLoaded(msg)
     stopLoadingSpinner()
 end sub
 
-'
 'Set Background Image
 sub SetBackground(backgroundUri as string)
 
@@ -510,7 +506,6 @@ sub SetBackground(backgroundUri as string)
     m.newBackdrop.uri = backgroundUri
 end sub
 
-'
 'Handle new item being focused
 sub onItemFocused()
 
@@ -536,7 +531,6 @@ sub onItemFocused()
     end if
 end sub
 
-'
 'When Image Loading Status changes
 sub newBGLoaded()
     'If image load was sucessful, start the fade swap
@@ -545,12 +539,9 @@ sub newBGLoaded()
     end if
 end sub
 
-'
 'Swap Complete
 sub swapDone()
-
-    if m.swapAnimation.state = "stopped"
-
+    if isValid(m.swapAnimation) and m.swapAnimation.state = "stopped"
         'Set main BG node image and hide transitioning node
         m.backdrop.uri = m.newBackdrop.uri
         m.backdrop.opacity = 0.25
@@ -564,7 +555,6 @@ sub swapDone()
     end if
 end sub
 
-'
 'Load next set of items
 sub loadMoreData()
     if m.Loading = true then return
@@ -576,7 +566,6 @@ sub loadMoreData()
     m.loadItemsTask.control = "RUN"
 end sub
 
-'
 'Item Selected
 sub onItemSelected()
     m.top.selectedItem = m.itemGrid.content.getChild(m.itemGrid.itemSelected)
@@ -627,8 +616,6 @@ sub onvoiceFilter()
     end if
 end sub
 
-
-'
 'Check if options updated and any reloading required
 sub optionsClosed()
     if m.top.parentItem.collectionType = "livetv" and m.options.view <> m.view


### PR DESCRIPTION
Prevent crash by validating node ref. Comes from roku.com crash log:

```
   file/line: pkg:/components/ItemGrid/ItemGrid.brs(696) 
#0  Function swapdone() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/ItemGrid.brs(696) 
m                roAssociativeArray refcnt=2 count:2 
global           Interface:ifGloba$1 Local Variables:
```

which points to this line after running build-prod on 2.1.2:
```
if m.swapAnimation.state = "stopped"
```

## Issues
Ref #1164 