### PR TITLE
Prevent crash when audio codec is invalid

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -47,8 +47,8 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
 
             ' force the server to transcode AAC profiles we don't support to MP3 instead of the usual AAC
             ' TODO: Remove this after server adds support for transcoding AAC from one profile to another
-            if LCase(selectedAudioStream.Codec) = "aac"
-                if LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
+            if selectedAudioStream.Codec <> invalid and LCase(selectedAudioStream.Codec) = "aac"
+                if selectedAudioStream.Profile <> invalid and LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
                     for each rule in deviceProfile.TranscodingProfiles
                         if rule.Container = "ts" or rule.Container = "mp4"
                             if rule.AudioCodec = "aac"


### PR DESCRIPTION
From roku crash log 2.1.8

```
if LCase(selectedAudioStream.Codec) = "aac"
```

```
Type Mismatch. (runtime error &h18) in pkg:/source/api/Items.brs(45) 
Backtrace: 
#3  Function itempostplaybackinfo(id As String, mediasourceid As String, audiotrackindex As Integer, subtitletrackindex As Integer, starttimeticks As LongInteger) As Dynami$1 file/line: pkg:/source/api/Items.brs(45) 
#2  Function loaditems_addvideocontent(video As Object, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(138) 
#1  Function loaditems_videoplayer(id As String, mediasourceid As Dynamic, audio_stream_idx As Integer, forcetranscoding As Boolean) As Dynami$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(55) 
#0  Function loaditems() As Voi$1 file/line: pkg:/components/ItemGrid/LoadVideoContentTask.brs(47) 
Local Variables: 
id               roString (2.1 was String) refcnt=7 val:"6c9c3889ad597ffdbe8d66ec365cef8e" 
mediasourceid    roString (2.1 was String) refcnt=7 val:"6c9c3889ad597ffdbe8d66ec365cef8e" 
audiotrackindex  Integer val:1 (&h1) 
subtitletrackindex Integer val:-2 (&hFFFFFFFE) 
starttimeticks   LongInteger refcnt=3 val:0 (&h0) 
global           Interface:ifGloba$1 m                roAssociativeArray refcnt=5 count:2 
params           roAssociativeArray refcnt=1 count:9 
deviceprofile    roAssociativeArray refcnt=1 count:17 
myglobal         roSGNode:Node refcnt=2 
selectedaudiostream roAssociativeArray refcnt=1 count:18 
rule             <uninitialized> 
req              <uninitialized>
```

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
