### PR TITLE
Subtitle should be on when a default one has been selected by the user.

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -466,8 +466,8 @@ sub onVideoContentLoaded()
                     ' If IsForced, make sure to remember the Roku global setting so we
                     ' can set it back when the video is done playing.
                     m.originalClosedCaptionState = m.top.globalCaptionMode
-                    m.top.globalCaptionMode = "On"
                 end if
+                m.top.globalCaptionMode = "On"
                 m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
             end if
         end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix bug that was introduced by PR #2020.  Default subtitles are no longer shown (even though they are auto selected).
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Logic bug.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2049 
