### PR TITLE
Added the ability to Show User Icon for SavedUsers as well

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -77,6 +77,10 @@ function LoginFlow()
                                 user.name = savedUser.username
                             end if
 
+                            if isValid(savedUser.primaryImageTag)
+                                user.ImageURL = UserImageURL(user.id, { "tag": savedUser.primaryImageTag })
+                            end if
+
                             publicUsersNodes.push(user)
                         end if
                     end if
@@ -103,6 +107,7 @@ function LoginFlow()
                 end for
                 ' try to login with token from registry
                 myToken = get_user_setting("token")
+                myPrimaryImageTag = get_user_setting("primaryimagetag")
                 if myToken <> invalid
                     ' check if token is valid
                     print "Auth token found in registry for selected user"
@@ -113,6 +118,9 @@ function LoginFlow()
                         print "Auth token is no longer valid - deleting token"
                         unset_user_setting("token")
                         unset_user_setting("username")
+                        if isValid(myPrimaryImageTag)
+                            unset_user_setting("primaryimagetag")
+                        end if
                     else
                         print "Success! Auth token is still valid"
                         session.user.Login(currentUser, true)
@@ -155,10 +163,14 @@ function LoginFlow()
 
         myUsername = get_user_setting("username")
         myAuthToken = get_user_setting("token")
+        myPrimaryImageTag = get_user_setting("primaryimagetag")
         if isValid(myAuthToken) and isValid(myUsername)
             print "Auth token found in registry"
             session.user.Update("authToken", myAuthToken)
             session.user.Update("name", myUsername)
+            if isValid(myPrimaryImageTag)
+                session.user.Update("primaryImageTag", myPrimaryImageTag)
+            end if
 
             print "Attempting to use API with auth token"
             currentUser = AboutMe()
@@ -177,6 +189,9 @@ function LoginFlow()
                     print "delete token and restart login flow"
                     unset_user_setting("token")
                     unset_user_setting("username")
+                    if isValid(myPrimaryImageTag)
+                        unset_user_setting("primaryimagetag")
+                    end if
                     goto start_login
                 end if
             else
@@ -484,6 +499,9 @@ function CreateSigninGroup(user = "")
                         session.user.Login(activeUser, true)
                         set_user_setting("token", activeUser.token)
                         set_user_setting("username", username.value)
+                        if isValid(activeUser.json.PrimaryImageTag)
+                            set_user_setting("primaryimagetag", activeUser.json.PrimaryImageTag)
+                        end if
                     else
                         session.user.Login(activeUser)
                     end if

--- a/source/utils/config.bs
+++ b/source/utils/config.bs
@@ -127,6 +127,12 @@ function getSavedUsers() as object
             userArray["serverId"] = serverId
         end if
 
+        primaryImageTag = registry_read("primaryimagetag", userId)
+        if primaryImageTag <> invalid
+            print "Found Saved Primary Image Tag: ", primaryImageTag, " for user: ", userId
+            userArray["primaryImageTag"] = primaryImageTag
+        end if
+
         if username <> invalid and token <> invalid and serverId <> invalid and serverId = m.global.session.server.id
             savedServerUsers.push(userArray)
         end if

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -155,12 +155,19 @@ namespace session
             if userData.json = invalid
                 ' we were passed data from AboutMe()
                 myAuthToken = tmpSession.user.authToken
+                myPrimaryImageTag = tmpSession.user.primaryImageTag
                 tmpSession.AddReplace("user", userData)
                 tmpSession.user.AddReplace("authToken", myAuthToken)
+                if isValid(myPrimaryImageTag)
+                    tmpSession.user.AddReplace("primaryImageTag", myPrimaryImageTag)
+                end if
             else
                 ' we were passed data from a UserData object
                 tmpSession.AddReplace("user", userData.json.User)
                 tmpSession.user.AddReplace("authToken", userData.json.AccessToken)
+                if isValid(userData.json.user.PrimaryImageTag)
+                    tmpSession.user.AddReplace("primaryImageTag", userData.json.user.PrimaryImageTag)
+                end if
             end if
             ' remove special characters from name
             regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
@@ -191,6 +198,9 @@ namespace session
             if saveCredentials
                 set_user_setting("token", tmpSession.user.authToken)
                 set_user_setting("username", tmpSession.user.name)
+                if isValid(tmpSession.user.primaryImageTag)
+                    set_user_setting("primaryimagetag", tmpSession.user.primaryImageTag)
+                end if
             end if
 
             if m.global.session.user.settings["global.rememberme"]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Added additional user setting `primaryimagetag` to store the relative data used for generating the profile icon URL

All usages are behind an `if isValid` condition to make sure the value can be ignored when it doesn't exist

This finally allows the ability to see Icons for SavedUsers. Not just PublicUsers
| Before               | After               |
| ---------------------- | ---------------------- |
| ![dev](https://github.com/user-attachments/assets/797a98ec-63db-40c6-8e8f-6300d0b40ef4) | ![New](https://github.com/user-attachments/assets/2e361c42-2555-47ec-8833-e1a38f2194ed) |

I did a BrightScript documenation speed-learn in about half an hour just to implement this. It was bothering me for a while :P

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
