### PR TITLE
Prevent type mismatch crash

### DIFF
--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1207,7 +1207,7 @@ namespace api
 
         ' Moves a playlist item.
         function Move(playlistid as string, itemid as string, newindex as integer)
-            req = APIRequest(Substitute("/playlists/{0}/items/{1}/move/{2}", playlistid, itemid, newindex))
+            req = APIRequest(Substitute("/playlists/{0}/items/{1}/move/{2}", playlistid, itemid, newindex.ToStr()))
             return postVoid(req)
         end function
     end namespace
@@ -2099,7 +2099,7 @@ namespace api
 
         ' Gets an HLS subtitle playlist.
         function GetHLSSubtitlePlaylistURL(id as string, streamindex as integer, mediasourceid as string, params = {} as object)
-            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/subtitles.m3u8", id, streamindex, mediasourceid), params)
+            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/subtitles.m3u8", id, streamindex.ToStr(), mediasourceid), params)
         end function
 
         ' Upload an external subtitle file.
@@ -2115,13 +2115,13 @@ namespace api
         ' Gets subtitles in a specified format.
         function GetSubtitlesWithStartPosition(routeitemid as string, routemediasourceid as string, routeindex as integer, routestartpositionticks as integer, routeformat as string, params = {} as object)
             ' We maxed out params for substitute() so we must manually add the routeformat value
-            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/{3}/stream." + routeformat, routeitemid, routemediasourceid, routeindex, routestartpositionticks), params)
+            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/{3}/stream." + routeformat, routeitemid, routemediasourceid, routeindex.ToStr(), routestartpositionticks.ToStr()), params)
         end function
 
         ' Gets subtitles in a specified format.
         function GetSubtitles(routeitemid as string, routemediasourceid as string, routeindex as integer, routestartpositionticks as integer, routeformat as string, params = {} as object)
             ' We maxed out params for substitute() so we must manually add the routeformat value
-            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/{3}/stream." + routeformat, routeitemid, routemediasourceid, routeindex, routestartpositionticks), params)
+            return buildURL(Substitute("/videos/{0}/{1}/subtitles/{2}/{3}/stream." + routeformat, routeitemid, routemediasourceid, routeindex.ToStr(), routestartpositionticks.ToStr()), params)
         end function
     end namespace
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Prevent type mismatches in `sdk.bs` where we were passing `integer` arguments into `string`-only param spots for the [Substitute function](https://developer.roku.com/en-gb/docs/references/brightscript/language/global-string-functions.md#substitutestr-as-string-arg0-as-string-arg1---as-string-arg2---as-string-arg3---as-string-as-string). (discovered by testing out the BrighterScript v1 alpha release)

![image](https://github.com/user-attachments/assets/549e1595-50dc-4a1c-9b41-b673c9bb92d2)

Proven that this is an issue:
![image](https://github.com/user-attachments/assets/9322b879-e999-4039-a4c8-ce1e6470cd5b)


## Issues
- #1940
