### PR TITLE
Fix forced subs keep Roku subs set to "On Always"

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -9,6 +9,7 @@ sub init()
     m.top.getScene().findNode("overhang").visible = false
     userSettings = m.global.session.user.settings
     m.currentItem = m.global.queueManager.callFunc("getCurrentItem")
+    m.originalClosedCaptionState = invalid
 
     m.top.id = m.currentItem.id
     m.top.seekMode = "accurate"
@@ -461,7 +462,12 @@ sub onVideoContentLoaded()
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
         if availableSubtitleTrackIndex <> -1
             if not selectedSubtitle.IsEncoded
-                m.top.globalCaptionMode = "On"
+                if selectedSubtitle.IsForced
+                    ' If IsForced, make sure to remember the Roku global setting so we
+                    ' can set it back when the video is done playing.
+                    m.originalClosedCaptionState = m.top.globalCaptionMode
+                    m.top.globalCaptionMode = "On"
+                end if
                 m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
             end if
         end if
@@ -695,6 +701,12 @@ sub ReportPlayback(state = "update" as string)
             "LiveStreamId": m.top.transcodeParams.LiveStreamId
         })
         m.bufferCheckTimer.duration = 30
+    end if
+
+    if (state = "stop" or state = "finished") and m.originalClosedCaptionState <> invalid
+        m.log.debug("ReportPlayback() setting", m.top.globalCaptionMode, "back to", m.originalClosedCaptionState)
+        m.top.globalCaptionMode = m.originalClosedCaptionState
+        m.originalClosedCaptionState = invalid
     end if
 
     ' Report playstate via worker task


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix keeping Roku global subtitle settings to "On Always" when a video with Forced subtitles is played.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Remembers the Roku global subtitle setting when playing a video with Forced subtitles and then sets the Roku back to the original state when the video is done playing.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #1665 

## Known Issues
If the user hits "Home" instead of "Back" or letting the video finish on its own, there is no way to set the Roku back to its original settings.