### PR TITLE
Revert uneeded buffer state change

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -610,18 +610,11 @@ sub onState(msg)
     ' Pass video state into OSD
     m.osd.playbackState = m.top.state
 
-    ' When buffering, start timer to monitor buffering process
     if m.top.state = "buffering"
-        ' start buffer timer
+        ' When buffering, start timer to monitor buffering process
         if isValid(m.bufferCheckTimer)
             m.bufferCheckTimer.control = "start"
             m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
-        end if
-
-        ' update server if needed
-        if not m.playReported
-            m.playReported = true
-            ReportPlayback("start")
         end if
     else if m.top.state = "error"
         m.log.error(m.top.errorCode, m.top.errorMsg, m.top.errorStr, m.top.errorCode)


### PR DESCRIPTION
This is causing "start" playback to be duplicated. Once during buffering state and once during playing state

## Changes
- Revert uneeded buffer state change

Introduced in #1941 (2.1.5)