### PR TITLE
Prevent crash on episode list

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -224,8 +224,12 @@ sub Main (args as dynamic) as void
                     ' Find the object in the scene's data and update its json data
                     for i = 0 to currentScene.objects.Items.count() - 1
                         if LCase(currentScene.objects.Items[i].id) = LCase(currentEpisode.id)
-                            currentScene.objects.Items[i].json = api.users.GetItem(m.global.session.user.id, currentEpisode.id)
-                            m.global.queueManager.callFunc("setTopStartingPoint", currentScene.objects.Items[i].json.UserData.PlaybackPositionTicks)
+
+                            data = api.users.GetItem(m.global.session.user.id, currentEpisode.id)
+                            if isValid(data)
+                                currentScene.objects.Items[i].json = data
+                                m.global.queueManager.callFunc("setTopStartingPoint", data.UserData.PlaybackPositionTicks)
+                            end if
                             exit for
                         end if
                     end for


### PR DESCRIPTION
Validate data from api to prevent crash on episode list

Comes from roku.com crash log:
```
info             <uninitialized> 
trackselected    <uninitialized> 
panel            <uninitialized> 
button           <uninitialized> 
movie            <uninitialized> 
trailerdata      <uninitialized> 
buttons          <uninitialized> 
btn              <uninitialized> 
startingpoint    <uninitialized> 
results          <uninitialized> 
options          <uninitialized> 
query            <uninitialized> 
viewhandled      <uninitialized> 
screencontent    <uninitialized> 
selectedindex    <uninitialized> 
albums           <uninitialized> 
series           roSGNode:TVShowDetails refcnt=1 
ptr              roArray refcnt=1 count:2 
node             roSGNode:TVSeasonData refcnt=1 
photoplayer      <uninitialized> 
photoalbumdata   <uninitialized> 
showplaybackoptiondialog <uninitialized> 
audio_stream_idx Integer val:0 (&h0) 
selecteditemtype roString refcnt=1 val:"Episode" 
selecteditem     roInvalid refcnt=1 
popupnode        <uninitialized> 
inputeventvideo  <uninitialized> 
posttask         <uninitialized> 
tmpglobaldevice  <uninitialized> 
event            roAssociativeArray refcnt=1 count:2 
retryvideo       <uninitialized> 
video            <uninitialized> 
moviemetadata    <uninitialized> 
seasonmetadata   <uninitialized> 
i                Integer val:21 (&h15) 
currentepisode   roAssociativeArray refcnt=1 count:31 
currentscene     roSGNode:TVEpisodes refcnt=1 
elapsed          <uninitialized> 
itemtype         <uninitialized> 
reportingnodetype <uninitialized> 
itemnode         <uninitialized> 
reportingnode    <uninitialized> 
timespan         <uninitialized> 
msg              roSGNodeEvent refcnt=1 
deeplinkvideo    <uninitialized> 
device           roDeviceInfo refcnt=1 
input            roInput refcnt=1 
dialog           <uninitialized> 
userslastrunversion roString refcnt=1 val:"2.1.4" 
filename         <uninitialized> 
re               <uninitialized> 
configencoding   roAssociativeArray refcnt=1 count:43 
group            roSGNode:TVEpisodes refcnt=1 
scenemanager     roSGNode:SceneManager refcnt=1 
playstatetask    roSGNode:PlaystateTask refcnt=1 
m                roAssociativeArray refcnt=2 count:6 
global           Interface:ifGloba$1 args             roAssociativeArray refcnt=2 count:4 
Local Variables: 
   file/line: pkg:/source/Main.brs(215) 
#0  Function main(args As Dynamic) As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(215)
```

which points to this line after running build-prod on 2.1.4:
```
m.global.queueManager.callFunc("setTopStartingPoint", currentScene.objects.Items[i].json.UserData.PlaybackPositionTicks)
```

## Issues
Ref #1164 