### PR TITLE
Improve direct play support for HDR files

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -416,12 +416,7 @@ end function
 function getCodecProfiles() as object
     myGlobal = m.global
     globalUserSettings = myGlobal.session.user.settings
-    displayMaxBitDepth = myGlobal.device.videoBitDepth
-    if displayMaxBitDepth = invalid
-        displayMaxBitDepth = "8"
-    else
-        displayMaxBitDepth = displayMaxBitDepth.toStr()
-    end if
+
     codecProfiles = []
     profileSupport = {
         "h264": {},
@@ -632,12 +627,6 @@ function getCodecProfiles() as object
                 "IsRequired": false
             },
             {
-                "Condition": "LessThanEqual",
-                "Property": "VideoBitDepth",
-                "Value": "8",
-                "IsRequired": false
-            },
-            {
                 "Condition": "EqualsAny",
                 "Property": "VideoProfile",
                 "Value": h264AssProfiles.Keys().join("|"),
@@ -696,13 +685,7 @@ function getCodecProfiles() as object
                     "Property": "VideoLevel",
                     "Value": mpeg2Levels.join("|"),
                     "IsRequired": false
-                },
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitDepth",
-                    "Value": displayMaxBitDepth,
-                    "IsRequired": false
-                },
+                }
             ]
         }
 
@@ -738,12 +721,6 @@ function getCodecProfiles() as object
             "Type": "Video",
             "Codec": "av1",
             "Conditions": [
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitDepth",
-                    "Value": displayMaxBitDepth,
-                    "IsRequired": false
-                },
                 {
                     "Condition": "EqualsAny",
                     "Property": "VideoProfile",
@@ -803,12 +780,6 @@ function getCodecProfiles() as object
             "Type": "Video",
             "Codec": "hevc",
             "Conditions": [
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitDepth",
-                    "Value": displayMaxBitDepth,
-                    "IsRequired": false
-                },
                 {
                     "Condition": "NotEquals",
                     "Property": "IsAnamorphic",
@@ -878,12 +849,6 @@ function getCodecProfiles() as object
             "Type": "Video",
             "Codec": "vp9",
             "Conditions": [
-                {
-                    "Condition": "LessThanEqual",
-                    "Property": "VideoBitDepth",
-                    "Value": displayMaxBitDepth,
-                    "IsRequired": false
-                },
                 {
                     "Condition": "EqualsAny",
                     "Property": "VideoProfile",

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -562,27 +562,44 @@ function getCodecProfiles() as object
     hevcVideoRangeTypes = "SDR"
     vp9VideoRangeTypes = "SDR"
     av1VideoRangeTypes = "SDR"
+    canPlayDovi = false
 
     if canPlay4k()
         dp = di.GetDisplayProperties()
+
+        if dp.DolbyVision
+            canPlayDovi = true
+
+            h264VideoRangeTypes = h264VideoRangeTypes + "|DOVI|DOVIWithSDR"
+            hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVI|DOVIWithSDR"
+            av1VideoRangeTypes = av1VideoRangeTypes + "|DOVI|DOVIWithSDR"
+        end if
+
         if dp.Hdr10
             hevcVideoRangeTypes = hevcVideoRangeTypes + "|HDR10"
             vp9VideoRangeTypes = vp9VideoRangeTypes + "|HDR10"
             av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10"
+
+            if canPlayDovi
+                hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVIWithHDR10"
+                av1VideoRangeTypes = av1VideoRangeTypes + "|DOVIWithHDR10"
+            end if
         end if
+
         if dp.Hdr10Plus
             av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10+"
         end if
+
         if dp.HLG
             hevcVideoRangeTypes = hevcVideoRangeTypes + "|HLG"
             vp9VideoRangeTypes = vp9VideoRangeTypes + "|HLG"
             av1VideoRangeTypes = av1VideoRangeTypes + "|HLG"
-        end if
-        if dp.DolbyVision
-            h264VideoRangeTypes = h264VideoRangeTypes + "|DOVI"
-            hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVI"
-            'vp9VideoRangeTypes = vp9VideoRangeTypes + ",DOVI" no evidence that vp9 can hold DOVI
-            av1VideoRangeTypes = av1VideoRangeTypes + "|DOVI"
+
+            if canPlayDovi
+                hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVIWithHLG"
+                vp9VideoRangeTypes = vp9VideoRangeTypes + "|DOVIWithHLG"
+                av1VideoRangeTypes = av1VideoRangeTypes + "|DOVIWithHLG"
+            end if
         end if
     end if
 

--- a/source/utils/globals.bs
+++ b/source/utils/globals.bs
@@ -44,6 +44,7 @@ end sub
 ' Save information from roDeviceInfo to m.global.device
 sub SaveDeviceToGlobal()
     deviceInfo = CreateObject("roDeviceInfo")
+    displayProperties = deviceInfo.GetDisplayProperties()
 
     ' remove special characters
     regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
@@ -98,6 +99,7 @@ sub SaveDeviceToGlobal()
     end if
     videoWidth = heightToWidth[videoHeight]
     if extraData <> invalid and extraData = "b10" then bitDepth = 10
+    if bitDepth = 8 and displayProperties.HdrSeamless then bitDepth = 10
     if videoHeight = "4320" then bitDepth = 12
 
     m.global.addFields({

--- a/source/utils/globals.bs
+++ b/source/utils/globals.bs
@@ -97,11 +97,8 @@ sub SaveDeviceToGlobal()
         print "ERROR parsing deviceInfo.GetVideoMode()"
     end if
     videoWidth = heightToWidth[videoHeight]
-    if videoHeight = "2160" and extraData = "b10"
-        bitDepth = 10
-    else if videoHeight = "4320"
-        bitDepth = 12
-    end if
+    if extraData <> invalid and extraData = "b10" then bitDepth = 10
+    if videoHeight = "4320" then bitDepth = 12
 
     m.global.addFields({
         device: {

--- a/source/utils/globals.bs
+++ b/source/utils/globals.bs
@@ -44,7 +44,6 @@ end sub
 ' Save information from roDeviceInfo to m.global.device
 sub SaveDeviceToGlobal()
     deviceInfo = CreateObject("roDeviceInfo")
-    displayProperties = deviceInfo.GetDisplayProperties()
 
     ' remove special characters
     regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
@@ -99,7 +98,6 @@ sub SaveDeviceToGlobal()
     end if
     videoWidth = heightToWidth[videoHeight]
     if extraData <> invalid and extraData = "b10" then bitDepth = 10
-    if bitDepth = 8 and displayProperties.HdrSeamless then bitDepth = 10
     if videoHeight = "4320" then bitDepth = 12
 
     m.global.addFields({


### PR DESCRIPTION
Adds `DOVIWithSDR`, `DOVIWithHDR10`, and `DOVIWithHLG` video ranges to the device profile if support is detected. Files with these video ranges should now direct play as expected.

## Issues
Remake of #1919 Credit to @Skin80
