### PR TITLE
Allow for LiveTV remux from server

### DIFF
--- a/components/data/ChannelData.xml
+++ b/components/data/ChannelData.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="ChannelData" extends="JFContentItem">
   <interface>
+    <field id="image" type="node" onChange="setPoster" />
     <field id="channelID" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" value="0" />
   </interface>

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -26,7 +26,17 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         "SubtitleStreamIndex": subtitleTrackIndex
     }
 
-    if mediaSourceId <> "" then params.MediaSourceId = mediaSourceId
+    ' Note: Jellyfin v10.9+ now remuxs LiveTV and does not allow DirectPlay anymore.
+    ' Because of this, we need to tell the server "EnableDirectPlay = false" so that we receive the
+    ' transcoding URL (which is just a remux and not a transcode; unless it is)
+    ' The web handles this by disabling EnableDirectPlay on a Retry, but we don't currently Retry a Live
+    ' TV stream, thus we just turn it off on the first try here.
+    if mediaSourceId <> ""
+        params.MediaSourceId = mediaSourceId
+    else
+        ' No mediaSourceId? Must be LiveTV...
+        params.EnableDirectPlay = false
+    end if
 
     if audioTrackIndex > -1 then params.AudioStreamIndex = audioTrackIndex
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Server v10.9+ now remuxes live TV. DirectPlay is no longer allowed. However, we still need to tell the server that we aren't asking for DirectPlay, otherwise we do not receive a TranscodingURL (which in this case is actually a Remux URL).

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #1925 