### PR TITLE
Prevent crash when video path is invalid

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -350,11 +350,15 @@ sub addVideoContentURL(video, mediaSourceId, audio_stream_idx, fully_external)
     protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
     if protocol <> "file"
         uri = parseUrl(m.playbackInfo.MediaSources[0].Path)
-        if isLocalhost(uri[2])
+        if not isValidAndNotEmpty(uri) then return
+
+        if isValid(uri[2]) and isLocalhost(uri[2])
             ' if the domain of the URI is local to the server,
             ' create a new URI by appending the received path to the server URL
             ' later we will substitute the users provided URL for this case
-            video.content.url = buildURL(uri[4])
+            if isValid(uri[4])
+                video.content.url = buildURL(uri[4])
+            end if
         else
             fully_external = true
             video.content.url = m.playbackInfo.MediaSources[0].Path

--- a/source/VideoPlayer.bs
+++ b/source/VideoPlayer.bs
@@ -263,16 +263,20 @@ sub AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx 
         protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
         if protocol <> "file"
             uri = parseUrl(m.playbackInfo.MediaSources[0].Path)
-            if isLocalhost(uri[2])
+            if not isValidAndNotEmpty(uri) then return
+
+            if isValid(uri[2]) and isLocalhost(uri[2])
                 ' the domain of the URI is local to the server.
                 ' create a new URI by appending the received path to the server URL
                 ' later we will substitute the users provided URL for this case
-                video.content.url = buildURL(uri[4])
+                if isValid(uri[4])
+                    video.content.url = buildURL(uri[4])
+                end if
             else
                 fully_external = true
                 video.content.url = m.playbackInfo.MediaSources[0].Path
             end if
-        else:
+        else
             params.append({
                 "Static": "true",
                 "Container": video.container,


### PR DESCRIPTION
Don't send `invalid` to `isLocalHost()`

Comes from roku.com crash log:
```
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(190) 
m                roAssociativeArray refcnt=6 count:3 
#2  Function loaditems_addvideocontent(video As Object, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(322) 
#3  Function addvideocontenturl(video As Dynamic, mediasourceid As Dynamic, audio_stream_idx As Dynamic, fully_external As Dynamic) As Voi$1 file/line: pkg:/source/utils/misc.brs(389) 
#4  Function islocalhost(url As String) As Boolea$1 Backtrace: 
Type Mismatch. Unable to cast "Invalid" to "String". (runtime error &h18) in pkg:/source/utils/misc.brs(387) 
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(54) 
   file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(46) 
Local Variables: 
#0  Function loaditems() As Voi$1 global           Interface:ifGloba$1 url              Invalid
```

which points to this line after running build-prod on 2.1.4:
```
function isLocalhost(url as string) as boolean
```

## Issues
Ref #1164 
