### PR TITLE
Prevent crash when viewing person details

### DIFF
--- a/components/data/PersonData.bs
+++ b/components/data/PersonData.bs
@@ -4,9 +4,12 @@ import "pkg:/source/utils/config.bs"
 
 sub setFields()
     json = m.top.json
+    m.top.Type = "Person"
+
+    if json = invalid then return
+
     m.top.id = json.id
     m.top.favorite = json.UserData.isFavorite
-    m.top.Type = "Person"
     setPoster()
 end sub
 


### PR DESCRIPTION
Caused by loss of connection to the server. 

Comes from roku.com crash log:
```
'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in pkg:/components/data/PersonData.brs(7) 
Backtrace: 
#0  Function setfields() As Voi$1 file/line: pkg:/components/data/PersonData.brs(7) 
Local Variables: 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=2 count:2 
json             Invalid
```

which points to this line after running build-prod on 2.1.4:
```
m.top.id = json.id
```

## Issues
Ref #1164 