### PR TITLE
Fix ItemGridOptions crash

### DIFF
--- a/components/ItemGrid/ItemGridOptions.bs
+++ b/components/ItemGrid/ItemGridOptions.bs
@@ -195,6 +195,8 @@ sub buttonFocusChanged()
 end sub
 
 sub toggleFavorite()
+    if not isValid(m.selectedFavoriteItem) then return
+
     m.favItemsTask = createObject("roSGNode", "FavoriteItemsTask")
     if m.favoriteMenu.iconUri = "pkg:/images/icons/favorite.png"
         m.favoriteMenu.iconUri = "pkg:/images/icons/favorite_selected.png"


### PR DESCRIPTION
Prevent crash by exiting function when node ref is invalid. Comes from roku.com crash log:

```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/ItemGridOptions.brs(188) 
Backtrace: 
#0  Function togglefavorite() As Voi$1 file/line: pkg:/components/ItemGrid/ItemGridOptions.brs(188) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:21
```

which points to this line after running build-prod on 2.1.2:
```
m.favItemsTask.itemId = m.selectedFavoriteItem.id
```

## Issues
Ref #1164 