### PR TITLE
Fix home item poster and progress bar alignment

### DIFF
--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -9,7 +9,7 @@
       </Rectangle>
       <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" />
     </Poster>
-    <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[0,255]">
+    <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[0,253]">
       <Rectangle id="progress" color="#00a4dcFF" width="0" height="8" />
     </Rectangle>
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="HomeItem" extends="Group">
   <children>
-    <Rectangle id="backdrop" width="464" height="261" translation="[8,5]" />
+    <Rectangle id="backdrop" width="464" height="261" />
     <Poster id="itemIcon" width="100" height="100" translation="[190,85]" loadDisplayMode="scaleToFit" />
-    <Poster id="itemPoster" width="464" height="261" translation="[8,5]" loadDisplayMode="scaleToZoom">
+    <Poster id="itemPoster" width="464" height="261" loadDisplayMode="scaleToZoom">
       <Rectangle id="unplayedCount" visible="false" width="90" height="60" color="#00a4dcFF" translation="[375, 0]">
         <Label id="unplayedEpisodeCount" width="90" height="60" font="font:MediumBoldSystemFont" horizAlign="center" vertAlign="center" />
       </Rectangle>
       <PlayedCheckmark id="playedIndicator" color="#00a4dcFF" width="60" height="46" visible="false" />
     </Poster>
-    <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[8,260]">
+    <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[0,255]">
       <Rectangle id="progress" color="#00a4dcFF" width="0" height="8" />
     </Rectangle>
     <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />


### PR DESCRIPTION

## Changes
- Fix alignment of home item posters when highlighted with the remote
- Fix vertical alignment of progress bar so that it is flush with the poster

