### PR TITLE
Prevent app crash on home screen

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -10,12 +10,12 @@ sub init()
     initItemPoster()
     m.itemProgress = m.top.findNode("progress")
     m.itemProgressBackground = m.top.findNode("progressBackground")
-    m.itemIcon = m.top.findNode("itemIcon")
+    initItemIcon()
     initItemTextExtra()
     m.itemPoster.observeField("loadStatus", "onPosterLoadStatusChanged")
     m.unplayedCount = m.top.findNode("unplayedCount")
     m.unplayedEpisodeCount = m.top.findNode("unplayedEpisodeCount")
-    m.playedIndicator = m.top.findNode("playedIndicator")
+    initPlayedIndicator()
 
     m.showProgressBarAnimation = m.top.findNode("showProgressBar")
     m.showProgressBarField = m.top.findNode("showProgressBarField")
@@ -50,6 +50,14 @@ sub initBackdrop()
     m.backdrop = m.top.findNode("backdrop")
 end sub
 
+sub initItemIcon()
+    m.itemIcon = m.top.findNode("itemIcon")
+end sub
+
+sub initPlayedIndicator()
+    m.playedIndicator = m.top.findNode("playedIndicator")
+end sub
+
 sub itemContentChanged()
     if isValid(m.unplayedCount) then m.unplayedCount.visible = false
     itemData = m.top.itemContent
@@ -63,6 +71,8 @@ sub itemContentChanged()
     if not isValid(m.itemText) then initItemText()
     if not isValid(m.itemTextExtra) then initItemTextExtra()
     if not isValid(m.backdrop) then initBackdrop()
+    if not isValid(m.itemIcon) then initItemIcon()
+    if not isValid(m.playedIndicator) then initPlayedIndicator()
 
     m.itemPoster.width = itemData.imageWidth
     m.itemText.maxWidth = itemData.imageWidth
@@ -87,7 +97,9 @@ sub itemContentChanged()
                     if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
                         if itemData.json.UserData.UnplayedItemCount > 0
                             if isValid(m.unplayedCount) then m.unplayedCount.visible = true
-                            m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+                            if isValid(m.unplayedEpisodeCount)
+                                m.unplayedEpisodeCount.text = itemData.json.UserData.UnplayedItemCount
+                            end if
                         end if
                     end if
                 end if


### PR DESCRIPTION
This was fixed before but the crash just moved further down the app. This should hopefully fix it for good

This is one of those crashlogs that says one line in the error text but then the backtrace points to a different line.

Error text: `Function itemcontentchanged() As Void; pkg:/components/home/HomeItem.brs(81)`

Full backtrace:
```
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/home/HomeItem.brs(79) 
Backtrace: 
#0  Function itemcontentchanged() As Voi$1 file/line: pkg:/components/home/HomeItem.brs(81) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:6 
itemdata         roSGNode:HomeData refcnt=1 
localglobal      roSGNode:Node refcnt=2 
playedindicatorleftposition <uninitialized> 
extraprefix      <uninitialized> 
textextra        <uninitialized> 
BRIGHTSCRIPT: ERROR: roSGNode.<lookup>: Rendezvous aborted for LoadItemsTask: pkg:/components/home/LoadItemsTask.brs(55)
```

which points to this line(79) after running build-prod on 2.1.4:
```
m.itemIcon.uri = itemData.iconUrl
```

## Issues
Ref #1164 