### PR TITLE
Prevent crash on music artist grid view

### DIFF
--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -18,10 +18,8 @@ sub init()
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
     end if
 
-    m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
     m.posterText.visible = false
     m.postTextBackground.visible = false
-
 end sub
 
 sub itemContentChanged()


### PR DESCRIPTION
`m.gridTitles` isn't used so I removed it.


Comes from roku.com crash log:
```
m                roAssociativeArray refcnt=2 count:7 
global           Interface:ifGloba$1 Local Variables: 
   file/line: pkg:/components/ItemGrid/MusicArtistGridItem.brs(17) 
#0  Function init() As Voi$1 Backtrace: 
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/ItemGrid/MusicArtistGridItem.brs(17)
```

which points to this line after running build-prod on 2.1.4:
```
m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
```

## Issues
Ref #1164 