### PR TITLE
Fix incorrect data type being passed to `OverviewDialog.Overview`

### DIFF
--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -136,7 +136,7 @@ sub createFullDscrDlg()
     dlg.Title = tr("Press 'Back' to Close")
     dlg.width = 1290
     dlg.palette = m.dlgPalette
-    dlg.overview = [m.dscr.text]
+    dlg.overview = m.dscr.text
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
     border = createObject("roSGNode", "Poster")

--- a/components/music/ArtistView.bs
+++ b/components/music/ArtistView.bs
@@ -223,7 +223,7 @@ sub createFullDscrDlg()
     dlg.Title = tr("Press 'Back' to Close")
     dlg.width = 1290
     dlg.palette = m.dlgPalette
-    dlg.overview = [m.dscr.text]
+    dlg.overview = m.dscr.text
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
     border = createObject("roSGNode", "Poster")

--- a/components/music/PlaylistView.bs
+++ b/components/music/PlaylistView.bs
@@ -127,7 +127,7 @@ sub createFullDscrDlg()
     dlg.Title = tr("Press 'Back' to Close")
     dlg.width = 1290
     dlg.palette = m.dlgPalette
-    dlg.overview = [m.dscr.text]
+    dlg.overview = m.dscr.text
     m.fullDscrDlg = dlg
     m.top.getScene().dialog = dlg
     border = createObject("roSGNode", "Poster")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Fix a few type mismatch errors when setting the `Overview` field on `OverviewDialog`. (discovered while testing the v1 brighterscript alphas)

I'm not sure how to trigger each of these functions, but it appears to be a clear issue of passing the wrong data type so should be pretty straightforward?

![image](https://github.com/user-attachments/assets/178d8557-270b-4b5b-9ee1-1ddd266613b8)



## Issues
- #1940
