### PR TITLE
Prevent subtitle timeout crash

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -1,7 +1,9 @@
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/api/baserequest.bs"
+import "pkg:/source/roku_modules/log/LogMixin.brs"
 
 sub init()
+    m.log = log.Logger("captionTask")
     m.top.observeField("url", "fetchCaption")
     m.top.currentCaption = []
     m.top.currentPos = 0
@@ -41,17 +43,26 @@ sub setFont()
 end sub
 
 sub fetchCaption()
+    m.log.debug("start fetchCaption()")
     m.captionTimer.control = "stop"
     re = CreateObject("roRegex", "(http.*?\.vtt)", "s")
     url = re.match(m.top.url)[0]
+
     if url <> invalid
+        port = createObject("roMessagePort")
         m.reader.setUrl(url)
-        text = m.reader.GetToString()
-        m.captionList = parseVTT(text)
-        m.captionTimer.control = "start"
+        m.reader.setMessagePort(port)
+        if m.reader.AsyncGetToString()
+            msg = port.waitMessage(0)
+            if type(msg) = "roUrlEvent"
+                m.captionList = parseVTT(msg.GetString())
+                m.captionTimer.control = "start"
+            end if
+        end if
     else
         m.captionTimer.control = "stop"
     end if
+    m.log.debug("end fetchCaption()", url)
 end sub
 
 function newlabel(txt)


### PR DESCRIPTION


Comes from roku.com crash log:
```
text             <uninitialized> 
url              roString refcnt=1 val:"http://192.168.1.30:8096/Videos/fb51ac18-d13f-7e61-7821-3ea889a4d2ed/fb51ac18d13f7e6178213ea88"... 
re               roRegex refcnt=1 
m                roAssociativeArray refcnt=2 count:16 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/captionTask.brs(77) 
#0  Function fetchcaption() As Voi$1 Backtrace: 
Execution timeout (runtime error &h23) in pkg:/components/captionTask.brs(77)
```

which points to this line after running build-prod on 2.1.4:
```
text = m.reader.GetToString()
```

## Issues
Ref #1164 