### PR TITLE
Fix: Remove conflicting metadata assignments to resolve audio switching

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -330,7 +330,6 @@ sub onSubtitleChange()
     m.top.control = "stop"
 
     m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
-    m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
     m.LoadMetaDataTask.itemId = m.currentItem.id
     m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
     m.LoadMetaDataTask.control = "RUN"
@@ -346,7 +345,6 @@ sub onAudioIndexChange()
 
     m.top.control = "stop"
 
-    m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle
     m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex
     m.LoadMetaDataTask.itemId = m.currentItem.id
     m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Removed the line `m.LoadMetaDataTask.selectedSubtitleIndex = m.top.SelectedSubtitle` from onAudioIndexChange()
- Removed the line `m.LoadMetaDataTask.selectedAudioStreamIndex = m.top.audioIndex` from onSubtitleChange()
- These removals address a race condition causing video playback to fail when switching audio tracks
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
Fixes #2059 <!-- Tag any issues that this PR solves here.
ex. Fixes # -->
