### PR TITLE
Increase segment length to handle really long (> 4 hours) movies

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -350,6 +350,7 @@ function getTranscodingProfiles() as object
         "VideoCodec": tsVideoCodecs,
         "MaxAudioChannels": maxAudioChannels,
         "MinSegments": 1,
+        "SegmentLength": 6,
         "BreakOnNonKeyFrames": false
     }
     mp4Array = {
@@ -361,6 +362,7 @@ function getTranscodingProfiles() as object
         "VideoCodec": mp4VideoCodecs,
         "MaxAudioChannels": maxAudioChannels,
         "MinSegments": 1,
+        "SegmentLength": 6,
         "BreakOnNonKeyFrames": false
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix crash at start of very long movies.
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Increase Segment Length to 6 seconds.
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2060 