### PR TITLE
Force LiveTV retry with transcoding when we get an AAC error

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -51,7 +51,12 @@ sub loadItems()
     id = m.top.itemId
     mediaSourceId = invalid
     audio_stream_idx = m.top.selectedAudioStreamIndex
-    forceTranscoding = false
+    if m.top.transcodeLiveTV = true
+        print "forcing retry of Live TV with transcoding..."
+        forceTranscoding = true
+    else
+        forceTranscoding = false
+    end if
 
     m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, forceTranscoding)]
 end sub
@@ -115,6 +120,11 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         end if
     end if
 
+    ' when a retry live TV is happening...
+    if videotype = "tvchannel"
+        meta.live = true
+    end if
+
     video.chapters = meta.json.Chapters
     video.content.title = meta.title
     video.showID = meta.showID
@@ -147,7 +157,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     currentItem = queueManager.callFunc("getCurrentItem")
 
-    if isValid(currentItem) and isValid(currentItem.startingPoint)
+    if isValid(currentItem) and isValid(currentItem.startingPoint) and not meta.live
         playbackPosition = currentItem.startingPoint
     end if
 
@@ -157,7 +167,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     if not isValid(mediaSourceId) then mediaSourceId = video.id
     if meta.live then mediaSourceId = ""
 
-    m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
+    m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceTranscoding)
     if not isValid(m.playbackInfo)
         video.errorMsg = "Error loading playback info"
         video.content = invalid
@@ -174,7 +184,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
             video.SelectedSubtitle = defaultSubtitleIndex
             subtitle_idx = defaultSubtitleIndex
 
-            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
+            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceTranscoding)
             if not isValid(m.playbackInfo)
                 video.errorMsg = "Error loading playback info"
                 video.content = invalid

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -51,23 +51,23 @@ sub loadItems()
     id = m.top.itemId
     mediaSourceId = invalid
     audio_stream_idx = m.top.selectedAudioStreamIndex
-    if m.top.transcodeLiveTV = true
+    forceTranscoding = false
+    forceMP3Audio = false
+    if m.top.forceTranscodeMP3Audio = true
         print "forcing retry of Live TV with transcoding..."
-        forceTranscoding = true
-    else
-        forceTranscoding = false
+        forceMP3Audio = true
     end if
 
-    m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, forceTranscoding)]
+    m.top.content = [LoadItems_VideoPlayer(id, mediaSourceId, audio_stream_idx, forceTranscoding, forceMP3Audio)]
 end sub
 
-function LoadItems_VideoPlayer(id as string, mediaSourceId = invalid as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean) as dynamic
+function LoadItems_VideoPlayer(id as string, mediaSourceId = invalid as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean, forceMP3Audio = false as boolean) as dynamic
 
     video = {}
     video.id = id
     video.content = createObject("RoSGNode", "ContentNode")
 
-    LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx, forceTranscoding)
+    LoadItems_AddVideoContent(video, mediaSourceId, audio_stream_idx, forceTranscoding, forceMP3Audio)
 
     if video.content = invalid
         return invalid
@@ -76,7 +76,7 @@ function LoadItems_VideoPlayer(id as string, mediaSourceId = invalid as dynamic,
     return video
 end function
 
-sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean)
+sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_stream_idx = 1 as integer, forceTranscoding = false as boolean, forceMP3Audio = false as boolean)
 
     meta = ItemMetaData(video.id)
     if not isValid(meta)
@@ -167,7 +167,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     if not isValid(mediaSourceId) then mediaSourceId = video.id
     if meta.live then mediaSourceId = ""
 
-    m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceTranscoding)
+    m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceMP3Audio)
     if not isValid(m.playbackInfo)
         video.errorMsg = "Error loading playback info"
         video.content = invalid
@@ -184,7 +184,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
             video.SelectedSubtitle = defaultSubtitleIndex
             subtitle_idx = defaultSubtitleIndex
 
-            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceTranscoding)
+            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, forceMP3Audio)
             if not isValid(m.playbackInfo)
                 video.errorMsg = "Error loading playback info"
                 video.content = invalid

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -21,5 +21,6 @@
     <!-- Total records available from server-->
     <field id="totalRecordCount" type="int" value="-1" />
     <field id="content" type="array" />
+    <field id="transcodeLiveTV" type="boolean" value="false" />
   </interface>
 </component>

--- a/components/ItemGrid/LoadVideoContentTask.xml
+++ b/components/ItemGrid/LoadVideoContentTask.xml
@@ -21,6 +21,6 @@
     <!-- Total records available from server-->
     <field id="totalRecordCount" type="int" value="-1" />
     <field id="content" type="array" />
-    <field id="transcodeLiveTV" type="boolean" value="false" />
+    <field id="forceTranscodeMP3Audio" type="boolean" value="false" />
   </interface>
 </component>

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -354,7 +354,7 @@ sub onAudioIndexChange()
 end sub
 
 sub RetryLiveTV()
-    m.LoadMetaDataTask.transcodeLiveTV = true
+    m.LoadMetaDataTask.forceTranscodeMP3Audio = true
     m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
     m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
     m.LoadMetaDataTask.itemId = m.currentItem.id

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -34,7 +34,6 @@ sub init()
 
     m.playbackTimer = m.top.findNode("playbackTimer")
     m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
-    m.top.observeField("state", "onState")
     m.top.observeField("content", "onContentChange")
     m.top.observeField("selectedSubtitle", "onSubtitleChange")
     m.top.observeField("audioIndex", "onAudioIndexChange")
@@ -354,6 +353,15 @@ sub onAudioIndexChange()
     m.LoadMetaDataTask.control = "RUN"
 end sub
 
+sub RetryLiveTV()
+    m.LoadMetaDataTask.transcodeLiveTV = true
+    m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
+    m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
+    m.LoadMetaDataTask.itemId = m.currentItem.id
+    m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
+    m.LoadMetaDataTask.control = "RUN"
+end sub
+
 sub onPlaybackErrorDialogClosed(msg)
     sourceNode = msg.getRoSGNode()
     sourceNode.unobserveField("buttonSelected")
@@ -380,6 +388,7 @@ end sub
 sub onVideoContentLoaded()
     m.LoadMetaDataTask.unobserveField("content")
     m.LoadMetaDataTask.control = "STOP"
+    m.top.observeField("state", "onState")
 
     videoContent = m.LoadMetaDataTask.content
     m.LoadMetaDataTask.content = []
@@ -639,6 +648,12 @@ sub onState(msg)
 
         if not m.playReported and m.top.transcodeAvailable
             m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
+        else if Instr(1, m.top.errorStr, "Unsupported AAC stream") > 0
+            ' Some Live TV streams use HE-AAC which Roku doesn't support
+            m.top.unobserveField("state")
+            m.playbackTimer.control = "stop"
+            RetryLiveTV()
+            return
         else
             ' If an error was encountered, Display dialog
             showPlaybackErrorDialog(tr("Error During Playback"))

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -13,7 +13,7 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     return getJson(resp)
 end function
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger, forceLiveTVTranscode = false)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger, forceMP3 = false)
     params = {
         "UserId": m.global.session.user.id,
         "StartTimeTicks": startTimeTicks,
@@ -39,16 +39,16 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
 
     myGLobal = m.global
 
-    if audioTrackIndex > -1 and myGLobal.session.video.json.MediaStreams <> invalid or forceLiveTVTranscode
+    if audioTrackIndex > -1 and myGLobal.session.video.json.MediaStreams <> invalid or forceMP3
         selectedAudioStream = myGLobal.session.video.json.MediaStreams[audioTrackIndex]
 
-        if selectedAudioStream <> invalid or forceLiveTVTranscode
+        if selectedAudioStream <> invalid or forceMP3
             params.AudioStreamIndex = audioTrackIndex
 
             ' force the server to transcode AAC profiles we don't support to MP3 instead of the usual AAC
             ' TODO: Remove this after server adds support for transcoding AAC from one profile to another
-            if forceLiveTVTranscode or selectedAudioStream.Codec <> invalid and LCase(selectedAudioStream.Codec) = "aac"
-                if forceLiveTVTranscode or selectedAudioStream.Profile <> invalid and LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
+            if forceMP3 or selectedAudioStream.Codec <> invalid and LCase(selectedAudioStream.Codec) = "aac"
+                if forceMP3 or selectedAudioStream.Profile <> invalid and LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
                     for each rule in deviceProfile.TranscodingProfiles
                         if rule.Container = "ts" or rule.Container = "mp4"
                             if rule.AudioCodec = "aac"

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -13,7 +13,7 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     return getJson(resp)
 end function
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger, forceLiveTVTranscode = false)
     params = {
         "UserId": m.global.session.user.id,
         "StartTimeTicks": startTimeTicks,
@@ -39,16 +39,16 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
 
     myGLobal = m.global
 
-    if audioTrackIndex > -1 and myGLobal.session.video.json.MediaStreams <> invalid
+    if audioTrackIndex > -1 and myGLobal.session.video.json.MediaStreams <> invalid or forceLiveTVTranscode
         selectedAudioStream = myGLobal.session.video.json.MediaStreams[audioTrackIndex]
 
-        if selectedAudioStream <> invalid
+        if selectedAudioStream <> invalid or forceLiveTVTranscode
             params.AudioStreamIndex = audioTrackIndex
 
             ' force the server to transcode AAC profiles we don't support to MP3 instead of the usual AAC
             ' TODO: Remove this after server adds support for transcoding AAC from one profile to another
-            if selectedAudioStream.Codec <> invalid and LCase(selectedAudioStream.Codec) = "aac"
-                if selectedAudioStream.Profile <> invalid and LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
+            if forceLiveTVTranscode or selectedAudioStream.Codec <> invalid and LCase(selectedAudioStream.Codec) = "aac"
+                if forceLiveTVTranscode or selectedAudioStream.Profile <> invalid and LCase(selectedAudioStream.Profile) = "main" or LCase(selectedAudioStream.Profile) = "he-aac"
                     for each rule in deviceProfile.TranscodingProfiles
                         if rule.Container = "ts" or rule.Container = "mp4"
                             if rule.AudioCodec = "aac"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Retries LiveTV when an "Unsupported AAC stream" error is received.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2043 