### PR TITLE
Improve Direct Play support for AV1 codec

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -301,21 +301,11 @@ function getTranscodingProfiles() as object
     end if
 
     ' AV1
-    for each container in transcodingContainers
-        if di.CanDecodeVideo({ Codec: "av1", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",av1") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",av1"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",av1") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",av1"
-                end if
-            end if
-        end if
-    end for
+    ' CanDecodeVideo() returns false for AV1 when the container is provided
+    ' Manually add AV1 to the mp4VideoCodecs list if support is detected
+    if di.CanDecodeVideo({ Codec: "av1" }).Result
+        mp4VideoCodecs = mp4VideoCodecs + ",av1"
+    end if
 
     ' AUDIO CODECS
     for each container in transcodingContainers


### PR DESCRIPTION
Files with the AV1 codec will now always copy the video stream when support is detected instead of transcoding when the audio stream is incompatible.

## Changes
- Don't pass container to `CanDecodeVideo()` when checking for av1 support. Manually add codec to mp4 codec list if suport is detected

## Issues
Fixes #1851 
