### PR TITLE
Prevent crash on TV show page when shuffling

### DIFF
--- a/components/tvshows/TVShowDetails.bs
+++ b/components/tvshows/TVShowDetails.bs
@@ -181,8 +181,10 @@ end function
 
 sub onShuffleEpisodeDataLoaded()
     m.getShuffleEpisodesTask.unobserveField("data")
-    m.global.queueManager.callFunc("set", m.getShuffleEpisodesTask.data.items)
-    m.global.queueManager.callFunc("playQueue")
+    if isValid(m.getShuffleEpisodesTask.data)
+        m.global.queueManager.callFunc("set", m.getShuffleEpisodesTask.data.items)
+        m.global.queueManager.callFunc("playQueue")
+    end if
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean


### PR DESCRIPTION
Caused by loss of connection to the api server

Comes from roku.com crash log:
```
m                roAssociativeArray refcnt=2 count:9 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/tvshows/TVShowDetails.brs(165) 
#0  Function onshuffleepisodedataloaded() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/tvshows/TVShowDetails.brs(165)
```

which points to this line after running build-prod on 2.1.4:
```
m.global.queueManager.callFunc("set", m.getShuffleEpisodesTask.data.items)
```

## Issues
Ref #1164 