### PR TITLE
Prevent crash on `GridItemSmall`

### DIFF
--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -4,7 +4,7 @@ import "pkg:/source/utils/config.bs"
 sub init()
     m.itemPoster = m.top.findNode("itemPoster")
     m.posterText = m.top.findNode("posterText")
-    m.title = m.top.findNode("title")
+    initTitle()
     m.posterText.font.size = 30
     m.title.font.size = 25
     m.backdrop = m.top.findNode("backdrop")
@@ -21,6 +21,10 @@ sub init()
     if m.topParent.imageDisplayMode <> invalid
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
+end sub
+
+sub initTitle()
+    m.title = m.top.findNode("title")
 end sub
 
 sub itemContentChanged()
@@ -54,6 +58,8 @@ sub itemContentChanged()
 end sub
 
 sub focusChanged()
+    if not isValid(m.title) then initTitle()
+
     if m.top.itemHasFocus = true
         m.title.repeatCount = -1
     else


### PR DESCRIPTION


Comes from roku.com crash log:
```
Invalid value for left-side of expression. (runtime error &he4) in pkg:/components/ItemGrid/GridItemSmall.brs(51) 
Backtrace: 
#0  Function focuschanged() As Voi$1 file/line: pkg:/components/ItemGrid/GridItemSmall.brs(53) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:2
```

which points to this line after running build-prod on 2.1.4:
```
m.title.repeatCount = 0
```

## Issues
Ref #1164 