### PR TITLE
Prevent crash when refreshing movie details

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -244,15 +244,19 @@ sub Main (args as dynamic) as void
             currentScene = m.global.sceneManager.callFunc("getActiveScene")
 
             if isValid(currentScene) and isValid(currentScene.itemContent) and isValid(currentScene.itemContent.id)
-                ' Refresh movie detail data
-                currentScene.itemContent.json = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
-                movieMetaData = ItemMetaData(currentScene.itemContent.id)
+                data = api.users.GetItem(m.global.session.user.id, currentScene.itemContent.id)
+                if isValid(data)
+                    currentScene.itemContent.json = data
+                    ' Set updated starting point for the queue item
+                    m.global.queueManager.callFunc("setTopStartingPoint", data.UserData.PlaybackPositionTicks)
 
-                ' Redraw movie poster
-                currentScene.newPosterImageURI = movieMetaData.posterURL
-
-                ' Set updated starting point for the queue item
-                m.global.queueManager.callFunc("setTopStartingPoint", currentScene.itemContent.json.UserData.PlaybackPositionTicks)
+                    ' Refresh movie detail data
+                    movieMetaData = ItemMetaData(currentScene.itemContent.id)
+                    if isValid(movieMetaData)
+                        ' Redraw movie poster
+                        currentScene.newPosterImageURI = movieMetaData.posterURL
+                    end if
+                end if
             end if
 
             stopLoadingSpinner()


### PR DESCRIPTION
Caused by loss of connection to the server. This was fixed before but the crash just moved further down the app. This should fix it for good.

Comes from roku.com crash log:
```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/source/Main.brs(238) 
Backtrace: 
#0  Function main(args As Dynamic) As Voi$1 file/line: pkg:/source/Main.brs(238) 
Local Variables: 
args             roAssociativeArray refcnt=2 count:4 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:6 
playstatetask    roSGNode:PlaystateTask refcnt=1 
scenemanager     roSGNode:SceneManager refcnt=1 
group            roSGNode:MovieDetails refcnt=1 
configencoding   roAssociativeArray refcnt=1 count:43 
re               <uninitialized> 
filename         <uninitialized> 
userslastrunversion roString refcnt=1 val:"2.1.4" 
dialog           <uninitialized> 
input            roInput refcnt=1 
device           roDeviceInfo refcnt=1 
deeplinkvideo    <uninitialized> 
msg              roSGNodeEvent refcnt=1 
timespan         <uninitialized> 
reportingnode    <uninitialized> 
itemnode         <uninitialized> 
reportingnodetype <uninitialized> 
itemtype         <uninitialized> 
elapsed          <uninitialized> 
currentscene     roSGNode:MovieDetails refcnt=1 
currentepisode   <uninitialized> 
i                <uninitialized> 
seasonmetadata   <uninitialized> 
moviemetadata    roSGNode:MovieData refcnt=1 
selecteditem     roSGNode:MovieData refcnt=1 
selecteditemtype roString refcnt=1 val:"Movie" 
audio_stream_idx roInt refcnt=1 val:0 (&h0) 
showplaybackoptiondialog <uninitialized> 
photoalbumdata   <uninitialized> 
photoplayer      <uninitialized> 
node             <uninitialized> 
ptr              <uninitialized> 
series           <uninitialized> 
albums           <uninitialized> 
selectedindex    <uninitialized> 
screencontent    <uninitialized> 
viewhandled      <uninitialized> 
query            <uninitialized> 
options          <uninitialized> 
results          <uninitialized> 
btn              roSGNode:Button refcnt=1 
buttons          <uninitialized> 
trailerdata      <uninitialized> 
movie            <uninitialized> 
button           <uninitialized> 
panel            <uninitialized> 
trackselected    <uninitialized> 
info             <uninitialized> 
video            <uninitialized> 
retryvideo       <uninitialized> 
event            roAssociativeArray refcnt=1 count:1 
tmpglobaldevice  <uninitialized> 
posttask         <uninitialized> 
inputeventvideo  <uninitialized> 
popupnode        <uninitialized> 
startingpoint    <uninitialized>
```

which points to this line after running build-prod on 2.1.4:
```
m.global.queueManager.callFunc("setTopStartingPoint", currentScene.itemContent.json.UserData.PlaybackPositionTicks)
```

## Issues
Ref #1164 