### PR TITLE
Add tag filtering to movies and hide movie filtering by tag/genre/yea…

### DIFF
--- a/components/ItemGrid/ItemGridOptions.xml
+++ b/components/ItemGrid/ItemGridOptions.xml
@@ -13,7 +13,7 @@
           </RadiobuttonList>
           <RadiobuttonList id="sortMenu" itemSize="[600, 75]" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="1" numRows="8" drawFocusFeedback="false">
           </RadiobuttonList>
-          <RadiobuttonList id="filterMenu" itemSize="[600, 75]" checkOnSelect="false" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" drawFocusFeedback="false">
+          <RadiobuttonList id="filterMenu" itemSize="[600, 75]" checkOnSelect="false" itemspacing="[0,10]" vertFocusAnimationStyle="floatingFocus" opacity="0" numRows="8" drawFocusFeedback="false">
           </RadiobuttonList>
         </Group>
       </LayoutGroup>

--- a/components/ItemGrid/MovieLibraryView.bs
+++ b/components/ItemGrid/MovieLibraryView.bs
@@ -375,16 +375,20 @@ sub FilterDataLoaded(msg)
 
     ' Add Movie filters from the API data
     if LCase(m.loadItemsTask.view) = "movies"
-        if isValid(data.genres)
+        if isValid(data.genres) and data.genres.Count() > 0
             options.filter.push({ "Title": tr("Genres"), "Name": "Genres", "Options": data.genres, "Delimiter": "|", "CheckedState": [] })
         end if
 
-        if isValid(data.OfficialRatings)
+        if isValid(data.OfficialRatings) and data.OfficialRatings.Count() > 0
             options.filter.push({ "Title": tr("Parental Ratings"), "Name": "OfficialRatings", "Options": data.OfficialRatings, "Delimiter": "|", "CheckedState": [] })
         end if
 
-        if isValid(data.Years)
+        if isValid(data.Years) and data.Years.Count() > 0
             options.filter.push({ "Title": tr("Years"), "Name": "Years", "Options": data.Years, "Delimiter": ",", "CheckedState": [] })
+        end if
+
+        if isValid(data.Tags) and data.Tags.Count() > 0
+            options.filter.push({ "Title": tr("Tags"), "Name": "Tags", "Options": data.Tags, "Delimiter": ",", "CheckedState": [] })
         end if
     end if
 


### PR DESCRIPTION
Add tag filtering to movies and suppress filter categories containing no items

## Changes
Added the ability to filter movies by tag. 
Suppress filtering by tag/genre/year/rating when filter category contains zero valid selections (i.e. if no genres exist in the metadata, it will hide the genre filter option)

## Issues
Fixes #2129 
