### PR TITLE
Fix: Resolved issue for switching audio tracks

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -344,11 +344,17 @@ sub onAudioIndexChange()
     ' Save the current video position
     m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)
 
-    m.top.control = "stop"
+    ' Ensure metadata task is stopped before reusing
+    if m.LoadMetaDataTask.control = "RUN"
+        m.LoadMetaDataTask.control = "STOP"
+    end if
 
+    ' Configure metadata task with updated audio index
     m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
     m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
     m.LoadMetaDataTask.itemId = m.currentItem.id
+
+    ' Observe content and start task
     m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
     m.LoadMetaDataTask.control = "RUN"
 end sub


### PR DESCRIPTION
Fix: Prevent Video Playback Issues on Roku When Switching Audio Tracks
<!-- Provide a concise title that explains the fix -->
Changes
<!-- Describe your changes here in 1-5 sentences. -->
Added logic to stop the LoadMetaDataTask before reusing it to prevent potential conflicts that could cause playback issues.
Improved comments to clarify the configuration and execution flow of the metadata task.
Context
This fixes a bug encountered on Roku devices where switching audio tracks during playback caused the video to stop functioning. The issue was due to conflicts arising from the reuse of the LoadMetaDataTask without proper stopping and resetting.

Issues
<!-- Tag any issues that this PR solves here. -->
Fixes #2059 <!-- Replace with the actual issue number if tracked. -->

Notes for Reviewers
* I would originally get "Error During Playback" when attempting to switch audio tracks before the bug fix
