### PR TITLE
Update _build-prod.yml

### DIFF
--- a/.github/workflows/_build-prod.yml
+++ b/.github/workflows/_build-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   prod:
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix build prod error
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Add closing brackets
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Getting the following whenever we merge PRs to Master:

```
[Invalid workflow file: .github/workflows/build-prod.yml#L12](https://github.com/jellyfin/jellyfin-roku/actions/runs/12473998524/workflow)
The workflow is not valid. In .github/workflows/build-prod.yml (Line: 12, Col: 11): Error from called workflow jellyfin/jellyfin-roku/.github/workflows/_build-prod.yml@cb0093c744583f4ec61ff0dff570ee42c6770232 (Line: 9, Col: 9): The expression is not closed. An unescaped ${{ sequence was found, but the closing }} sequence was not found.
```