### PR TITLE
Prevent crash when hitting play from movie details

### DIFF
--- a/source/Main.bs
+++ b/source/Main.bs
@@ -574,36 +574,41 @@ sub Main (args as dynamic) as void
             ' If a button is selected, we have some determining to do
             btn = getButton(msg)
             group = sceneManager.callFunc("getActiveScene")
+
             if isValid(btn) and btn.id = "play-button"
+                if not isValid(group) then return
+
                 ' User chose Play button from movie detail view
                 startLoadingSpinner()
                 ' Check if a specific Audio Stream was selected
                 audio_stream_idx = 0
-                if isValid(group) and isValid(group.selectedAudioStreamIndex)
+                if isValid(group.selectedAudioStreamIndex)
                     audio_stream_idx = group.selectedAudioStreamIndex
                 end if
 
-                group.itemContent.selectedAudioStreamIndex = audio_stream_idx
-                group.itemContent.id = group.selectedVideoStreamId
+                if isValid(group.itemContent)
+                    group.itemContent.selectedAudioStreamIndex = audio_stream_idx
+                    group.itemContent.id = group.selectedVideoStreamId
 
-                ' Display playback options dialog
-                if group.itemContent.json.userdata.PlaybackPositionTicks > 0
-                    m.global.queueManager.callFunc("hold", group.itemContent)
-                    playbackOptionDialog(group.itemContent.json.userdata.PlaybackPositionTicks, group.itemContent.json)
-                else
-                    m.global.queueManager.callFunc("clear")
-                    m.global.queueManager.callFunc("push", group.itemContent)
-                    m.global.queueManager.callFunc("playQueue")
+                    ' Display playback options dialog
+                    if group.itemContent.json.userdata.PlaybackPositionTicks > 0
+                        m.global.queueManager.callFunc("hold", group.itemContent)
+                        playbackOptionDialog(group.itemContent.json.userdata.PlaybackPositionTicks, group.itemContent.json)
+                    else
+                        m.global.queueManager.callFunc("clear")
+                        m.global.queueManager.callFunc("push", group.itemContent)
+                        m.global.queueManager.callFunc("playQueue")
+                    end if
                 end if
 
-                if isValid(group) and isValid(group.lastFocus) and isValid(group.lastFocus.id) and group.lastFocus.id = "main_group"
+                if isValid(group.lastFocus) and isValid(group.lastFocus.id) and group.lastFocus.id = "main_group"
                     buttons = group.findNode("buttons")
                     if isValid(buttons)
                         group.lastFocus = group.findNode("buttons")
                     end if
                 end if
 
-                if isValid(group) and isValid(group.lastFocus)
+                if isValid(group.lastFocus)
                     group.lastFocus.setFocus(true)
                 end if
 


### PR DESCRIPTION
Not sure the root cause. Using the movie detail screen to play a tv episode maybe?

Comes from roku.com crash log:
```
args             roAssociativeArray refcnt=2 count:4 
m                roAssociativeArray refcnt=2 count:6 
playstatetask    roSGNode:PlaystateTask refcnt=1 
scenemanager     roSGNode:SceneManager refcnt=1 
group            roSGNode:VideoPlayerView refcnt=1 
configencoding   roAssociativeArray refcnt=1 count:39 
re               <uninitialized> 
filename         <uninitialized> 
userslastrunversion roString refcnt=1 val:"2.1.4" 
dialog           <uninitialized> 
input            roInput refcnt=1 
device           roDeviceInfo refcnt=1 
deeplinkvideo    <uninitialized> 
msg              roSGNodeEvent refcnt=1 
timespan         <uninitialized> 
reportingnode    <uninitialized> 
itemnode         <uninitialized> 
reportingnodetype <uninitialized> 
itemtype         <uninitialized> 
elapsed          <uninitialized> 
currentscene     <uninitialized> 
currentepisode   <uninitialized> 
i                <uninitialized> 
seasonmetadata   <uninitialized> 
moviemetadata    <uninitialized> 
selecteditem     roSGNode:MovieData refcnt=1 
selecteditemtype roString refcnt=1 val:"Movie" 
audio_stream_idx Integer val:0 (&h0) 
showplaybackoptiondialog <uninitialized> 
photoalbumdata   <uninitialized> 
photoplayer      <uninitialized> 
node             <uninitialized> 
ptr              <uninitialized> 
series           <uninitialized> 
albums           <uninitialized> 
selectedindex    <uninitialized> 
screencontent    <uninitialized> 
viewhandled      <uninitialized> 
query            <uninitialized> 
options          <uninitialized> 
results          <uninitialized> 
btn              roSGNode:Button refcnt=1 
buttons          <uninitialized> 
trailerdata      <uninitialized> 
movie            <uninitialized> 
button           <uninitialized> 
panel            <uninitialized> 
trackselected    <uninitialized> 
info             <uninitialized> 
video            <uninitialized> 
retryvideo       <uninitialized> 
event            roAssociativeArray refcnt=1 count:2 
tmpglobaldevice  <uninitialized> 
posttask         <uninitialized> 
inputeventvideo  <uninitialized> 
popupnode        <uninitialized> 
startingpoint    <uninitialized> 
global           Interface:ifGloba$1 Invalid value for left-side of expression. (runtime error &he4) in pkg:/source/Main.brs(545) 
Backtrace: 
#0  Function main(args As Dynamic) As Voi$1 file/line: pkg:/source/Main.brs(546) 
Local Variables:
```

which points to this line after running build-prod on 2.1.4: (545)
```
group.itemContent.selectedAudioStreamIndex = audio_stream_idx
```

## Issues
Ref #1164 