### PR TITLE
Add `Date Show Added` sort option for TV show libraries

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -300,12 +300,13 @@ sub setTvShowsOptions(options)
     ]
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName" },
-        { "Title": tr("IMDB_RATING"), "Name": "CommunityRating" },
-        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
-        { "Title": tr("DATE_PLAYED"), "Name": "SeriesDatePlayed" },
-        { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating" },
-        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate" },
         { "Title": tr("Random"), "Name": "Random" },
+        { "Title": tr("IMDB_RATING"), "Name": "CommunityRating,SortName" },
+        { "Title": tr("DATE_SHOW_ADDED"), "Name": "DateCreated,SortName" },
+        { "Title": tr("DATE_EPISODE_ADDED"), "Name": "DateLastContentAdded,SortName" }
+        { "Title": tr("DATE_PLAYED"), "Name": "SeriesDatePlayed,SortName" },
+        { "Title": tr("OFFICIAL_RATING"), "Name": "OfficialRating,SortName" },
+        { "Title": tr("RELEASE_DATE"), "Name": "PremiereDate,SortName" },
     ]
     options.filter = [
         { "Title": tr("All"), "Name": "All" },

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -228,7 +228,7 @@
         </message>
         <message>
             <source>IMDB_RATING</source>
-            <translation>IMDb Rating</translation>
+            <translation>Community Rating</translation>
         </message>
         <message>
             <source>CRITIC_RATING</source>
@@ -1400,6 +1400,16 @@
             <source>CH</source>
             <translation>CH</translation>
             <extracomment>Abbreviation for Channel</extracomment>
+        </message>
+        <message>
+            <source>DATE_EPISODE_ADDED</source>
+            <translation>Date Episode Added</translation>
+            <extracomment>TV Show library sort option</extracomment>
+        </message>
+        <message>
+            <source>DATE_SHOW_ADDED</source>
+            <translation>Date Show Added</translation>
+            <extracomment>TV Show library sort option</extracomment>
         </message>
     </context>
 </TS>


### PR DESCRIPTION
## Changes
- Add `Date Show Added` sort option for TV show libraries
- Rearrange sort option list to match web client
- Rename `IMDb Rating` to `Community Rating` to match web client
- Update api params to match web client (append sortName)

## Issues
Fixes #2064
