### PR TITLE
Fix crash on episode list

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -307,7 +307,12 @@ sub Main (args as dynamic) as void
                 else if selectedItemType = "Series"
                     group = CreateSeriesDetailsGroup(selectedItem.json.id)
                 else if selectedItemType = "Season"
-                    group = CreateSeasonDetailsGroupByID(selectedItem.json.SeriesId, selectedItem.id)
+                    if isValid(selectedItem.json) and isValid(selectedItem.json.SeriesId) and isValid(selectedItem.id)
+                        group = CreateSeasonDetailsGroupByID(selectedItem.json.SeriesId, selectedItem.id)
+                    else
+                        stopLoadingSpinner()
+                        message_dialog(tr("Error loading Season"))
+                    end if
                 else if selectedItemType = "Movie"
                     ' open movie detail page
                     group = CreateMovieDetailsGroup(selectedItem)
@@ -810,7 +815,7 @@ sub Main (args as dynamic) as void
                 selectedItem = m.global.queueManager.callFunc("getHold")
                 m.global.queueManager.callFunc("clearHold")
 
-                if isValid(selectedItem) and selectedItem.count() > 0 and isValid(selectedItem[0])
+                if isValidAndNotEmpty(selectedItem) and isValid(selectedItem[0])
                     if popupNode.returnData.indexselected = 0
                         'Resume video from resume point
                         startLoadingSpinner()
@@ -838,7 +843,13 @@ sub Main (args as dynamic) as void
                         CreateSeriesDetailsGroup(selectedItem[0].json.SeriesId)
                     else if popupNode.returnData.indexselected = 3
                         ' User chose Go to season
-                        CreateSeasonDetailsGroupByID(selectedItem[0].json.SeriesId, selectedItem[0].json.seasonID)
+                        if isValid(selectedItem[0].json) and isValid(selectedItem[0].json.SeriesId) and isValid(selectedItem[0].json.seasonID)
+                            CreateSeasonDetailsGroupByID(selectedItem[0].json.SeriesId, selectedItem[0].json.seasonID)
+                        else
+                            stopLoadingSpinner()
+                            message_dialog(tr("Error loading Season"))
+                        end if
+
                     else if popupNode.returnData.indexselected = 4
                         ' User chose Go to episode
                         CreateMovieDetailsGroup(selectedItem[0])

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -644,7 +644,7 @@ function CreateSeriesDetailsGroup(seriesID as string) as dynamic
     ' Get season data early in the function so we can check number of seasons.
     seasonData = TVSeasons(seriesID)
     ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
-    if m.global.session.user.settings["ui.tvshows.goStraightToEpisodeListing"] = true and seasonData.Items.Count() = 1
+    if seasonData <> invalid and m.global.session.user.settings["ui.tvshows.goStraightToEpisodeListing"] and seasonData.Items.Count() = 1
         stopLoadingSpinner()
         return CreateSeasonDetailsGroupByID(seriesID, seasonData.Items[0].id)
     end if


### PR DESCRIPTION
Prevent crash by validating all data sent to `CreateSeasonDetailsGroupByID()`. Comes from roku.com crash log:

```
group            <uninitialized> 
seasonmetadata   <uninitialized> 
m                roAssociativeArray refcnt=3 count:6 
global           Interface:ifGloba$1 seasonid         Invali$1 seriesid         roString (2.1 was String) refcnt=1 val:"9f3800b10bae7a29a8bfbfc6d5b4f32e" 
Local Variables: 
   file/line: pkg:/source/Main.brs(786) 
#0  Function main(args As Dynamic) As Voi$1 file/line: pkg:/source/ShowScenes.brs(793) 
#1  Function createseasondetailsgroupbyid(seriesid As String, seasonid As String) As Dynami$1 Backtrace: 
Type Mismatch. Unable to cast "Invalid" to "String". (runtime error &h18) in pkg:/source/ShowScenes.brs(791)
```

which points to this line after running build-prod on 2.1.2:
```
function CreateSeasonDetailsGroupByID(seriesID as string, seasonID as string) as dynamic
```

## Issues
Ref #1164 