### PR TITLE
Prevent crash and Update video player meta data

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -79,6 +79,16 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     session.video.Update(meta)
+
+    if isValid(meta.json.MediaSources[0].RunTimeTicks)
+        if meta.json.MediaSources[0].RunTimeTicks = 0
+            video.length = 0
+        else
+            video.length = meta.json.MediaSources[0].RunTimeTicks / 10000000
+        end if
+    end if
+    video.MaxVideoDecodeResolution = [meta.json.MediaSources[0].MediaStreams[0].Width, meta.json.MediaSources[0].MediaStreams[0].Height]
+
     subtitle_idx = m.top.selectedSubtitleIndex
     videotype = LCase(meta.type)
 
@@ -183,6 +193,11 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     video.container = getContainerType(meta)
+    if video.container = "mp4"
+        video.content.StreamFormat = "mp4"
+    else if video.container = "mkv"
+        video.content.StreamFormat = "mkv"
+    end if
 
     if not isValid(m.playbackInfo.MediaSources[0])
         m.playbackInfo = meta.json

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -38,28 +38,31 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
     end if
 
     if audioTrackIndex > -1
-        params.AudioStreamIndex = audioTrackIndex
-
-        ' force the server to transcode AAC profiles we don't support to MP3 instead of the usual AAC
-        ' TODO: Remove this after server adds support for transcoding AAC from one profile to another
         selectedAudioStream = m.global.session.video.json.MediaStreams[audioTrackIndex]
 
-        if LCase(selectedAudioStream.Codec) = "aac"
-            if LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
-                for each rule in deviceProfile.TranscodingProfiles
-                    if rule.Container = "ts" or rule.Container = "mp4"
-                        if rule.AudioCodec = "aac"
-                            rule.AudioCodec = "mp3"
-                        else if rule.AudioCodec.Left(4) = "aac,"
-                            rule.AudioCodec = mid(rule.AudioCodec, 5)
+        if selectedAudioStream <> invalid
+            params.AudioStreamIndex = audioTrackIndex
 
-                            if rule.AudioCodec.Left(3) <> "mp3"
-                                rule.AudioCodec = "mp3," + rule.AudioCodec
+            ' force the server to transcode AAC profiles we don't support to MP3 instead of the usual AAC
+            ' TODO: Remove this after server adds support for transcoding AAC from one profile to another
+            if LCase(selectedAudioStream.Codec) = "aac"
+                if LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
+                    for each rule in deviceProfile.TranscodingProfiles
+                        if rule.Container = "ts" or rule.Container = "mp4"
+                            if rule.AudioCodec = "aac"
+                                rule.AudioCodec = "mp3"
+                            else if rule.AudioCodec.Left(4) = "aac,"
+                                rule.AudioCodec = mid(rule.AudioCodec, 5)
+
+                                if rule.AudioCodec.Left(3) <> "mp3"
+                                    rule.AudioCodec = "mp3," + rule.AudioCodec
+                                end if
                             end if
                         end if
-                    end if
-                end for
+                    end for
+                end if
             end if
+
         end if
     end if
 


### PR DESCRIPTION
## Changes
- Validate data to prevent crash introduced in #1963
- Add video length
- Add MaxVideoDecodeResolution 
  - https://developer.roku.com/en-ca/docs/references/scenegraph/media-playback-nodes/video.md#miscellaneous-fields
  - Ref #1554 There is a chance this fixes some bugs and I see no downside to setting this to the currently playing video's width and height
- Add StreamFormat (mp4 or mkv)
  - The docs specifically talk about mp4 needing this setting but doesn't mention why? Adding this can only help IMO https://developer.roku.com/en-ca/docs/developer-program/core-concepts/playing-videos.md#mpeg-4-playback
  - https://developer.roku.com/en-ca/docs/developer-program/getting-started/architecture/content-metadata.md#playback-configuration-attributes

