### PR TITLE
Improve AV1 support - Fix direct streaming with no sound

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -211,19 +211,6 @@ function getTranscodingProfiles() as object
     '
     ' AVC / h264 / MPEG4 AVC
     for each container in transcodingContainers
-        if di.CanDecodeVideo({ Codec: "h264", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",h264") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",h264"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",h264") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",h264"
-                end if
-            end if
-        end if
         if di.CanDecodeVideo({ Codec: "mpeg4 avc", Container: container }).Result
             if container = "mp4"
                 ' check for codec string before adding it

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -288,11 +288,9 @@ function getTranscodingProfiles() as object
     end if
 
     ' AV1
-    ' CanDecodeVideo() returns false for AV1 when the container is provided
-    ' Manually add AV1 to the mp4VideoCodecs list if support is detected
-    if di.CanDecodeVideo({ Codec: "av1" }).Result
-        mp4VideoCodecs = mp4VideoCodecs + ",av1"
-    end if
+    ' direct streaming av1 is not supported on roku
+    ' force a full transcode by omitting av1 from the transcoding profile
+    ' https://community.roku.com/t5/Roku-Developer-Program/HLS-fMP4-No-Audio/td-p/607399
 
     ' AUDIO CODECS
     for each container in transcodingContainers


### PR DESCRIPTION
Direct streaming AV1 results in no audio. Changing the container to .ts or .mkv results in no video. This removes av1 from the transcoding profile so that if the audio codec gets changed the video codec gets changed as well.

Roku doesn't seem to support HLS fMP4 https://community.roku.com/t5/Roku-Developer-Program/HLS-fMP4-No-Audio/td-p/607399 which I also confirmed using the stream tester. The audio stream is undetected. I swear the files I used to test #2001 had audio but they definitely don't have audio now 🤷 

If you want your AV1 files to always direct play, you will need a stereo audio stream until Roku fixes this.


## Changes
- Force a full transcode for AV1 instead of direct streaming

## Issues
Ref #1851