### PR TITLE
Prevent home screen crash. Validate user setting data

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -83,7 +83,8 @@ sub itemContentChanged()
 
         if LCase(itemData.type) = "series"
             if isValid(localGlobal) and isValid(localGlobal.session) and isValid(localGlobal.session.user) and isValid(localGlobal.session.user.settings)
-                if not localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"]
+                unwatchedEpisodeCountSetting = localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"]
+                if isValid(unwatchedEpisodeCountSetting) and not unwatchedEpisodeCountSetting
                     if isValid(itemData.json.UserData) and isValid(itemData.json.UserData.UnplayedItemCount)
                         if itemData.json.UserData.UnplayedItemCount > 0
                             if isValid(m.unplayedCount) then m.unplayedCount.visible = true


### PR DESCRIPTION

Comes from roku.com crash log:
```
textextra        <uninitialized> 
extraprefix      <uninitialized> 
playedindicatorleftposition <uninitialized> 
localglobal      roSGNode:Node refcnt=2 
itemdata         roSGNode:HomeData refcnt=1 
m                roAssociativeArray refcnt=2 count:15 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/home/HomeItem.brs(87) 
#0  Function itemcontentchanged() As Voi$1 Backtrace: 
Type Mismatch. Operator "not" can't be applied to "Invalid". (runtime error &h18) in pkg:/components/home/HomeItem.brs(87)
```

which points to this line after running build-prod on 2.1.4:
```
if not localGlobal.session.user.settings["ui.tvshows.disableUnwatchedEpisodeCount"]
```

## Issues
Ref #1164 